### PR TITLE
Various modifications

### DIFF
--- a/libraries/eosiolib/crypto.h
+++ b/libraries/eosiolib/crypto.h
@@ -199,6 +199,7 @@ void ripemd160( const char* data, uint32_t length, capi_checksum160* hash );
  *  @param siglen - Signature length
  *  @param pub - Public key
  *  @param publen - Public key length
+*   @return int - number of bytes written to pub
  *
  *  Example:
 *

--- a/libraries/eosiolib/crypto.hpp
+++ b/libraries/eosiolib/crypto.hpp
@@ -1,0 +1,177 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+#pragma once
+
+#include <eosiolib/crypto.h>
+#include <eosiolib/public_key.hpp>
+#include <eosiolib/fixed_bytes.hpp>
+
+namespace eosio {
+
+   /**
+    *  @defgroup cryptoapi Chain API
+    *  @brief Defines API for calculating and checking hashes
+    *  @ingroup contractdev
+    */
+
+   /**
+    *  @defgroup cryptocppapi Chain C API
+    *  @brief Defines type-safe C++ wrapers for calculating and checking hashes
+    *  @ingroup chainapi
+    *  @{
+    */
+
+   /**
+    *  Tests if the SHA256 hash generated from data matches the provided digest.
+    *  This method is optimized to a NO-OP when in fast evaluation mode.
+    *  @brief Tests if the sha256 hash generated from data matches the provided digest.
+    *
+    *  @param data - Data you want to hash
+    *  @param length - Data length
+    *  @param hash - hash to compare to
+    */
+   void assert_sha256( const char* data, uint32_t length, const eosio::digest256& hash ) {
+      auto hash_data = hash.extract_as_byte_array();
+      ::assert_sha256( data, length, reinterpret_cast<const capi_checksum256*>(hash_data.data()) );
+   }
+
+   /**
+    *  Tests if the SHA1 hash generated from data matches the provided digest.
+    *  This method is optimized to a NO-OP when in fast evaluation mode.
+    *  @brief Tests if the sha1 hash generated from data matches the provided digest.
+    *
+    *  @param data - Data you want to hash
+    *  @param length - Data length
+    *  @param hash - hash to compare to
+    */
+   void assert_sha1( const char* data, uint32_t length, const eosio::digest160& hash ) {
+      auto hash_data = hash.extract_as_byte_array();
+      ::assert_sha1( data, length, reinterpret_cast<const capi_checksum160*>(hash_data.data()) );
+   }
+
+   /**
+    *  Tests if the SHA512 hash generated from data matches the provided digest.
+    *  This method is optimized to a NO-OP when in fast evaluation mode.
+    *  @brief Tests if the sha512 hash generated from data matches the provided digest.
+    *
+    *  @param data - Data you want to hash
+    *  @param length - Data length
+    *  @param hash - hash to compare to
+    */
+   void assert_sha512( const char* data, uint32_t length, const eosio::digest512& hash ) {
+      auto hash_data = hash.extract_as_byte_array();
+      ::assert_sha512( data, length, reinterpret_cast<const capi_checksum512*>(hash_data.data()) );
+   }
+
+   /**
+    *  Tests if the RIPEMD160 hash generated from data matches the provided digest.
+    *  @brief Tests if the ripemd160 hash generated from data matches the provided digest.
+    *
+    *  @param data - Data you want to hash
+    *  @param length - Data length
+    *  @param hash - hash to compare to
+    */
+   void assert_ripemd160( const char* data, uint32_t length, const eosio::digest160& hash ) {
+      auto hash_data = hash.extract_as_byte_array();
+      ::assert_ripemd160( data, length, reinterpret_cast<const capi_checksum160*>(hash_data.data()) );
+   }
+
+   /**
+    *  Hashes `data` using SHA256.
+    *  @brief Hashes `data` using SHA256.
+    *
+    *  @param data - Data you want to hash
+    *  @param length - Data length
+    *  @return eosio::digest256 - Computed hash
+    */
+   eosio::digest256 sha256( const char* data, uint32_t length ) {
+      capi_checksum256 hash;
+      ::sha256( data, length, &hash );
+      return {hash.hash};
+   }
+
+   /**
+    *  Hashes `data` using SHA1.
+    *  @brief Hashes `data` using SHA1.
+    *
+    *  @param data - Data you want to hash
+    *  @param length - Data length
+    *  @return eosio::digest160 - Computed hash
+    */
+   eosio::digest160 sha1( const char* data, uint32_t length ) {
+      capi_checksum160 hash;
+      ::sha1( data, length, &hash );
+      return {hash.hash};
+   }
+
+   /**
+    *  Hashes `data` using SHA512.
+    *  @brief Hashes `data` using SHA512.
+    *
+    *  @param data - Data you want to hash
+    *  @param length - Data length
+    *  @return eosio::digest512 - Computed hash
+    */
+   eosio::digest512 sha512( const char* data, uint32_t length ) {
+      capi_checksum512 hash;
+      ::sha512( data, length, &hash );
+      return {hash.hash};
+   }
+
+   /**
+    *  Hashes `data` using RIPEMD160.
+    *  @brief Hashes `data` using RIPEMD160.
+    *
+    *  @param data - Data you want to hash
+    *  @param length - Data length
+    *  @return eosio::digest160 - Computed hash
+    */
+   eosio::digest160 ripemd160( const char* data, uint32_t length ) {
+      capi_checksum160 hash;
+      ::ripemd160( data, length, &hash );
+      return {hash.hash};
+   }
+
+   /**
+    *  Calculates the public key used for a given signature and hash used to create a message.
+    *  @brief Calculates the public key used for a given signature and hash used to create a message.
+    *
+    *  @param digest - Hash used to create a message
+    *  @param sig - Signature
+    *  @param siglen - Signature length
+    *  @param pub - Public key
+    *  @param publen - Public key length
+    *  @return eosio::public_key - Recovered public key
+    */
+   eosio::public_key recover_key( const eosio::digest256& digest, const char* sig, size_t siglen ) {
+      auto digest_data = digest.extract_as_byte_array();
+      char pubkey_data[38];
+      size_t pubkey_size = ::recover_key( reinterpret_cast<const capi_checksum256*>(digest_data.data()), sig, siglen, pubkey_data, sizeof(pubkey_data) );
+      eosio::datastream<char*> ds( pubkey_data, pubkey_size );
+      eosio::public_key pubkey;
+      ds >> pubkey;
+      return pubkey;
+   }
+
+   /**
+    *  Tests a given public key with the generated key from digest and the signature.
+    *  @brief Tests a given public key with the generated key from digest and the signature.
+    *
+    *  @param digest - What the key will be generated from
+    *  @param sig - Signature
+    *  @param siglen - Signature length
+    *  @param pubkey - Public key
+    */
+   void assert_recover_key( const eosio::digest256& digest, const char* sig, size_t siglen, const eosio::public_key& pubkey ) {
+      auto digest_data = digest.extract_as_byte_array();
+      char pubkey_data[38];
+      eosio::datastream<char*> ds( pubkey_data, sizeof(pubkey_data) );
+      auto begin = ds.pos();
+      ds << pubkey;
+      ::assert_recover_key( reinterpret_cast<const capi_checksum256*>(digest_data.data()), sig, siglen, begin, (ds.pos() - begin) );
+   }
+
+   /// }@cryptocppapi
+}

