### PR TITLE
Dockerfile: added make & cmake to installed packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:18.04
 ARG release=latest
 
 # Install required packages
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates curl wget && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make cmake openssl ca-certificates curl wget && rm -rf /var/lib/apt/lists/*
 
 # Install CDT from deb package
 ADD install_deb.sh /


### PR DESCRIPTION
Those two packages are required when using the "standard" scripts to compile Smart Contract since they use CMake to configure the build and the make to run it.

Test it with:

```
cd examples/hello
mkdir build
docker run --rm -it -w /app/build -v `pwd`:/app <imageId> cmake ..
docker run --rm -it -w /app/build -v `pwd`:/app <imageId> make
```

~**Note** There is no `.wasm` nor `.abi` file generated however, normal?~ Oupsss, forgot I had to run `make` at the end, code 18, sorry :P