### PR TITLE
change build.sh 1 gigabytes per core

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -67,7 +67,7 @@ else
 fi
 
 CORES_AVAIL=`getconf _NPROCESSORS_ONLN`
-MEM_CORES=$(( ${FREE_MEM}/4000000 )) # 4 gigabytes per core
+MEM_CORES=$(( ${FREE_MEM}/1000000 )) # 1 gigabytes per core
 MEM_CORES=$(( $MEM_CORES > 0 ? $MEM_CORES : 1 ))
 CORES=$(( $CORES_AVAIL < $MEM_CORES ? $CORES_AVAIL : $MEM_CORES ))
 


### PR DESCRIPTION
I saw that the compiler uses up to 1G.
I have 7G free memory, but only use one core.
This may improve compile performence?