### PR TITLE
Fix/add back includes to abigen

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ public:
    void testact( account_name test ) {
    }
 };
-EOSIO_ABI( test, (test_action))
+EOSIO_ABI( test, (testact))
 ```
 
 Since, EosioWasmToolchain overwrites `cmake` to cross-compile WASM, standard cmake commands of _add\_executable/ add\_library_ can then be used.  Also note, the __EOSIO_CDT_ROOT__ variable, this needs to be set if you decided to install to the non-default location.

--- a/libraries/eosiolib/transaction.hpp
+++ b/libraries/eosiolib/transaction.hpp
@@ -33,7 +33,7 @@ namespace eosio {
       uint32_t        ref_block_prefix;
       unsigned_int    net_usage_words = 0UL; /// number of 8 byte words this transaction can serialize into after compressions
       uint8_t         max_cpu_usage_ms = 0UL; /// number of CPU usage units to bill transaction for
-      unsigned_int    delay_sec = 0UL; /// number of CPU usage units to bill transaction for
+      unsigned_int    delay_sec = 0UL; /// number of seconds to delay transaction, default: 0
 
       EOSLIB_SERIALIZE( transaction_header, (expiration)(ref_block_num)(ref_block_prefix)(net_usage_words)(max_cpu_usage_ms)(delay_sec) )
    };


### PR DESCRIPTION
Fixes for missing include paths, string types, builtin types and reference type handling.