--- a/libraries/eosiolib/datastream.hpp
+++ b/libraries/eosiolib/datastream.hpp
@@ -7,6 +7,8 @@
 #include <eosiolib/memory.h>
 #include <eosiolib/symbol.hpp>
 #include <eosiolib/fixed_key.hpp>
+#include <eosiolib/fixed_bytes.hpp>
+#include <eosiolib/public_key.hpp>
 #include <eosiolib/ignore.hpp>
 #include <eosiolib/varint.hpp>
 #include <eosiolib/binary_extension.hpp>
@@ -545,7 +547,7 @@ inline datastream<Stream>& operator>>(datastream<Stream>& ds, ::eosio::ignore<T>
  *  @return datastream<Stream>& - Reference to the datastream
  */
 template<typename Stream>
-inline datastream<Stream>& operator<<(datastream<Stream>& ds, const capi_public_key pubkey) {
+inline datastream<Stream>& operator<<(datastream<Stream>& ds, const capi_public_key& pubkey) {
   ds.write( (const char*)&pubkey, sizeof(pubkey));
   return ds;
 }
@@ -563,6 +565,38 @@ template<typename Stream>
 inline datastream<Stream>& operator>>(datastream<Stream>& ds, capi_public_key& pubkey) {
   ds.read((char*)&pubkey, sizeof(pubkey));
   return ds;
+}
+
+/**
+ *  Serialize an eosio::public_key into a stream
+ *
+ *  @brief Serialize an eosio::public_key
+ *  @param ds - The stream to write
+ *  @param pubkey - The value to serialize
+ *  @tparam Stream - Type of datastream buffer
+ *  @return datastream<Stream>& - Reference to the datastream
+ */
+template<typename Stream>
+inline datastream<Stream>& operator<<(datastream<Stream>& ds, const eosio::public_key& pubkey) {
+   ds << pubkey.type;
+   ds.write( pubkey.data.data(), pubkey.data.size() );
+   return ds;
+}
+
+/**
+ *  Deserialize an eosio::public_key from a stream
+ *
+ *  @brief Deserialize an eosio::public_key
+ *  @param ds - The stream to read
+ *  @param pubkey - The destination for deserialized value
+ *  @tparam Stream - Type of datastream buffer
+ *  @return datastream<Stream>& - Reference to the datastream
+ */
+template<typename Stream>
+inline datastream<Stream>& operator>>(datastream<Stream>& ds, eosio::public_key& pubkey) {
+   ds >> pubkey.type;
+   ds.read( pubkey.data.data(), pubkey.data.size() );
+   return ds;
 }
 
 /**
@@ -593,6 +627,39 @@ template<typename Stream>
 inline datastream<Stream>& operator>>(datastream<Stream>& ds, key256& d) {
   ds.read((char*)d.data(), d.size() );
   return ds;
+}
+
+/**
+ *  Serialize a fixed_bytes into a stream
+ *
+ *  @brief Serialize a fixed_bytes
+ *  @param ds - The stream to write
+ *  @param d - The value to serialize
+ *  @tparam Stream - Type of datastream buffer
+ *  @return datastream<Stream>& - Reference to the datastream
+ */
+template<typename Stream, size_t Size>
+inline datastream<Stream>& operator<<(datastream<Stream>& ds, const fixed_bytes<Size>& d) {
+   auto arr = d.extract_as_byte_array();
+   ds.write( (const char*)arr.data(), arr.size() );
+   return ds;
+}
+
+/**
+ *  Deserialize a fixed_bytes from a stream
+ *
+ *  @brief Deserialize a fixed_bytes
+ *  @param ds - The stream to read
+ *  @param d - The destination for deserialized value
+ *  @tparam Stream - Type of datastream buffer
+ *  @return datastream<Stream>& - Reference to the datastream
+ */
+template<typename Stream, size_t Size>
+inline datastream<Stream>& operator>>(datastream<Stream>& ds, fixed_bytes<Size>& d) {
+   std::array<uint8_t, Size> arr;
+   ds.read( (char*)arr.data(), arr.size() );
+   d = fixed_bytes<Size>( arr );
+   return ds;
 }
 
 /**
@@ -694,9 +761,9 @@ DataStream& operator >> ( DataStream& ds, std::string& v ) {
 }
 
 /**
- *  Serialize a fixed size array into a stream
+ *  Serialize a fixed size std::array
  *
- *  @brief Serialize a fixed size array
+ *  @brief Serialize a fixed size std::array
  *  @param ds - The stream to write
  *  @param v - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -713,9 +780,9 @@ DataStream& operator << ( DataStream& ds, const std::array<T,N>& v ) {
 
 
 /**
- *  Deserialize a fixed size array from a stream
+ *  Deserialize a fixed size std::array
  *
- *  @brief Deserialize a fixed size array
+ *  @brief Deserialize a fixed size std::array
  *  @param ds - The stream to read
  *  @param v - The destination for deserialized value
  *  @tparam DataStream - Type of datastream
@@ -778,9 +845,9 @@ DataStream& operator >> ( DataStream& ds, T ) {
 }
 
 /**
- *  Serialize a fixed size array of non-primitive and non-pointer type
+ *  Serialize a fixed size C array of non-primitive and non-pointer type
  *
- *  @brief Serialize a fixed size array of non-primitive and non-pointer type
+ *  @brief Serialize a fixed size C array of non-primitive and non-pointer type
  *  @param ds - The stream to write
  *  @param v - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -798,9 +865,9 @@ DataStream& operator << ( DataStream& ds, const T (&v)[N] ) {
 }
 
 /**
- *  Serialize a fixed size array of non-primitive type
+ *  Serialize a fixed size C array of primitive type
  *
- *  @brief Serialize a fixed size array of non-primitive type
+ *  @brief Serialize a fixed size C array of primitive type
  *  @param ds - The stream to write
  *  @param v - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -816,9 +883,9 @@ DataStream& operator << ( DataStream& ds, const T (&v)[N] ) {
 }
 
 /**
- *  Deserialize a fixed size array of non-primitive and non-pointer type
+ *  Deserialize a fixed size C array of non-primitive and non-pointer type
  *
- *  @brief Deserialize a fixed size array of non-primitive and non-pointer type
+ *  @brief Deserialize a fixed size C array of non-primitive and non-pointer type
  *  @param ds - The stream to read
  *  @param v - The destination for deserialized value
  *  @tparam T - Type of the object contained in the array
@@ -839,9 +906,9 @@ DataStream& operator >> ( DataStream& ds, T (&v)[N] ) {
 }
 
 /**
- *  Deserialize a fixed size array of non-primitive type
+ *  Deserialize a fixed size C array of primitive type
  *
- *  @brief Deserialize a fixed size array of non-primitive type
+ *  @brief Deserialize a fixed size C array of primitive type
  *  @param ds - The stream to read
  *  @param v - The destination for deserialized value
  *  @tparam T - Type of the object contained in the array

--- a/libraries/eosiolib/fixed_bytes.hpp
+++ b/libraries/eosiolib/fixed_bytes.hpp
@@ -13,42 +13,42 @@
 namespace eosio {
 
    template<size_t Size>
-   class fixed_key;
+   class fixed_bytes;
 
    template<size_t Size>
-   bool operator ==(const fixed_key<Size> &c1, const fixed_key<Size> &c2);
+   bool operator ==(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
    template<size_t Size>
-   bool operator !=(const fixed_key<Size> &c1, const fixed_key<Size> &c2);
+   bool operator !=(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
    template<size_t Size>
-   bool operator >(const fixed_key<Size> &c1, const fixed_key<Size> &c2);
+   bool operator >(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
    template<size_t Size>
-   bool operator <(const fixed_key<Size> &c1, const fixed_key<Size> &c2);
+   bool operator <(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
    template<size_t Size>
-   bool operator >=(const fixed_key<Size> &c1, const fixed_key<Size> &c2);
+   bool operator >=(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
    template<size_t Size>
-   bool operator <=(const fixed_key<Size> &c1, const fixed_key<Size> &c2);
+   bool operator <=(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
     /**
-    *  @defgroup fixed_key Fixed Size Key
-    *  @brief Fixed size key sorted lexicographically for Multi Index Table
+    *  @defgroup fixed_bytes Fixed Size Byte Array
+    *  @brief Fixed size array of bytes sorted lexicographically
     *  @ingroup types
     *  @{
     */
 
    /**
-    *  Fixed size key sorted lexicographically for Multi Index Table
+    *  Fixed size byte array sorted lexicographically
     *
-    *  @brief Fixed size key sorted lexicographically for Multi Index Table
-    *  @tparam Size - Size of the fixed_key object
+    *  @brief Fixed size array of bytes sorted lexicographically
+    *  @tparam Size - Size of the fixed_bytes object
     *  @ingroup types
     */
    template<size_t Size>
-   class [[deprecated("Replaced by fixed_bytes")]] fixed_key {
+   class fixed_bytes {
       private:
 
          template<bool...> struct bool_pack;
@@ -56,14 +56,14 @@ namespace eosio {
          using all_true = std::is_same< bool_pack<bs..., true>, bool_pack<true, bs...> >;
 
          template<typename Word, size_t NumWords>
-         static void set_from_word_sequence(Word* arr_begin, Word* arr_end, fixed_key<Size>& key)
+         static void set_from_word_sequence(const Word* arr_begin, const Word* arr_end, fixed_bytes<Size>& key)
          {
             auto itr = key._data.begin();
             word_t temp_word = 0;
             const size_t sub_word_shift = 8 * sizeof(Word);
             const size_t num_sub_words = sizeof(word_t) / sizeof(Word);
             auto sub_words_left = num_sub_words;
-            for( Word w_itr = arr_begin; w_itr != arr_end; ++w_itr ) {
+            for( auto w_itr = arr_begin; w_itr != arr_end; ++w_itr ) {
                if( sub_words_left > 1 ) {
                    temp_word |= static_cast<word_t>(*w_itr);
                    temp_word <<= sub_word_shift;
@@ -71,7 +71,7 @@ namespace eosio {
                    continue;
                }
 
-               eosio_assert( sub_words_left == 1, "unexpected error in fixed_key constructor" );
+               eosio_assert( sub_words_left == 1, "unexpected error in fixed_bytes constructor" );
                temp_word |= static_cast<word_t>(*w_itr);
                sub_words_left = num_sub_words;
 
@@ -91,81 +91,81 @@ namespace eosio {
          typedef uint128_t word_t;
 
          /**
-          * Get number of words contained in this fixed_key object. A word is defined to be 16 bytes in size
+          * Get number of words contained in this fixed_bytes object. A word is defined to be 16 bytes in size
           *
-          * @brief Get number of words contained in this fixed_key object
+          * @brief Get number of words contained in this fixed_bytes object
           */
 
          static constexpr size_t num_words() { return (Size + sizeof(word_t) - 1) / sizeof(word_t); }
 
          /**
-          * Get number of padded bytes contained in this fixed_key object. Padded bytes are the remaining bytes
-          * inside the fixed_key object after all the words are allocated
+          * Get number of padded bytes contained in this fixed_bytes object. Padded bytes are the remaining bytes
+          * inside the fixed_bytes object after all the words are allocated
           *
-          * @brief Get number of padded bytes contained in this fixed_key object
+          * @brief Get number of padded bytes contained in this fixed_bytes object
           */
          static constexpr size_t padded_bytes() { return num_words() * sizeof(word_t) - Size; }
 
          /**
-         * @brief Default constructor to fixed_key object
+         * @brief Default constructor to fixed_bytes object
          *
-         * @details Default constructor to fixed_key object which initializes all bytes to zero
+         * @details Default constructor to fixed_bytes object which initializes all bytes to zero
          */
-         constexpr fixed_key() : _data() {}
+         constexpr fixed_bytes() : _data() {}
 
          /**
-         * @brief Constructor to fixed_key object from std::array of num_words() word_t types
+         * @brief Constructor to fixed_bytes object from std::array of num_words() word_t types
          *
-         * @details Constructor to fixed_key object from std::array of num_words() word_t types
+         * @details Constructor to fixed_bytes object from std::array of num_words() word_t types
          * @param arr    data
          */
-         fixed_key(const std::array<word_t, num_words()>& arr)
+         fixed_bytes(const std::array<word_t, num_words()>& arr)
          {
            std::copy(arr.begin(), arr.end(), _data.begin());
          }
 
          /**
-         * @brief Constructor to fixed_key object from std::array of Word types smaller in size than word_t
+         * @brief Constructor to fixed_bytes object from std::array of Word types smaller in size than word_t
          *
-         * @details Constructor to fixed_key object from std::array of Word types smaller in size than word_t
+         * @details Constructor to fixed_bytes object from std::array of Word types smaller in size than word_t
          * @param arr - Source data
          */
          template<typename Word, size_t NumWords,
                   typename Enable = typename std::enable_if<std::is_integral<Word>::value &&
                                                              !std::is_same<Word, bool>::value &&
                                                              sizeof(Word) < sizeof(word_t)>::type >
-         fixed_key(const std::array<Word, NumWords>& arr)
+         fixed_bytes(const std::array<Word, NumWords>& arr)
          {
             static_assert( sizeof(word_t) == (sizeof(word_t)/sizeof(Word)) * sizeof(Word),
                            "size of the backing word size is not divisible by the size of the array element" );
-            static_assert( sizeof(Word) * NumWords <= Size, "too many words supplied to fixed_key constructor" );
+            static_assert( sizeof(Word) * NumWords <= Size, "too many words supplied to fixed_bytes constructor" );
 
             set_from_word_sequence<Word, NumWords>(arr.data(), arr.data() + arr.size(), *this);
          }
 
          /**
-         * @brief Constructor to fixed_key object from fixed-sized C array of Word types smaller in size than word_t
+         * @brief Constructor to fixed_bytes object from fixed-sized C array of Word types smaller in size than word_t
          *
-         * @details Constructor to fixed_key object from fixed-sized C array of Word types smaller in size than word_t
+         * @details Constructor to fixed_bytes object from fixed-sized C array of Word types smaller in size than word_t
          * @param arr - Source data
          */
          template<typename Word, size_t NumWords,
                   typename Enable = typename std::enable_if<std::is_integral<Word>::value &&
                                                              !std::is_same<Word, bool>::value &&
                                                              sizeof(Word) < sizeof(word_t)>::type >
-         fixed_key(const Word(&arr)[NumWords])
+         fixed_bytes(const Word(&arr)[NumWords])
          {
             static_assert( sizeof(word_t) == (sizeof(word_t)/sizeof(Word)) * sizeof(Word),
                            "size of the backing word size is not divisible by the size of the array element" );
-            static_assert( sizeof(Word) * NumWords <= Size, "too many words supplied to fixed_key constructor" );
+            static_assert( sizeof(Word) * NumWords <= Size, "too many words supplied to fixed_bytes constructor" );
 
             set_from_word_sequence<Word, NumWords>(arr, arr + NumWords, *this);
          }
 
          /**
-         * @brief Create a new fixed_key object from a sequence of words
+         * @brief Create a new fixed_bytes object from a sequence of words
          *
-         * @details Create a new fixed_key object from a sequence of words
+         * @details Create a new fixed_bytes object from a sequence of words
          * @tparam FirstWord - The type of the first word in the sequence
          * @tparam Rest - The type of the remaining words in the sequence
          * @param first_word - The first word in the sequence
@@ -173,7 +173,7 @@ namespace eosio {
          */
          template<typename FirstWord, typename... Rest>
          static
-         fixed_key<Size>
+         fixed_bytes<Size>
          make_from_word_sequence(typename std::enable_if<std::is_integral<FirstWord>::value &&
                                                           !std::is_same<FirstWord, bool>::value &&
                                                           sizeof(FirstWord) <= sizeof(word_t) &&
@@ -185,7 +185,7 @@ namespace eosio {
                            "size of the backing word size is not divisible by the size of the words supplied as arguments" );
             static_assert( sizeof(FirstWord) * (1 + sizeof...(Rest)) <= Size, "too many words supplied to make_from_word_sequence" );
 
-            fixed_key<Size> key;
+            fixed_bytes<Size> key;
             std::array<FirstWord, 1+sizeof...(Rest)> arr{{ first_word, rest... }};
             set_from_word_sequence<FirstWord, 1+sizeof...(Rest)>(arr.data(), arr.data() + arr.size(), key);
             return key;
@@ -247,17 +247,17 @@ namespace eosio {
          }
 
          // Comparison operators
-         friend bool operator == <>(const fixed_key<Size> &c1, const fixed_key<Size> &c2);
+         friend bool operator == <>(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
-         friend bool operator != <>(const fixed_key<Size> &c1, const fixed_key<Size> &c2);
+         friend bool operator != <>(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
-         friend bool operator > <>(const fixed_key<Size> &c1, const fixed_key<Size> &c2);
+         friend bool operator > <>(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
-         friend bool operator < <>(const fixed_key<Size> &c1, const fixed_key<Size> &c2);
+         friend bool operator < <>(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
-         friend bool operator >= <>(const fixed_key<Size> &c1, const fixed_key<Size> &c2);
+         friend bool operator >= <>(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
-         friend bool operator <= <>(const fixed_key<Size> &c1, const fixed_key<Size> &c2);
+         friend bool operator <= <>(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
       private:
 
@@ -265,84 +265,86 @@ namespace eosio {
     };
 
    /**
-    * @brief Compares two fixed_key variables c1 and c2
+    * @brief Compares two fixed_bytes variables c1 and c2
     *
-    * @details Lexicographically compares two fixed_key variables c1 and c2
-    * @param c1 - First fixed_key object to compare
-    * @param c2 - Second fixed_key object to compare
+    * @details Lexicographically compares two fixed_bytes variables c1 and c2
+    * @param c1 - First fixed_bytes object to compare
+    * @param c2 - Second fixed_bytes object to compare
     * @return if c1 == c2, return true, otherwise false
     */
    template<size_t Size>
-   bool operator ==(const fixed_key<Size> &c1, const fixed_key<Size> &c2) {
+   bool operator ==(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2) {
       return c1._data == c2._data;
    }
 
    /**
-    * @brief Compares two fixed_key variables c1 and c2
+    * @brief Compares two fixed_bytes variables c1 and c2
     *
-    * @details Lexicographically compares two fixed_key variables c1 and c2
-    * @param c1 - First fixed_key object to compare
-    * @param c2 - Second fixed_key object to compare
+    * @details Lexicographically compares two fixed_bytes variables c1 and c2
+    * @param c1 - First fixed_bytes object to compare
+    * @param c2 - Second fixed_bytes object to compare
     * @return if c1 != c2, return true, otherwise false
     */
    template<size_t Size>
-   bool operator !=(const fixed_key<Size> &c1, const fixed_key<Size> &c2) {
+   bool operator !=(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2) {
       return c1._data != c2._data;
    }
 
    /**
-    * @brief Compares two fixed_key variables c1 and c2
+    * @brief Compares two fixed_bytes variables c1 and c2
     *
-    * @details Lexicographically compares two fixed_key variables c1 and c2
-    * @param c1 - First fixed_key object to compare
-    * @param c2 - Second fixed_key object to compare
+    * @details Lexicographically compares two fixed_bytes variables c1 and c2
+    * @param c1 - First fixed_bytes object to compare
+    * @param c2 - Second fixed_bytes object to compare
     * @return if c1 > c2, return true, otherwise false
     */
    template<size_t Size>
-   bool operator >(const fixed_key<Size>& c1, const fixed_key<Size>& c2) {
+   bool operator >(const fixed_bytes<Size>& c1, const fixed_bytes<Size>& c2) {
       return c1._data > c2._data;
    }
 
    /**
-    * @brief Compares two fixed_key variables c1 and c2
+    * @brief Compares two fixed_bytes variables c1 and c2
     *
-    * @details Lexicographically compares two fixed_key variables c1 and c2
-    * @param c1 - First fixed_key object to compare
-    * @param c2 - Second fixed_key object to compare
+    * @details Lexicographically compares two fixed_bytes variables c1 and c2
+    * @param c1 - First fixed_bytes object to compare
+    * @param c2 - Second fixed_bytes object to compare
     * @return if c1 < c2, return true, otherwise false
     */
    template<size_t Size>
-   bool operator <(const fixed_key<Size> &c1, const fixed_key<Size> &c2) {
+   bool operator <(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2) {
       return c1._data < c2._data;
    }
 
    /**
-    * @brief Compares two fixed_key variables c1 and c2
+    * @brief Compares two fixed_bytes variables c1 and c2
     *
-    * @details Lexicographically compares two fixed_key variables c1 and c2
-    * @param c1 - First fixed_key object to compare
-    * @param c2 - Second fixed_key object to compare
+    * @details Lexicographically compares two fixed_bytes variables c1 and c2
+    * @param c1 - First fixed_bytes object to compare
+    * @param c2 - Second fixed_bytes object to compare
     * @return if c1 >= c2, return true, otherwise false
     */
    template<size_t Size>
-   bool operator >=(const fixed_key<Size>& c1, const fixed_key<Size>& c2) {
+   bool operator >=(const fixed_bytes<Size>& c1, const fixed_bytes<Size>& c2) {
       return c1._data >= c2._data;
    }
 
    /**
-    * @brief Compares two fixed_key variables c1 and c2
+    * @brief Compares two fixed_bytes variables c1 and c2
     *
-    * @details Lexicographically compares two fixed_key variables c1 and c2
-    * @param c1 - First fixed_key object to compare
-    * @param c2 - Second fixed_key object to compare
+    * @details Lexicographically compares two fixed_bytes variables c1 and c2
+    * @param c1 - First fixed_bytes object to compare
+    * @param c2 - Second fixed_bytes object to compare
     * @return if c1 <= c2, return true, otherwise false
     */
    template<size_t Size>
-   bool operator <=(const fixed_key<Size> &c1, const fixed_key<Size> &c2) {
+   bool operator <=(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2) {
       return c1._data < c2._data;
    }
 
-   /// @} fixed_key
+   /// @} fixed_bytes
 
-   typedef fixed_key<32> key256;
+   using digest160 = fixed_bytes<20>;
+   using digest256 = fixed_bytes<32>;
+   using digest512 = fixed_bytes<64>;
 }

--- a/libraries/eosiolib/fixed_bytes.hpp
+++ b/libraries/eosiolib/fixed_bytes.hpp
@@ -232,10 +232,11 @@ namespace eosio {
             for( size_t counter = _data.size(); counter > 0; --counter, ++data_itr ) {
                size_t sub_words_left = num_sub_words;
 
+               auto temp_word = *data_itr;
                if( counter == 1 ) { // If last word in _data array...
                   sub_words_left -= padded_bytes();
+                  temp_word >>= 8*padded_bytes();
                }
-               auto temp_word = *data_itr;
                for( ; sub_words_left > 0; --sub_words_left ) {
                   *(arr_itr + sub_words_left - 1) = static_cast<uint8_t>(temp_word & 0xFF);
                   temp_word >>= 8;

--- a/libraries/eosiolib/fixed_key.hpp
+++ b/libraries/eosiolib/fixed_key.hpp
@@ -232,10 +232,15 @@ namespace eosio {
             for( size_t counter = _data.size(); counter > 0; --counter, ++data_itr ) {
                size_t sub_words_left = num_sub_words;
 
+               auto temp_word = *data_itr;
                if( counter == 1 ) { // If last word in _data array...
                   sub_words_left -= padded_bytes();
+                  //temp_word >>= 8*padded_bytes();
+                  // Without the commented line above, fixed_key<Size>::extract_as_byte_array() is buggy for Size % 16 != 0.
+                  // Cannot fix the bug for fixed_key without changing the behavior of extract_as_byte_array.
+                  // fixed_key is deprecated. Instead use fixed_bytes which has fixed this bug and also has correct serialization behavior.
                }
-               auto temp_word = *data_itr;
+
                for( ; sub_words_left > 0; --sub_words_left ) {
                   *(arr_itr + sub_words_left - 1) = static_cast<uint8_t>(temp_word & 0xFF);
                   temp_word >>= 8;

--- a/libraries/eosiolib/multi_index.hpp
+++ b/libraries/eosiolib/multi_index.hpp
@@ -21,6 +21,7 @@
 #include <eosiolib/datastream.hpp>
 #include <eosiolib/db.h>
 #include <eosiolib/fixed_key.hpp>
+#include <eosiolib/fixed_bytes.hpp>
 
 namespace eosio {
 
@@ -136,10 +137,16 @@ namespace _multi_index_detail {
    WRAP_SECONDARY_SIMPLE_TYPE(idx_long_double, long double)
    MAKE_TRAITS_FOR_ARITHMETIC_SECONDARY_KEY(long double)
 
-   WRAP_SECONDARY_ARRAY_TYPE(idx256, key256)
+   WRAP_SECONDARY_ARRAY_TYPE(idx256, eosio::key256)
    template<>
-   struct secondary_key_traits<key256> {
-      static constexpr key256 lowest() { return key256(); }
+   struct secondary_key_traits<eosio::key256> {
+      static constexpr eosio::key256 lowest() { return eosio::key256(); }
+   };
+
+   WRAP_SECONDARY_ARRAY_TYPE(idx256, eosio::digest256)
+   template<>
+   struct secondary_key_traits<eosio::digest256> {
+      static constexpr eosio::digest256 lowest() { return eosio::digest256(); }
    };
 
 }

--- a/libraries/eosiolib/print.hpp
+++ b/libraries/eosiolib/print.hpp
@@ -177,7 +177,6 @@ namespace eosio {
    template<size_t Size>
    inline void print( const fixed_bytes<Size>& val ) {
       auto arr = val.extract_as_byte_array();
-      prints("0x");
       printhex(static_cast<const void*>(arr.data()), arr.size());
    }
 

--- a/libraries/eosiolib/print.hpp
+++ b/libraries/eosiolib/print.hpp
@@ -7,6 +7,7 @@
 #include <eosiolib/name.hpp>
 #include <eosiolib/symbol.hpp>
 #include <eosiolib/fixed_key.hpp>
+#include <eosiolib/fixed_bytes.hpp>
 #include <utility>
 #include <string>
 
@@ -165,6 +166,30 @@ namespace eosio {
    template<size_t Size>
    inline void print( fixed_key<Size>& val ) {
       print(static_cast<const fixed_key<Size>&>(val));
+   }
+
+   /**
+    * Prints fixed_bytes as a hexidecimal string
+    *
+    * @brief Prints fixed_bytes as a hexidecimal string
+    * @param val to be printed
+    */
+   template<size_t Size>
+   inline void print( const fixed_bytes<Size>& val ) {
+      auto arr = val.extract_as_byte_array();
+      prints("0x");
+      printhex(static_cast<const void*>(arr.data()), arr.size());
+   }
+
+  /**
+    * Prints fixed_bytes as a hexidecimal string
+    *
+    * @brief Prints fixed_bytes as a hexidecimal string
+    * @param val to be printed
+    */
+   template<size_t Size>
+   inline void print( fixed_bytes<Size>& val ) {
+      print(static_cast<const fixed_bytes<Size>&>(val));
    }
 
    /**

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -42,7 +42,7 @@ struct simple_ricardian_tokenizer {
    }
 
    bool is_decl(std::string type) {
-      return check("<") && check("h1") && check("class") && check("=") 
+      return check("<") && check("h1") && check("class") && check("=")
             && check('\"'+type+'\"') && check(">");
    }
 
@@ -59,7 +59,7 @@ struct simple_ricardian_tokenizer {
             else
                ws++;
          }
-         index = after; 
+         index = after;
          if (check("<") && check("/h1") && check(">"))
             return {source.substr(before, after-before-ws)};
       }
@@ -68,7 +68,7 @@ struct simple_ricardian_tokenizer {
    std::string get_body(const std::string& type) {
       int i, before;
       i = before = index;
-      int ws = 0; 
+      int ws = 0;
       for (; i < source.size(); i++) {
          index = i;
          if (is_decl(type))
@@ -104,10 +104,10 @@ struct generation_utils {
    std::function<void()> error_handler;
    std::vector<std::string> resource_dirs;
    std::string contract_name;
-  
+
    generation_utils( std::function<void()> err ) : error_handler(err), resource_dirs({"./"}) {}
    generation_utils( std::function<void()> err, const std::vector<std::string>& paths ) : error_handler(err), resource_dirs(paths) {}
-   
+
    static inline bool is_tuple( const clang::QualType& type ) {
    }
 
@@ -127,7 +127,7 @@ struct generation_utils {
          is_ignore = check(type.getTypePtr());
       return is_ignore;
    }
-   
+
    static inline clang::QualType get_ignored_type( const clang::QualType& type ) {
       if ( !is_ignorable(type) )
          return type;
@@ -137,7 +137,7 @@ struct generation_utils {
                return decl->getDecl()->isEosioIgnore() ? tst->getArg(0).getAsType() : type;
          return type;
       };
-      
+
       const clang::Type* t;
       if ( auto pt = llvm::dyn_cast<clang::ElaboratedType>(type.getTypePtr()) ) {
          t = pt->desugar().getTypePtr();
@@ -146,11 +146,11 @@ struct generation_utils {
          t = type.getTypePtr();
       return get(t);
    }
-    
+
 
    inline void set_contract_name( const std::string& cn ) { contract_name = cn; }
    inline std::string get_contract_name()const { return contract_name; }
-   inline void set_resource_dirs( const llvm::cl::list<std::string>& rd ) { 
+   inline void set_resource_dirs( const llvm::cl::list<std::string>& rd ) {
       llvm::SmallString<128> cwd;
       auto has_real_path = llvm::sys::fs::real_path("./", cwd, true);
       if (!has_real_path)
@@ -162,7 +162,7 @@ struct generation_utils {
             resource_dirs.push_back(rp.str());
       }
    }
-  
+
    static inline bool has_eosio_ricardian( const clang::CXXMethodDecl* decl ) {
       return decl->hasEosioRicardian();
    }
@@ -176,7 +176,7 @@ struct generation_utils {
    static inline std::string get_eosio_ricardian( const clang::CXXRecordDecl* decl ) {
       return decl->getEosioRicardianAttr()->getName();
    }
-   
+
    static inline std::string get_action_name( const clang::CXXMethodDecl* decl ) {
       std::string action_name = "";
       if (auto tmp = decl->getEosioActionAttr()->getName(); !tmp.empty())
@@ -222,34 +222,34 @@ struct generation_utils {
    inline std::map<std::string, std::string> parse_contracts() {
       std::string contracts = get_ricardian_contracts();
       std::map<std::string, std::string> rcs;
-      simple_ricardian_tokenizer srt(contracts); 
+      simple_ricardian_tokenizer srt(contracts);
       if (contracts.empty()) {
          std::cout << "Warning, empty ricardian clause file\n";
          return rcs;
       }
 
-      auto parsed = srt.parse("contract"); 
+      auto parsed = srt.parse("contract");
       for (auto cl : parsed) {
          rcs.emplace(std::get<0>(cl), std::get<1>(cl));
       }
       return rcs;
-   }  
-  
+   }
+
    inline std::vector<std::pair<std::string, std::string>> parse_clauses() {
       std::string clauses = get_ricardian_clauses();
       std::vector<std::pair<std::string, std::string>> clause_pairs;
-      simple_ricardian_tokenizer srt(clauses); 
+      simple_ricardian_tokenizer srt(clauses);
       if (clauses.empty()) {
          std::cout << "Warning, empty ricardian clause file\n";
          return clause_pairs;
       }
 
-      auto parsed = srt.parse("clause"); 
+      auto parsed = srt.parse("clause");
       for (auto cl : parsed) {
          clause_pairs.emplace_back(std::get<0>(cl), std::get<1>(cl));
       }
       return clause_pairs;
-   }  
+   }
 
    static inline bool is_eosio_contract( const clang::CXXMethodDecl* decl, const std::string& cn ) {
       std::string name = "";
@@ -260,7 +260,7 @@ struct generation_utils {
       if (name.empty()) {
          name = decl->getParent()->getName().str();
       }
-      return name == cn; 
+      return name == cn;
    }
 
    static inline bool is_eosio_contract( const clang::CXXRecordDecl* decl, const std::string& cn ) {
@@ -324,7 +324,7 @@ struct generation_utils {
          if (type_str[i] == '>') ++template_nested;
          if (type_str[i] == '<') --template_nested;
          if (type_str[i] == ':' && template_nested == 0) {
-            return type_str.substr(i+1); 
+            return type_str.substr(i+1);
          }
          if (type_str[i] == ' ' && template_nested == 0) {
             static const std::string valid_prefixs[] = {"long", "signed", "unsigned" };
@@ -332,13 +332,13 @@ struct generation_utils {
             for (auto &s : valid_prefixs) {
                if (i >= s.length() && type_str.substr(i - s.length(), s.length()) == s &&
                    (i - s.length() == 0 || type_str[i - s.length() - 1] == ' ')) {
-                  valid = true; 
+                  valid = true;
                   i -= s.length();
                   break;
                }
             }
             if (valid) continue;
-            return type_str.substr(i+1); 
+            return type_str.substr(i+1);
          }
       }
       return type_str;
@@ -379,18 +379,21 @@ struct generation_utils {
          {"float",  "float32"},
          {"double", "float64"},
          {"long double", "float128"},
-         
+
          {"unsigned_int", "varuint32"},
-         {"signed_int",   "varint32"}, 
-         
+         {"signed_int",   "varint32"},
+
          {"block_timestamp", "block_timestamp_type"},
          {"capi_name",    "name"},
          {"capi_public_key", "public_key"},
          {"capi_signature", "signature"},
          {"capi_checksum160", "checksum160"},
          {"capi_checksum256", "checksum256"},
-         {"capi_checksum512", "checksum512"}
-      }; 
+         {"capi_checksum512", "checksum512"},
+         {"digest160", "checksum160"},
+         {"digest256", "checksum256"},
+         {"digest512", "checksum512"}
+      };
 
       std::string base_name = get_base_type_name(t);
       auto ret = translation_table[get_base_type_name(t)];
@@ -408,13 +411,13 @@ struct generation_utils {
       return ret;
    }
 
-   inline std::string get_template_name( const clang::QualType& type ) { 
+   inline std::string get_template_name( const clang::QualType& type ) {
       auto pt = llvm::dyn_cast<clang::ElaboratedType>(type.getTypePtr());
       auto tst = llvm::dyn_cast<clang::TemplateSpecializationType>(pt->desugar().getTypePtr());
       std::string ret = tst->getTemplateName().getAsTemplateDecl()->getName().str()+"_";
       for (int i=0; i < tst->getNumArgs(); ++i) {
          ret += _translate_type(get_template_argument( type, i ));
-         if ( i < tst->getNumArgs()-1 ) 
+         if ( i < tst->getNumArgs()-1 )
             ret += "_";
       }
       return replace_in_name(ret);
@@ -449,7 +452,7 @@ struct generation_utils {
          std::string ret = "tuple_";
          for (int i=0; i < tst->getNumArgs(); ++i) {
             ret += _translate_type(get_template_argument( type, i ));
-            if ( i < tst->getNumArgs()-1 ) 
+            if ( i < tst->getNumArgs()-1 )
                ret += "_";
          }
          return replace_in_name(ret);
@@ -460,7 +463,7 @@ struct generation_utils {
          std::string ret = tst->getTemplateName().getAsTemplateDecl()->getName().str()+"_";
          for (int i=0; i < tst->getNumArgs(); ++i) {
             ret += _translate_type(get_template_argument( type, i ));
-            if ( i < tst->getNumArgs()-1 ) 
+            if ( i < tst->getNumArgs()-1 )
                ret += "_";
          }
          return replace_in_name(ret);
@@ -470,7 +473,7 @@ struct generation_utils {
 
 
    inline bool is_name_type( const std::string& t ) {
-      static const std::set<std::string> name_types = { "name", 
+      static const std::set<std::string> name_types = { "name",
                                                         "account_name",
                                                         "permission_name",
                                                         "table_name",
@@ -478,7 +481,7 @@ struct generation_utils {
                                                         "action_name" };
       return name_types.count(t) >= 1;
    }
-   
+
    inline bool is_builtin_type( const std::string& t ) {
       static const std::set<std::string> builtins =
       {
@@ -510,9 +513,9 @@ struct generation_utils {
          "capi_checksum512",
          "capi_public_key",
          "capi_signature",
-         "checksum160",
-         "checksum256",
-         "checksum512",
+         "digest160",
+         "digest256",
+         "digest512",
          "public_key",
          "signature",
          "symbol",
@@ -522,18 +525,18 @@ struct generation_utils {
       };
       return builtins.count(t) >= 1;
    }
-   
+
    inline bool is_builtin_type( const clang::QualType& t ) {
       std::string nt = translate_type(t);
       return is_builtin_type(nt) || is_name_type(nt); // || is_template_specialization(t, {"optional"});
-   } 
+   }
 
    inline bool is_cxx_record( const clang::QualType& t ) {
       return t.getTypePtr()->isRecordType();
    }
 
    inline std::string get_type( const clang::QualType& t ) {
-      return translate_type(t); 
+      return translate_type(t);
    }
 
    inline std::string get_type_alias_string( const clang::QualType& t ) {


### PR DESCRIPTION
The (de)serialization of `eosio::key256` was implemented in a way which was not intended. The raw bytes of the inner `uint128_t` array were copied without modification. Because WASM is little endian, this means that the byte sequence of the serialized data was not MSB to LSB but rather mixed up. 

The MSB to LSB order is expected for the crypto intrinsics. This means contracts that were using `capi_checksum256` to calculate a SHA256 hash using the `sha256` intrinsic which was then stored in a table would have the byte sequence in the order of MSB to LSB. If the contract wished to upgrade the type of that table row to a `eosio::key256` in the future, its deserialization implementation would mix up the bytes causing all kinds of problems.

Furthermore, the builtin `checksum256` ABI type expects the same MSB to LSB order. Tools like cleos take a hex string of bytes with the expectation of it being in this order and serialize it in that order for the action arguments. Taking a `eosio::key256` as an action argument would also mix up the bytes. 

It is not possible to update the serialization of `eosio::key256` without introducing a breaking change. Even worse a modification to the serialization of `eosio::key256` would break the binary serialization of existing tables rows for any contracts that are already using `eosio::key256` in their tables.

Furthermore, there is a bug in the implementation of `eosio::fixed_key<Size>::extract_as_byte_array` for the cases where `Size % 16 != 0`.

Due to the reasons above, a new template class `eosio::fixed_bytes` is introduced as a nearly identical replacement to `eosio::fixed_key` with the exception that it has the correct (de)serialization behavior and the bug in `extract_as_byte_array` has been fixed. The class (as well as `eosio::fixed_key`) has been updated to also support construction from a fixed-sized C array. A type alias called `eosio::digest256` to `eosio::fixed_bytes<32>` is introduced as a replacement for `eosio::key256` (which is a typedef to `eosio::fixed_key<32>`).

**Both `eosio::fixed_key` and `eosio::key256` will be deprecated with the v1.4.0 release of eosio.cdt.**

This PR also introduces additional type aliases: `eosio::digest160` (a type alias to `eosio::fixed_bytes<20>` and `eosio::digest512` (a type alias to `eosio::fixed_bytes<64>`).

This PR also adds print support for all specializations of the `eosio::fixed_bytes` template. It also adds support for the `eosio::fixed_bytes<32>` specialization (i.e. `eosio::digest256`) to be used as a key for a secondary index of `eosio::multi_index`.

Finally, this PR adds (de)serialization support for `eosio::public_key` and it adds new C++ wrapper functions for the crypto intrinsics (see file `crypto.hpp` in eosiolib). 