### PR TITLE
rename digest to checksum; add eosio::signature

### DIFF
--- a/libraries/eosiolib/CMakeLists.txt
+++ b/libraries/eosiolib/CMakeLists.txt
@@ -3,6 +3,7 @@ file(GLOB HEADERS "*.hpp"
 
 add_library(eosio
             eosiolib.cpp
+            crypto.cpp
             ${HEADERS})
 
 target_include_directories(eosio PUBLIC

--- a/libraries/eosiolib/crypto.cpp
+++ b/libraries/eosiolib/crypto.cpp
@@ -1,0 +1,91 @@
+/**
+ *  @file
+ *  @copyright defined in eos/LICENSE.txt
+ */
+
+#include <eosiolib/crypto.hpp>
+#include <eosiolib/datastream.hpp>
+
+namespace eosio {
+
+   void assert_sha256( const char* data, uint32_t length, const eosio::checksum256& hash ) {
+      auto hash_data = hash.extract_as_byte_array();
+      ::assert_sha256( data, length, reinterpret_cast<const ::capi_checksum256*>(hash_data.data()) );
+   }
+
+   void assert_sha1( const char* data, uint32_t length, const eosio::checksum160& hash ) {
+      auto hash_data = hash.extract_as_byte_array();
+      ::assert_sha1( data, length, reinterpret_cast<const ::capi_checksum160*>(hash_data.data()) );
+   }
+
+   void assert_sha512( const char* data, uint32_t length, const eosio::checksum512& hash ) {
+      auto hash_data = hash.extract_as_byte_array();
+      ::assert_sha512( data, length, reinterpret_cast<const ::capi_checksum512*>(hash_data.data()) );
+   }
+
+   void assert_ripemd160( const char* data, uint32_t length, const eosio::checksum160& hash ) {
+      auto hash_data = hash.extract_as_byte_array();
+      ::assert_ripemd160( data, length, reinterpret_cast<const ::capi_checksum160*>(hash_data.data()) );
+   }
+
+   eosio::checksum256 sha256( const char* data, uint32_t length ) {
+      ::capi_checksum256 hash;
+      ::sha256( data, length, &hash );
+      return {hash.hash};
+   }
+
+   eosio::checksum160 sha1( const char* data, uint32_t length ) {
+      ::capi_checksum160 hash;
+      ::sha1( data, length, &hash );
+      return {hash.hash};
+   }
+
+   eosio::checksum512 sha512( const char* data, uint32_t length ) {
+      ::capi_checksum512 hash;
+      ::sha512( data, length, &hash );
+      return {hash.hash};
+   }
+
+   eosio::checksum160 ripemd160( const char* data, uint32_t length ) {
+      ::capi_checksum160 hash;
+      ::ripemd160( data, length, &hash );
+      return {hash.hash};
+   }
+
+   eosio::public_key recover_key( const eosio::checksum256& digest, const eosio::signature& sig ) {
+      auto digest_data = digest.extract_as_byte_array();
+
+      char sig_data[70];
+      eosio::datastream<char*> sig_ds( sig_data, sizeof(sig_data) );
+      auto sig_begin = sig_ds.pos();
+      sig_ds << sig;
+
+      char pubkey_data[38];
+      size_t pubkey_size = ::recover_key( reinterpret_cast<const capi_checksum256*>(digest_data.data()),
+                                          sig_begin, (sig_ds.pos() - sig_begin),
+                                          pubkey_data, sizeof(pubkey_data) );
+      eosio::datastream<char*> pubkey_ds( pubkey_data, pubkey_size );
+      eosio::public_key pubkey;
+      pubkey_ds >> pubkey;
+      return pubkey;
+   }
+
+   void assert_recover_key( const eosio::checksum256& digest, const eosio::signature& sig, const eosio::public_key& pubkey ) {
+      auto digest_data = digest.extract_as_byte_array();
+
+      char sig_data[70];
+      eosio::datastream<char*> sig_ds( sig_data, sizeof(sig_data) );
+      auto sig_begin = sig_ds.pos();
+      sig_ds << sig;
+
+      char pubkey_data[38];
+      eosio::datastream<char*> pubkey_ds( pubkey_data, sizeof(pubkey_data) );
+      auto pubkey_begin = pubkey_ds.pos();
+      pubkey_ds << pubkey;
+
+      ::assert_recover_key( reinterpret_cast<const capi_checksum256*>(digest_data.data()),
+                            sig_begin, (sig_ds.pos() - sig_begin),
+                            pubkey_begin, (pubkey_ds.pos() - pubkey_begin) );
+   }
+
+}

--- a/libraries/eosiolib/crypto.hpp
+++ b/libraries/eosiolib/crypto.hpp
@@ -5,15 +5,93 @@
 #pragma once
 
 #include <eosiolib/crypto.h>
-#include <eosiolib/public_key.hpp>
 #include <eosiolib/fixed_bytes.hpp>
+#include <eosiolib/varint.hpp>
+#include <eosiolib/serialize.hpp>
+
+#include <array>
 
 namespace eosio {
+
+   /**
+   *  @defgroup publickeytype Public Key Type
+   *  @ingroup types
+   *  @brief Specifies public key type
+   *
+   *  @{
+   */
+
+   /**
+    * EOSIO Public Key
+    * @brief EOSIO Public Key
+    */
+   struct public_key {
+      /**
+       * Type of the public key, could be either K1 or R1
+       * @brief Type of the public key
+       */
+      unsigned_int        type;
+
+      /**
+       * Bytes of the public key
+       *
+       * @brief Bytes of the public key
+       */
+      std::array<char,33> data;
+
+      friend bool operator == ( const public_key& a, const public_key& b ) {
+        return std::tie(a.type,a.data) == std::tie(b.type,b.data);
+      }
+      friend bool operator != ( const public_key& a, const public_key& b ) {
+        return std::tie(a.type,a.data) != std::tie(b.type,b.data);
+      }
+      EOSLIB_SERIALIZE( public_key, (type)(data) )
+   };
+
+   /// @} publickeytype
+
+   /**
+   *  @defgroup signaturetype Public Key Type
+   *  @ingroup types
+   *  @brief Specifies signature type
+   *
+   *  @{
+   */
+
+   /**
+    * EOSIO Signature
+    * @brief EOSIO Signature
+    */
+   struct signature {
+      /**
+       * Type of the signature, could be either K1 or R1
+       * @brief Type of the signature
+       */
+      unsigned_int        type;
+
+      /**
+       * Bytes of the signature
+       *
+       * @brief Bytes of the signature
+       */
+      std::array<char,65> data;
+
+      friend bool operator == ( const signature& a, const signature& b ) {
+        return std::tie(a.type,a.data) == std::tie(b.type,b.data);
+      }
+      friend bool operator != ( const signature& a, const signature& b ) {
+        return std::tie(a.type,a.data) != std::tie(b.type,b.data);
+      }
+      EOSLIB_SERIALIZE( signature, (type)(data) )
+   };
+
+   /// @} signaturetype
 
    /**
     *  @defgroup cryptoapi Chain API
     *  @brief Defines API for calculating and checking hashes
     *  @ingroup contractdev
+    *  @{
     */
 
    /**
@@ -30,12 +108,9 @@ namespace eosio {
     *
     *  @param data - Data you want to hash
     *  @param length - Data length
-    *  @param hash - hash to compare to
+    *  @param hash - digest to compare to
     */
-   void assert_sha256( const char* data, uint32_t length, const eosio::digest256& hash ) {
-      auto hash_data = hash.extract_as_byte_array();
-      ::assert_sha256( data, length, reinterpret_cast<const capi_checksum256*>(hash_data.data()) );
-   }
+   void assert_sha256( const char* data, uint32_t length, const eosio::checksum256& hash );
 
    /**
     *  Tests if the SHA1 hash generated from data matches the provided digest.
@@ -44,12 +119,9 @@ namespace eosio {
     *
     *  @param data - Data you want to hash
     *  @param length - Data length
-    *  @param hash - hash to compare to
+    *  @param hash - digest to compare to
     */
-   void assert_sha1( const char* data, uint32_t length, const eosio::digest160& hash ) {
-      auto hash_data = hash.extract_as_byte_array();
-      ::assert_sha1( data, length, reinterpret_cast<const capi_checksum160*>(hash_data.data()) );
-   }
+   void assert_sha1( const char* data, uint32_t length, const eosio::checksum160& hash );
 
    /**
     *  Tests if the SHA512 hash generated from data matches the provided digest.
@@ -58,12 +130,9 @@ namespace eosio {
     *
     *  @param data - Data you want to hash
     *  @param length - Data length
-    *  @param hash - hash to compare to
+    *  @param hash - digest to compare to
     */
-   void assert_sha512( const char* data, uint32_t length, const eosio::digest512& hash ) {
-      auto hash_data = hash.extract_as_byte_array();
-      ::assert_sha512( data, length, reinterpret_cast<const capi_checksum512*>(hash_data.data()) );
-   }
+   void assert_sha512( const char* data, uint32_t length, const eosio::checksum512& hash );
 
    /**
     *  Tests if the RIPEMD160 hash generated from data matches the provided digest.
@@ -71,12 +140,9 @@ namespace eosio {
     *
     *  @param data - Data you want to hash
     *  @param length - Data length
-    *  @param hash - hash to compare to
+    *  @param hash - digest to compare to
     */
-   void assert_ripemd160( const char* data, uint32_t length, const eosio::digest160& hash ) {
-      auto hash_data = hash.extract_as_byte_array();
-      ::assert_ripemd160( data, length, reinterpret_cast<const capi_checksum160*>(hash_data.data()) );
-   }
+   void assert_ripemd160( const char* data, uint32_t length, const eosio::checksum160& hash );
 
    /**
     *  Hashes `data` using SHA256.
@@ -84,13 +150,9 @@ namespace eosio {
     *
     *  @param data - Data you want to hash
     *  @param length - Data length
-    *  @return eosio::digest256 - Computed hash
+    *  @return eosio::checksum256 - Computed digest
     */
-   eosio::digest256 sha256( const char* data, uint32_t length ) {
-      capi_checksum256 hash;
-      ::sha256( data, length, &hash );
-      return {hash.hash};
-   }
+   eosio::checksum256 sha256( const char* data, uint32_t length );
 
    /**
     *  Hashes `data` using SHA1.
@@ -98,13 +160,9 @@ namespace eosio {
     *
     *  @param data - Data you want to hash
     *  @param length - Data length
-    *  @return eosio::digest160 - Computed hash
+    *  @return eosio::checksum160 - Computed digest
     */
-   eosio::digest160 sha1( const char* data, uint32_t length ) {
-      capi_checksum160 hash;
-      ::sha1( data, length, &hash );
-      return {hash.hash};
-   }
+   eosio::checksum160 sha1( const char* data, uint32_t length );
 
    /**
     *  Hashes `data` using SHA512.
@@ -112,13 +170,9 @@ namespace eosio {
     *
     *  @param data - Data you want to hash
     *  @param length - Data length
-    *  @return eosio::digest512 - Computed hash
+    *  @return eosio::checksum512 - Computed digest
     */
-   eosio::digest512 sha512( const char* data, uint32_t length ) {
-      capi_checksum512 hash;
-      ::sha512( data, length, &hash );
-      return {hash.hash};
-   }
+   eosio::checksum512 sha512( const char* data, uint32_t length );
 
    /**
     *  Hashes `data` using RIPEMD160.
@@ -126,52 +180,30 @@ namespace eosio {
     *
     *  @param data - Data you want to hash
     *  @param length - Data length
-    *  @return eosio::digest160 - Computed hash
+    *  @return eosio::checksum160 - Computed digest
     */
-   eosio::digest160 ripemd160( const char* data, uint32_t length ) {
-      capi_checksum160 hash;
-      ::ripemd160( data, length, &hash );
-      return {hash.hash};
-   }
+   eosio::checksum160 ripemd160( const char* data, uint32_t length );
 
    /**
-    *  Calculates the public key used for a given signature and hash used to create a message.
-    *  @brief Calculates the public key used for a given signature and hash used to create a message.
+    *  Calculates the public key used for a given signature on a given digest.
+    *  @brief Calculates the public key used for a given signature on a given digest.
     *
-    *  @param digest - Hash used to create a message
+    *  @param digest - Digest of the message that was signed
     *  @param sig - Signature
-    *  @param siglen - Signature length
-    *  @param pub - Public key
-    *  @param publen - Public key length
     *  @return eosio::public_key - Recovered public key
     */
-   eosio::public_key recover_key( const eosio::digest256& digest, const char* sig, size_t siglen ) {
-      auto digest_data = digest.extract_as_byte_array();
-      char pubkey_data[38];
-      size_t pubkey_size = ::recover_key( reinterpret_cast<const capi_checksum256*>(digest_data.data()), sig, siglen, pubkey_data, sizeof(pubkey_data) );
-      eosio::datastream<char*> ds( pubkey_data, pubkey_size );
-      eosio::public_key pubkey;
-      ds >> pubkey;
-      return pubkey;
-   }
+   eosio::public_key recover_key( const eosio::checksum256& digest, const eosio::signature& sig );
 
    /**
-    *  Tests a given public key with the generated key from digest and the signature.
-    *  @brief Tests a given public key with the generated key from digest and the signature.
+    *  Tests a given public key with the recovered public key from digest and signature.
+    *  @brief Tests a given public key with the recovered public key from digest and signature.
     *
-    *  @param digest - What the key will be generated from
+    *  @param digest - Digest of the message that was signed
     *  @param sig - Signature
-    *  @param siglen - Signature length
     *  @param pubkey - Public key
     */
-   void assert_recover_key( const eosio::digest256& digest, const char* sig, size_t siglen, const eosio::public_key& pubkey ) {
-      auto digest_data = digest.extract_as_byte_array();
-      char pubkey_data[38];
-      eosio::datastream<char*> ds( pubkey_data, sizeof(pubkey_data) );
-      auto begin = ds.pos();
-      ds << pubkey;
-      ::assert_recover_key( reinterpret_cast<const capi_checksum256*>(digest_data.data()), sig, siglen, begin, (ds.pos() - begin) );
-   }
+   void assert_recover_key( const eosio::checksum256& digest, const eosio::signature& sig, const eosio::public_key& pubkey );
 
    /// }@cryptocppapi
+   /// }@cryptoapi
 }

--- a/libraries/eosiolib/datastream.hpp
+++ b/libraries/eosiolib/datastream.hpp
@@ -8,7 +8,7 @@
 #include <eosiolib/symbol.hpp>
 #include <eosiolib/fixed_key.hpp>
 #include <eosiolib/fixed_bytes.hpp>
-#include <eosiolib/public_key.hpp>
+#include <eosiolib/crypto.hpp>
 #include <eosiolib/ignore.hpp>
 #include <eosiolib/varint.hpp>
 #include <eosiolib/binary_extension.hpp>
@@ -596,6 +596,38 @@ template<typename Stream>
 inline datastream<Stream>& operator>>(datastream<Stream>& ds, eosio::public_key& pubkey) {
    ds >> pubkey.type;
    ds.read( pubkey.data.data(), pubkey.data.size() );
+   return ds;
+}
+
+/**
+ *  Serialize an eosio::signature into a stream
+ *
+ *  @brief Serialize an eosio::signature
+ *  @param ds - The stream to write
+ *  @param sig - The value to serialize
+ *  @tparam Stream - Type of datastream buffer
+ *  @return datastream<Stream>& - Reference to the datastream
+ */
+template<typename Stream>
+inline datastream<Stream>& operator<<(datastream<Stream>& ds, const eosio::signature& sig) {
+   ds << sig.type;
+   ds.write( sig.data.data(), sig.data.size() );
+   return ds;
+}
+
+/**
+ *  Deserialize an eosio::signature from a stream
+ *
+ *  @brief Deserialize an eosio::signature
+ *  @param ds - The stream to read
+ *  @param sig - The destination for deserialized value
+ *  @tparam Stream - Type of datastream buffer
+ *  @return datastream<Stream>& - Reference to the datastream
+ */
+template<typename Stream>
+inline datastream<Stream>& operator>>(datastream<Stream>& ds, eosio::signature& sig) {
+   ds >> sig.type;
+   ds.read( sig.data.data(), sig.data.size() );
    return ds;
 }
 

--- a/libraries/eosiolib/fixed_bytes.hpp
+++ b/libraries/eosiolib/fixed_bytes.hpp
@@ -345,7 +345,7 @@ namespace eosio {
 
    /// @} fixed_bytes
 
-   using digest160 = fixed_bytes<20>;
-   using digest256 = fixed_bytes<32>;
-   using digest512 = fixed_bytes<64>;
+   using checksum160 = fixed_bytes<20>;
+   using checksum256 = fixed_bytes<32>;
+   using checksum512 = fixed_bytes<64>;
 }

--- a/libraries/eosiolib/multi_index.hpp
+++ b/libraries/eosiolib/multi_index.hpp
@@ -143,10 +143,10 @@ namespace _multi_index_detail {
       static constexpr eosio::key256 lowest() { return eosio::key256(); }
    };
 
-   WRAP_SECONDARY_ARRAY_TYPE(idx256, eosio::digest256)
+   WRAP_SECONDARY_ARRAY_TYPE(idx256, eosio::fixed_bytes<32>)
    template<>
-   struct secondary_key_traits<eosio::digest256> {
-      static constexpr eosio::digest256 lowest() { return eosio::digest256(); }
+   struct secondary_key_traits<eosio::fixed_bytes<32>> {
+      static constexpr eosio::fixed_bytes<32> lowest() { return eosio::fixed_bytes<32>(); }
    };
 
 }

--- a/libraries/eosiolib/permission.hpp
+++ b/libraries/eosiolib/permission.hpp
@@ -6,7 +6,7 @@
 
 #include <eosiolib/permission.h>
 #include <eosiolib/transaction.hpp>
-#include <eosiolib/public_key.hpp>
+#include <eosiolib/crypto.hpp>
 
 #include <set>
 #include <limits>

--- a/libraries/eosiolib/privileged.hpp
+++ b/libraries/eosiolib/privileged.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include "privileged.h"
 #include "serialize.hpp"
-#include "public_key.hpp"
+#include "crypto.hpp"
 
 namespace eosio {
 

--- a/libraries/eosiolib/public_key.hpp
+++ b/libraries/eosiolib/public_key.hpp
@@ -1,44 +1,5 @@
-#pragma once 
-#include <eosiolib/varint.hpp>
-#include <eosiolib/serialize.hpp>
+#pragma once
+#include <eosiolib/crypto.hpp>
 
-namespace eosio {
-
-   /**
-   *  @defgroup publickeytype Public Key Type
-   *  @ingroup types
-   *  @brief Specifies public key type
-   *
-   *  @{
-   */
-   
-   /**
-    * EOSIO Public Key
-    * @brief EOSIO Public Key
-    */
-   struct public_key {
-      /**
-       * Type of the public key, could be either K1 or R1
-       * @brief Type of the public key
-       */
-      unsigned_int        type;
-
-      /**
-       * Bytes of the public key
-       * 
-       * @brief Bytes of the public key
-       */
-      std::array<char,33> data;
-
-      friend bool operator == ( const public_key& a, const public_key& b ) {
-        return std::tie(a.type,a.data) == std::tie(b.type,b.data);
-      }
-      friend bool operator != ( const public_key& a, const public_key& b ) {
-        return std::tie(a.type,a.data) != std::tie(b.type,b.data);
-      }
-      EOSLIB_SERIALIZE( public_key, (type)(data) )
-   };
-   
-}
-
-/// @} publickeytype
+// This file only exists so that existing contracts that include eosiolib/public_key.hpp do not break.
+// Going forward contracts should instead just include eosiolib/crypto.hpp

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -390,10 +390,7 @@ struct generation_utils {
          {"capi_signature", "signature"},
          {"capi_checksum160", "checksum160"},
          {"capi_checksum256", "checksum256"},
-         {"capi_checksum512", "checksum512"},
-         {"digest160", "checksum160"},
-         {"digest256", "checksum256"},
-         {"digest512", "checksum512"}
+         {"capi_checksum512", "checksum512"}
       };
 
       std::string base_name = get_base_type_name(t);
@@ -503,9 +500,6 @@ struct generation_utils {
          "capi_checksum512",
          "capi_public_key",
          "capi_signature",
-         "digest160",
-         "digest256",
-         "digest512",
          "public_key",
          "signature",
          "symbol",
@@ -519,7 +513,7 @@ struct generation_utils {
    inline bool is_builtin_type( const clang::QualType& t ) {
       std::string nt = translate_type(t);
       return is_builtin_type(nt);
-   } 
+   }
 
    inline bool is_cxx_record( const clang::QualType& t ) {
       return t.getTypePtr()->isRecordType();


### PR DESCRIPTION
This PR makes changes to the additions in PR #236.

Specifically, this PR includes the following changes:

- To reduce confusion, it renames the type aliases to `eosio::fixed_bytes` introduced in PR #236 as follows:
   + `eosio::digest160` is now `eosio::checksum160`
   + `eosio::digest256` is now `eosio::checksum256`
   + `eosio::digest512` is now `eosio::checksum512`

- Adds a C++ type `eosio::signature` (with serialization/deserialization support) to be used instead of the C struct `capi_signature`.
- Modifies the `eosio::recover_key` and `eosio::assert_recover_key` C++ functions introduced in PR #236 which simply wrap the functionality of the corresponding C intrinsics so that they now take the new `eosio::signature` type as an argument.