### PR TITLE
Force execute compile time

### DIFF
--- a/libraries/eosiolib/name.hpp
+++ b/libraries/eosiolib/name.hpp
@@ -218,5 +218,6 @@ namespace eosio {
  */
 template <typename T, T... Str>
 inline constexpr eosio::name operator""_n() {
-   return eosio::name{std::string_view{eosio::detail::to_const_char_arr<Str...>::value, sizeof...(Str)}};
+   constexpr auto x = eosio::name{std::string_view{eosio::detail::to_const_char_arr<Str...>::value, sizeof...(Str)}};
+   return x;
 }

--- a/modules/EosioWasmToolchain.cmake.in
+++ b/modules/EosioWasmToolchain.cmake.in
@@ -37,7 +37,6 @@ include_directories(
 macro(add_contract CONTRACT_NAME TARGET)
    add_executable( ${TARGET}.wasm ${ARGN} )
    target_compile_options( ${TARGET}.wasm PUBLIC -abigen )
-   set_target_properties( ${TARGET}.wasm PROPERTIES LINKER_LANGUAGE C )
    get_target_property(BINOUTPUT ${TARGET}.wasm BINARY_DIR)
    target_compile_options( ${TARGET}.wasm PUBLIC -abigen_output=${BINOUTPUT}/${TARGET}.abi )
    target_compile_options( ${TARGET}.wasm PUBLIC -contract ${CONTRACT_NAME} )


### PR DESCRIPTION
```
   set_target_properties( ${TARGET}.wasm PROPERTIES LINKER_LANGUAGE C )
```
Cause my cmake generate -lm -lstdc++
cmake version 3.10.2

```
   return eosio::name{std::string_view{eosio::detail::to_const_char_arr<Str...>::value, sizeof...(Str)}};
```
Does not execute in compile time!