### PR TITLE
Add Dockerfile for generating docker image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:18.04
+
+# Arguments that may be overridden by the user
+ARG release=latest
+
+# Install required packages
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates curl wget && rm -rf /var/lib/apt/lists/*
+
+# Install CDT from deb package
+ADD install_deb.sh /
+RUN /install_deb.sh $release && rm -f install_deb.sh
+
+USER root

--- a/docker/install_deb.sh
+++ b/docker/install_deb.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+if [ "$1" = "" ]; then
+	echo "In order to continue, you must specify either latest or the release version."
+	exit 1
+elif [ "$1" = "latest" ]; then
+	deb=$(/usr/bin/curl -s https://api.github.com/repos/EOSIO/eosio.cdt/releases/latest | grep "browser_download_url.*deb" | cut -d '"' -f 4)
+	filename=$(/usr/bin/curl -s https://api.github.com/repos/EOSIO/eosio.cdt/releases/latest | grep "name.*deb" | cut -d '"' -f 4)
+else
+	deb=$(/usr/bin/curl -s https://api.github.com/repos/EOSIO/eosio.cdt/releases/tags/$1 | grep "browser_download_url.*deb" | cut -d '"' -f 4)
+	filename=$(/usr/bin/curl -s https://api.github.com/repos/EOSIO/eosio.cdt/releases/tags/$1 | grep "name.*deb" | cut -d '"' -f 4)
+fi
+
+if [ "$deb" = "" ]; then
+	echo "Either $1 is not a valid release, or there is not a published .deb package for the release."
+	exit 1
+fi
+
+/usr/bin/wget $deb && /usr/bin/dpkg -i "$filename" && rm -f "$filename"


### PR DESCRIPTION
This Dockerfile create an image based on the latest release by default. The release can be overridden by specifying ```--build-arg release=<tag>``` when building the image.