### PR TITLE
Added a buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,20 +23,20 @@ steps:
       os: "mojave"
     timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":ubuntu: 16.04 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:ubuntu"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":ubuntu: 16.04 Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:ubuntu"
+  #       workdir: /data/job
+  #   timeout: 60
     
   - command: |
         echo "+++ :hammer: Building" && \
@@ -68,20 +68,20 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":centos: Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:centos"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":centos: Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:centos"
+  #       workdir: /data/job
+  #   timeout: 60
   
   - command: |
         echo "+++ :hammer: Building" && \
@@ -128,25 +128,25 @@ steps:
       - "build/packages/*.tar.gz"
     timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
-        cd /data/job/build/packages && bash generate_package.sh deb
-    label: ":ubuntu: Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.deb"
-    plugins:
-      docker#v1.4.0:
-        image: "eosio/ci:ubuntu"
-        workdir: /data/job
-    env:
-      OS: "ubuntu-16.04"
-      PKGTYPE: "deb"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       cd /data/job/build/packages && bash generate_package.sh deb
+  #   label: ":ubuntu: Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/*.deb"
+  #   plugins:
+  #     docker#v1.4.0:
+  #       image: "eosio/ci:ubuntu"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "ubuntu-16.04"
+  #     PKGTYPE: "deb"
+  #   timeout: 60
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
@@ -195,29 +195,29 @@ steps:
       PKGTYPE: "rpm"
     timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
-        yum install -y rpm-build && \
-        mkdir -p /root/rpmbuild/BUILD && \
-        mkdir -p /root/rpmbuild/BUILDROOT && \
-        mkdir -p /root/rpmbuild/RPMS && \
-        mkdir -p /root/rpmbuild/SOURCES && \
-        mkdir -p /root/rpmbuild/SPECS && \
-        mkdir -p /root/rpmbuild/SRPMS && \
-        cd /data/job/build/packages && bash generate_package.sh rpm
-    label: ":centos: Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/x86_64/*.rpm"
-    plugins:
-      docker#v1.4.0:
-        image: "eosio/ci:centos"
-        workdir: /data/job
-    env:
-      OS: "centos"
-      PKGTYPE: "rpm"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       yum install -y rpm-build && \
+  #       mkdir -p /root/rpmbuild/BUILD && \
+  #       mkdir -p /root/rpmbuild/BUILDROOT && \
+  #       mkdir -p /root/rpmbuild/RPMS && \
+  #       mkdir -p /root/rpmbuild/SOURCES && \
+  #       mkdir -p /root/rpmbuild/SPECS && \
+  #       mkdir -p /root/rpmbuild/SRPMS && \
+  #       cd /data/job/build/packages && bash generate_package.sh rpm
+  #   label: ":centos: Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/x86_64/*.rpm"
+  #   plugins:
+  #     docker#v1.4.0:
+  #       image: "eosio/ci:centos"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "centos"
+  #     PKGTYPE: "rpm"
+  #   timeout: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,105 @@
+steps:
+  - command: |
+      echo "+++ :hammer: Building" && \
+      echo 1 | ./build.sh && \
+      echo "--- Compressing build directory :compression:" && \
+      tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":darwin: Build"
+    agents:
+      role: "macos-builder"
+    timeout: 60
+
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":ubuntu: 16.04 Build"
+    agents:
+      role: "automation-builder-fleet"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:ubuntu"
+        workdir: /data/job
+    timeout: 60
+    
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":ubuntu: 18.04 Build"
+    agents:
+      role: "automation-builder-fleet"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:ubuntu18"
+        workdir: /data/job
+    timeout: 60
+
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":fedora: Build"
+    agents:
+      role: "automation-builder-fleet"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:fedora"
+        workdir: /data/job
+    timeout: 60
+
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":centos: Build"
+    agents:
+      role: "automation-builder-fleet"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:centos"
+        workdir: /data/job
+    timeout: 60
+  
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":aws: Build"
+    agents:
+      role: "automation-builder-fleet"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:amazonlinux"
+        workdir: /data/job
+    timeout: 60
+
+  # - wait
+
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step "":ubuntu: 16.04 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       cd /data/job/build/packages && bash generate_package.sh deb
+  #   label: ":ubuntu: 16.04 Package builder"
+  #   agents:
+  #     role: "automation-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/*.deb"
+  #   plugins:
+  #     docker#v1.4.0:
+  #       image: "eosio/ci:ubuntu"
+  #       workdir: /data/job
+  #   timeout: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,10 +8,11 @@ steps:
     label: ":darwin: Build"
     agents:
       role: "macos-builder"
-    timeout: 120
+    timeout: 60
 
   - command: |
         echo "+++ :hammer: Building" && \
+        docker stats && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
@@ -21,13 +22,14 @@ steps:
       role: "automation-builder-fleet"
       aws:instance-type: "m5d.2xlarge"
     plugins:
-      docker#v1.4.0:
+      docker#v2.0.0:
         image: "eosio/ci:ubuntu"
         workdir: /data/job
-    timeout: 120
+    timeout: 60
     
   - command: |
         echo "+++ :hammer: Building" && \
+        docker stats && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
@@ -37,13 +39,14 @@ steps:
       role: "automation-builder-fleet"
       aws:instance-type: "m5d.2xlarge"
     plugins:
-      docker#v1.4.0:
+      docker#v2.0.0:
         image: "eosio/ci:ubuntu18"
         workdir: /data/job
-    timeout: 120
+    timeout: 60
 
   - command: |
         echo "+++ :hammer: Building" && \
+        docker stats && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
@@ -53,13 +56,14 @@ steps:
       role: "automation-builder-fleet"
       aws:instance-type: "m5d.2xlarge"
     plugins:
-      docker#v1.4.0:
+      docker#v2.0.0:
         image: "eosio/ci:fedora"
         workdir: /data/job
-    timeout: 120
+    timeout: 60
 
   - command: |
         echo "+++ :hammer: Building" && \
+        docker stats && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
@@ -69,13 +73,14 @@ steps:
       role: "automation-builder-fleet"
       aws:instance-type: "m5d.2xlarge"
     plugins:
-      docker#v1.4.0:
+      docker#v2.0.0:
         image: "eosio/ci:centos"
         workdir: /data/job
-    timeout: 120
+    timeout: 60
   
   - command: |
         echo "+++ :hammer: Building" && \
+        docker stats && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
@@ -85,10 +90,10 @@ steps:
       role: "automation-builder-fleet"
       aws:instance-type: "m5d.2xlarge"
     plugins:
-      docker#v1.4.0:
+      docker#v2.0.0:
         image: "eosio/ci:amazonlinux"
         workdir: /data/job
-    timeout: 120
+    timeout: 60
 
   # - wait
 
@@ -105,7 +110,7 @@ steps:
   #   artifact_paths:
   #     - "build/packages/*.deb"
   #   plugins:
-  #     docker#v1.4.0:
+  #     docker#v2.0.0:
   #       image: "eosio/ci:ubuntu"
   #       workdir: /data/job
   #   timeout: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -22,21 +22,6 @@ steps:
       role: "builder"
       os: "mojave"
     timeout: 60
-
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":ubuntu: 16.04 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:ubuntu"
-  #       workdir: /data/job
-  #   timeout: 60
     
   - command: |
         echo "+++ :hammer: Building" && \
@@ -68,20 +53,20 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":centos: Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:centos"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":centos: Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:centos"
+        workdir: /data/job
+    timeout: 60
   
   - command: |
         echo "+++ :hammer: Building" && \
@@ -127,26 +112,6 @@ steps:
     artifact_paths:
       - "build/packages/*.tar.gz"
     timeout: 60
-
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       cd /data/job/build/packages && bash generate_package.sh deb
-  #   label: ":ubuntu: Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/*.deb"
-  #   plugins:
-  #     docker#v1.4.0:
-  #       image: "eosio/ci:ubuntu"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "ubuntu-16.04"
-  #     PKGTYPE: "deb"
-  #   timeout: 60
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
@@ -195,29 +160,29 @@ steps:
       PKGTYPE: "rpm"
     timeout: 60
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       yum install -y rpm-build && \
-  #       mkdir -p /root/rpmbuild/BUILD && \
-  #       mkdir -p /root/rpmbuild/BUILDROOT && \
-  #       mkdir -p /root/rpmbuild/RPMS && \
-  #       mkdir -p /root/rpmbuild/SOURCES && \
-  #       mkdir -p /root/rpmbuild/SPECS && \
-  #       mkdir -p /root/rpmbuild/SRPMS && \
-  #       cd /data/job/build/packages && bash generate_package.sh rpm
-  #   label: ":centos: Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/x86_64/*.rpm"
-  #   plugins:
-  #     docker#v1.4.0:
-  #       image: "eosio/ci:centos"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "centos"
-  #     PKGTYPE: "rpm"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        yum install -y rpm-build && \
+        mkdir -p /root/rpmbuild/BUILD && \
+        mkdir -p /root/rpmbuild/BUILDROOT && \
+        mkdir -p /root/rpmbuild/RPMS && \
+        mkdir -p /root/rpmbuild/SOURCES && \
+        mkdir -p /root/rpmbuild/SPECS && \
+        mkdir -p /root/rpmbuild/SRPMS && \
+        cd /data/job/build/packages && bash generate_package.sh rpm
+    label: ":centos: Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/x86_64/*.rpm"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:centos"
+        workdir: /data/job
+    env:
+      OS: "centos"
+      PKGTYPE: "rpm"
+    timeout: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -89,7 +89,7 @@ steps:
         echo "--- :arrow_down: Downloading build directory" && \
         buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
         tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
+        echo "+++ :package: Starting package build" && \
         ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
     label: ":darwin: High Sierra Package Builder"
     agents:
@@ -103,7 +103,7 @@ steps:
         echo "--- :arrow_down: Downloading build directory" && \
         buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
         tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
+        echo "+++ :package: Starting package build" && \
         ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
     label: ":darwin: Mojave Package Builder"
     agents:
@@ -117,7 +117,7 @@ steps:
         echo "--- :arrow_down: Downloading build directory" && \
         buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
         tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
+        echo "+++ :package: Starting package build" && \
         cd /data/job/build/packages && bash generate_package.sh deb
     label: ":ubuntu: 18.04 Package builder"
     agents:
@@ -137,7 +137,7 @@ steps:
         echo "--- :arrow_down: Downloading build directory" && \
         buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
         tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
+        echo "+++ :package: Starting package build" && \
         yum install -y rpm-build && \
         mkdir -p /root/rpmbuild/BUILD && \
         mkdir -p /root/rpmbuild/BUILDROOT && \
@@ -164,7 +164,7 @@ steps:
         echo "--- :arrow_down: Downloading build directory" && \
         buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
         tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
+        echo "+++ :package: Starting package build" && \
         yum install -y rpm-build && \
         mkdir -p /root/rpmbuild/BUILD && \
         mkdir -p /root/rpmbuild/BUILDROOT && \
@@ -186,3 +186,29 @@ steps:
       OS: "centos"
       PKGTYPE: "rpm"
     timeout: 15
+
+  - wait
+
+  - command: |
+        echo "--- :arrow_down: Downloading package" && \
+        buildkite-agent artifact download "build/packages/*.deb" docker/dev/. --step ":ubuntu: 18.04 Package builder" && \
+        echo "--- :key: AUTHENTICATING GOOGLE SERVICE ACCOUNT" && \
+        gcloud --quiet auth activate-service-account b1-automation-svc@b1-automation-dev.iam.gserviceaccount.com --key-file=/etc/gcp-service-account.json && \
+        docker-credential-gcr configure-docker && \
+        echo "--- :hammer_and_wrench: BUILDING BUILD IMAGE" && \
+        cd docker/dev \
+        docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT . && \
+        docker tag eosio/cdt:$BUILDKITE_COMMIT gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
+        docker tag eosio/cdt:latest gcr.io/b1-automation-dev/eosio/cdt:latest && \
+        echo "--- :hand: PUSHING DOCKER IMAGES" && \
+        docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
+        docker push gcr.io/b1-automation-dev/eosio/cdt:latest && \
+        echo "--- :tada: TRASHING OLD IMAGES" && \
+        docker rmi eosio/cdt:$BUILDKITE_COMMIT && \
+        docker rmi eosio/cdt:latest && \
+        docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
+        docker rmi gcr.io/b1-automation-dev/eosio/cdt:latest
+    label: "Docker build builder"
+    agents:
+      queue: "automation-docker-builder-fleet"
+    timeout: 300

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,7 @@ steps:
     agents:
       role: "macos-builder"
       os: "high-sierra"
-    timeout: 60
+    timeout: 120
 
   - command: |
       echo "+++ :hammer: Building" && \
@@ -21,7 +21,7 @@ steps:
     agents:
       role: "builder"
       os: "mojave"
-    timeout: 60
+    timeout: 120
     
   - command: |
         echo "+++ :hammer: Building" && \
@@ -36,7 +36,7 @@ steps:
       docker#v2.0.0:
         image: "eosio/ci:ubuntu18"
         workdir: /data/job
-    timeout: 60
+    timeout: 120
 
   - command: |
         echo "+++ :hammer: Building" && \
@@ -51,7 +51,7 @@ steps:
       docker#v2.0.0:
         image: "eosio/ci:fedora"
         workdir: /data/job
-    timeout: 60
+    timeout: 120
 
   - command: |
         echo "+++ :hammer: Building" && \
@@ -66,7 +66,7 @@ steps:
       docker#v2.0.0:
         image: "eosio/ci:centos"
         workdir: /data/job
-    timeout: 60
+    timeout: 120
   
   - command: |
         echo "+++ :hammer: Building" && \
@@ -81,7 +81,7 @@ steps:
       docker#v2.0.0:
         image: "eosio/ci:amazonlinux"
         workdir: /data/job
-    timeout: 60
+    timeout: 120
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,29 +1,29 @@
 steps:
-  # - command: |
-  #     echo "+++ :hammer: Building" && \
-  #     echo 1 | ./build.sh && \
-  #     echo "--- Compressing build directory :compression:" && \
-  #     tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":darwin: Build"
-  #   agents:
-  #     role: "macos-builder"
-  #   timeout: 60
+  - command: |
+      echo "+++ :hammer: Building" && \
+      echo 1 | ./build.sh && \
+      echo "--- Compressing build directory :compression:" && \
+      tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":darwin: Build"
+    agents:
+      role: "macos-builder"
+    timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":ubuntu: 16.04 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:ubuntu"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":ubuntu: 16.04 Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:ubuntu"
+        workdir: /data/job
+    timeout: 60
     
   - command: |
         echo "+++ :hammer: Building" && \
@@ -40,50 +40,50 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":fedora: Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:fedora"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":fedora: Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:fedora"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":centos: Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:centos"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":centos: Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:centos"
+        workdir: /data/job
+    timeout: 60
   
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":aws: Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:amazonlinux"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":aws: Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:amazonlinux"
+        workdir: /data/job
+    timeout: 60
 
   # - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,7 +5,7 @@ steps:
       echo "--- Compressing build directory :compression:" && \
       tar -pczf build.tar.gz build/
     artifact_paths: "build.tar.gz"
-    label: ":highsierra: Build"
+    label: ":darwin: High Sierra Build"
     agents:
       role: "macos-builder"
       os: "high-sierra"
@@ -17,7 +17,7 @@ steps:
       echo "--- Compressing build directory :compression:" && \
       tar -pczf build.tar.gz build/
     artifact_paths: "build.tar.gz"
-    label: ":mojave: Build"
+    label: ":darwin: Mojave Build"
     agents:
       role: "builder"
       os: "mojave"
@@ -102,11 +102,11 @@ steps:
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":highsierra: Build" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
         tar -zxf build.tar.gz && \
         echo "+++ :microscope: Starting package build" && \
         ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-    label: ":highsierra: Package Builder"
+    label: ":darwin: High Sierra Package Builder"
     agents:
       role: "macos-builder"
       os: "high-sierra"
@@ -116,11 +116,11 @@ steps:
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":mojave: Build" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
         tar -zxf build.tar.gz && \
         echo "+++ :microscope: Starting package build" && \
         ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-    label: ":mojave: Package Builder"
+    label: ":darwin: Mojave Package Builder"
     agents:
       role: "builder"
       os: "mojave"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,27 +1,27 @@
 steps:
-  # - command: |
-  #     echo "+++ :hammer: Building" && \
-  #     echo 1 | ./build.sh && \
-  #     echo "--- Compressing build directory :compression:" && \
-  #     tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":darwin: High Sierra Build"
-  #   agents:
-  #     role: "macos-builder"
-  #     os: "high-sierra"
-  #   timeout: 60
+  - command: |
+      echo "+++ :hammer: Building" && \
+      echo 1 | ./build.sh && \
+      echo "--- Compressing build directory :compression:" && \
+      tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":darwin: High Sierra Build"
+    agents:
+      role: "macos-builder"
+      os: "high-sierra"
+    timeout: 60
 
-  # - command: |
-  #     echo "+++ :hammer: Building" && \
-  #     echo 1 | ./build.sh && \
-  #     echo "--- Compressing build directory :compression:" && \
-  #     tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":darwin: Mojave Build"
-  #   agents:
-  #     role: "builder"
-  #     os: "mojave"
-  #   timeout: 60
+  - command: |
+      echo "+++ :hammer: Building" && \
+      echo 1 | ./build.sh && \
+      echo "--- Compressing build directory :compression:" && \
+      tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":darwin: Mojave Build"
+    agents:
+      role: "builder"
+      os: "mojave"
+    timeout: 60
     
   - command: |
         echo "+++ :hammer: Building" && \
@@ -38,80 +38,80 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":fedora: Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:fedora"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":fedora: Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:fedora"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":centos: Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:centos"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":centos: Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:centos"
+        workdir: /data/job
+    timeout: 60
   
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":aws: Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:amazonlinux"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":aws: Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:amazonlinux"
+        workdir: /data/job
+    timeout: 60
 
   - wait
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :package: Starting package build" && \
-  #       ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-  #   label: ":darwin: High Sierra Package Builder"
-  #   agents:
-  #     role: "macos-builder"
-  #     os: "high-sierra"
-  #   artifact_paths:
-  #     - "build/packages/*.tar.gz"
-  #   timeout: 15
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :package: Starting package build" && \
+        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+    label: ":darwin: High Sierra Package Builder"
+    agents:
+      role: "macos-builder"
+      os: "high-sierra"
+    artifact_paths:
+      - "build/packages/*.tar.gz"
+    timeout: 15
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :package: Starting package build" && \
-  #       ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-  #   label: ":darwin: Mojave Package Builder"
-  #   agents:
-  #     role: "builder"
-  #     os: "mojave"
-  #   artifact_paths:
-  #     - "build/packages/*.tar.gz"
-  #   timeout: 15
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :package: Starting package build" && \
+        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+    label: ":darwin: Mojave Package Builder"
+    agents:
+      role: "builder"
+      os: "mojave"
+    artifact_paths:
+      - "build/packages/*.tar.gz"
+    timeout: 15
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
@@ -133,59 +133,59 @@ steps:
       PKGTYPE: "deb"
     timeout: 15
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :package: Starting package build" && \
-  #       yum install -y rpm-build && \
-  #       mkdir -p /root/rpmbuild/BUILD && \
-  #       mkdir -p /root/rpmbuild/BUILDROOT && \
-  #       mkdir -p /root/rpmbuild/RPMS && \
-  #       mkdir -p /root/rpmbuild/SOURCES && \
-  #       mkdir -p /root/rpmbuild/SPECS && \
-  #       mkdir -p /root/rpmbuild/SRPMS && \
-  #       cd /data/job/build/packages && bash generate_package.sh rpm
-  #   label: ":fedora: Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/x86_64/*.rpm"
-  #   plugins:
-  #     docker#v1.4.0:
-  #       image: "eosio/ci:fedora"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "fedora"
-  #     PKGTYPE: "rpm"
-  #   timeout: 15
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :package: Starting package build" && \
+        yum install -y rpm-build && \
+        mkdir -p /root/rpmbuild/BUILD && \
+        mkdir -p /root/rpmbuild/BUILDROOT && \
+        mkdir -p /root/rpmbuild/RPMS && \
+        mkdir -p /root/rpmbuild/SOURCES && \
+        mkdir -p /root/rpmbuild/SPECS && \
+        mkdir -p /root/rpmbuild/SRPMS && \
+        cd /data/job/build/packages && bash generate_package.sh rpm
+    label: ":fedora: Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/x86_64/*.rpm"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:fedora"
+        workdir: /data/job
+    env:
+      OS: "fedora"
+      PKGTYPE: "rpm"
+    timeout: 15
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :package: Starting package build" && \
-  #       yum install -y rpm-build && \
-  #       mkdir -p /root/rpmbuild/BUILD && \
-  #       mkdir -p /root/rpmbuild/BUILDROOT && \
-  #       mkdir -p /root/rpmbuild/RPMS && \
-  #       mkdir -p /root/rpmbuild/SOURCES && \
-  #       mkdir -p /root/rpmbuild/SPECS && \
-  #       mkdir -p /root/rpmbuild/SRPMS && \
-  #       cd /data/job/build/packages && bash generate_package.sh rpm
-  #   label: ":centos: Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/x86_64/*.rpm"
-  #   plugins:
-  #     docker#v1.4.0:
-  #       image: "eosio/ci:centos"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "centos"
-  #     PKGTYPE: "rpm"
-  #   timeout: 15
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :package: Starting package build" && \
+        yum install -y rpm-build && \
+        mkdir -p /root/rpmbuild/BUILD && \
+        mkdir -p /root/rpmbuild/BUILDROOT && \
+        mkdir -p /root/rpmbuild/RPMS && \
+        mkdir -p /root/rpmbuild/SOURCES && \
+        mkdir -p /root/rpmbuild/SPECS && \
+        mkdir -p /root/rpmbuild/SRPMS && \
+        cd /data/job/build/packages && bash generate_package.sh rpm
+    label: ":centos: Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/x86_64/*.rpm"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:centos"
+        workdir: /data/job
+    env:
+      OS: "centos"
+      PKGTYPE: "rpm"
+    timeout: 15
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -12,7 +12,6 @@ steps:
 
   - command: |
         echo "+++ :hammer: Building" && \
-        docker stats && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
@@ -29,7 +28,6 @@ steps:
     
   - command: |
         echo "+++ :hammer: Building" && \
-        docker stats && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
@@ -46,7 +44,6 @@ steps:
 
   - command: |
         echo "+++ :hammer: Building" && \
-        docker stats && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
@@ -63,7 +60,6 @@ steps:
 
   - command: |
         echo "+++ :hammer: Building" && \
-        docker stats && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
@@ -80,7 +76,6 @@ steps:
   
   - command: |
         echo "+++ :hammer: Building" && \
-        docker stats && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -100,7 +100,7 @@ steps:
 
   - wait
 
-- command: |
+  - command: |
         echo "--- :arrow_down: Downloading build directory" && \
         buildkite-agent artifact download "build.tar.gz" . --step ":highsierra: Build" && \
         tar -zxf build.tar.gz && \

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,6 +19,7 @@ steps:
     label: ":ubuntu: 16.04 Build"
     agents:
       role: "automation-builder-fleet"
+      aws:instance-type: "m5d.2xlarge"
     plugins:
       docker#v1.4.0:
         image: "eosio/ci:ubuntu"
@@ -34,6 +35,7 @@ steps:
     label: ":ubuntu: 18.04 Build"
     agents:
       role: "automation-builder-fleet"
+      aws:instance-type: "m5d.2xlarge"
     plugins:
       docker#v1.4.0:
         image: "eosio/ci:ubuntu18"
@@ -49,6 +51,7 @@ steps:
     label: ":fedora: Build"
     agents:
       role: "automation-builder-fleet"
+      aws:instance-type: "m5d.2xlarge"
     plugins:
       docker#v1.4.0:
         image: "eosio/ci:fedora"
@@ -64,6 +67,7 @@ steps:
     label: ":centos: Build"
     agents:
       role: "automation-builder-fleet"
+      aws:instance-type: "m5d.2xlarge"
     plugins:
       docker#v1.4.0:
         image: "eosio/ci:centos"
@@ -79,6 +83,7 @@ steps:
     label: ":aws: Build"
     agents:
       role: "automation-builder-fleet"
+      aws:instance-type: "m5d.2xlarge"
     plugins:
       docker#v1.4.0:
         image: "eosio/ci:amazonlinux"
@@ -96,6 +101,7 @@ steps:
   #   label: ":ubuntu: 16.04 Package builder"
   #   agents:
   #     role: "automation-builder-fleet"
+  #     aws:instance-type: "m5d.2xlarge"
   #   artifact_paths:
   #     - "build/packages/*.deb"
   #   plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -130,7 +130,7 @@ steps:
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: Build" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 16.04 Build" && \
         tar -zxf build.tar.gz && \
         echo "+++ :microscope: Starting package build" && \
         cd /data/job/build/packages && bash generate_package.sh deb

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ steps:
     label: ":darwin: Build"
     agents:
       role: "macos-builder"
-    timeout: 60
+    timeout: 120
 
   - command: |
         echo "+++ :hammer: Building" && \
@@ -24,7 +24,7 @@ steps:
       docker#v1.4.0:
         image: "eosio/ci:ubuntu"
         workdir: /data/job
-    timeout: 60
+    timeout: 120
     
   - command: |
         echo "+++ :hammer: Building" && \
@@ -40,7 +40,7 @@ steps:
       docker#v1.4.0:
         image: "eosio/ci:ubuntu18"
         workdir: /data/job
-    timeout: 60
+    timeout: 120
 
   - command: |
         echo "+++ :hammer: Building" && \
@@ -56,7 +56,7 @@ steps:
       docker#v1.4.0:
         image: "eosio/ci:fedora"
         workdir: /data/job
-    timeout: 60
+    timeout: 120
 
   - command: |
         echo "+++ :hammer: Building" && \
@@ -72,7 +72,7 @@ steps:
       docker#v1.4.0:
         image: "eosio/ci:centos"
         workdir: /data/job
-    timeout: 60
+    timeout: 120
   
   - command: |
         echo "+++ :hammer: Building" && \
@@ -88,7 +88,7 @@ steps:
       docker#v1.4.0:
         image: "eosio/ci:amazonlinux"
         workdir: /data/job
-    timeout: 60
+    timeout: 120
 
   # - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,77 +11,77 @@ steps:
       os: "high-sierra"
     timeout: 60
 
-  - command: |
-      echo "+++ :hammer: Building" && \
-      echo 1 | ./build.sh && \
-      echo "--- Compressing build directory :compression:" && \
-      tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":darwin: Mojave Build"
-    agents:
-      role: "builder"
-      os: "mojave"
-    timeout: 60
+  # - command: |
+  #     echo "+++ :hammer: Building" && \
+  #     echo 1 | ./build.sh && \
+  #     echo "--- Compressing build directory :compression:" && \
+  #     tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":darwin: Mojave Build"
+  #   agents:
+  #     role: "builder"
+  #     os: "mojave"
+  #   timeout: 60
     
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":ubuntu: 18.04 Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:ubuntu18"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":ubuntu: 18.04 Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:ubuntu18"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":fedora: Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:fedora"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":fedora: Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:fedora"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":centos: Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:centos"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":centos: Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:centos"
+  #       workdir: /data/job
+  #   timeout: 60
   
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":aws: Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:amazonlinux"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":aws: Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:amazonlinux"
+  #       workdir: /data/job
+  #   timeout: 60
 
   - wait
 
@@ -99,90 +99,90 @@ steps:
       - "build/packages/*.tar.gz"
     timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
-        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-    label: ":darwin: Mojave Package Builder"
-    agents:
-      role: "builder"
-      os: "mojave"
-    artifact_paths:
-      - "build/packages/*.tar.gz"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+  #   label: ":darwin: Mojave Package Builder"
+  #   agents:
+  #     role: "builder"
+  #     os: "mojave"
+  #   artifact_paths:
+  #     - "build/packages/*.tar.gz"
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
-        cd /data/job/build/packages && bash generate_package.sh deb
-    label: ":ubuntu: 18.04 Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/*.deb"
-    plugins:
-      docker#v1.4.0:
-        image: "eosio/ci:ubuntu18"
-        workdir: /data/job
-    env:
-      OS: "ubuntu-18.04"
-      PKGTYPE: "deb"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       cd /data/job/build/packages && bash generate_package.sh deb
+  #   label: ":ubuntu: 18.04 Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/*.deb"
+  #   plugins:
+  #     docker#v1.4.0:
+  #       image: "eosio/ci:ubuntu18"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "ubuntu-18.04"
+  #     PKGTYPE: "deb"
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
-        yum install -y rpm-build && \
-        mkdir -p /root/rpmbuild/BUILD && \
-        mkdir -p /root/rpmbuild/BUILDROOT && \
-        mkdir -p /root/rpmbuild/RPMS && \
-        mkdir -p /root/rpmbuild/SOURCES && \
-        mkdir -p /root/rpmbuild/SPECS && \
-        mkdir -p /root/rpmbuild/SRPMS && \
-        cd /data/job/build/packages && bash generate_package.sh rpm
-    label: ":fedora: Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/x86_64/*.rpm"
-    plugins:
-      docker#v1.4.0:
-        image: "eosio/ci:fedora"
-        workdir: /data/job
-    env:
-      OS: "fedora"
-      PKGTYPE: "rpm"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       yum install -y rpm-build && \
+  #       mkdir -p /root/rpmbuild/BUILD && \
+  #       mkdir -p /root/rpmbuild/BUILDROOT && \
+  #       mkdir -p /root/rpmbuild/RPMS && \
+  #       mkdir -p /root/rpmbuild/SOURCES && \
+  #       mkdir -p /root/rpmbuild/SPECS && \
+  #       mkdir -p /root/rpmbuild/SRPMS && \
+  #       cd /data/job/build/packages && bash generate_package.sh rpm
+  #   label: ":fedora: Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/x86_64/*.rpm"
+  #   plugins:
+  #     docker#v1.4.0:
+  #       image: "eosio/ci:fedora"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "fedora"
+  #     PKGTYPE: "rpm"
+  #   timeout: 60
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :microscope: Starting package build" && \
-        yum install -y rpm-build && \
-        mkdir -p /root/rpmbuild/BUILD && \
-        mkdir -p /root/rpmbuild/BUILDROOT && \
-        mkdir -p /root/rpmbuild/RPMS && \
-        mkdir -p /root/rpmbuild/SOURCES && \
-        mkdir -p /root/rpmbuild/SPECS && \
-        mkdir -p /root/rpmbuild/SRPMS && \
-        cd /data/job/build/packages && bash generate_package.sh rpm
-    label: ":centos: Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/x86_64/*.rpm"
-    plugins:
-      docker#v1.4.0:
-        image: "eosio/ci:centos"
-        workdir: /data/job
-    env:
-      OS: "centos"
-      PKGTYPE: "rpm"
-    timeout: 60
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :microscope: Starting package build" && \
+  #       yum install -y rpm-build && \
+  #       mkdir -p /root/rpmbuild/BUILD && \
+  #       mkdir -p /root/rpmbuild/BUILDROOT && \
+  #       mkdir -p /root/rpmbuild/RPMS && \
+  #       mkdir -p /root/rpmbuild/SOURCES && \
+  #       mkdir -p /root/rpmbuild/SPECS && \
+  #       mkdir -p /root/rpmbuild/SRPMS && \
+  #       cd /data/job/build/packages && bash generate_package.sh rpm
+  #   label: ":centos: Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/x86_64/*.rpm"
+  #   plugins:
+  #     docker#v1.4.0:
+  #       image: "eosio/ci:centos"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "centos"
+  #     PKGTYPE: "rpm"
+  #   timeout: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,9 +5,22 @@ steps:
       echo "--- Compressing build directory :compression:" && \
       tar -pczf build.tar.gz build/
     artifact_paths: "build.tar.gz"
-    label: ":darwin: Build"
+    label: ":highsierra: Build"
     agents:
       role: "macos-builder"
+      os: "high-sierra"
+    timeout: 60
+
+  - command: |
+      echo "+++ :hammer: Building" && \
+      echo 1 | ./build.sh && \
+      echo "--- Compressing build directory :compression:" && \
+      tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":mojave: Build"
+    agents:
+      role: "builder"
+      os: "mojave"
     timeout: 60
 
   - command: |
@@ -85,21 +98,126 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  # - wait
+  - wait
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step "":ubuntu: 16.04 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       cd /data/job/build/packages && bash generate_package.sh deb
-  #   label: ":ubuntu: 16.04 Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/*.deb"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:ubuntu"
-  #       workdir: /data/job
-  #   timeout: 60
+- command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":highsierra: Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+    label: ":highsierra: Package Builder"
+    agents:
+      role: "macos-builder"
+      os: "high-sierra"
+    artifact_paths:
+      - "build/packages/*.tar.gz"
+    timeout: 60
+
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":mojave: Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+    label: ":mojave: Package Builder"
+    agents:
+      role: "builder"
+      os: "mojave"
+    artifact_paths:
+      - "build/packages/*.tar.gz"
+    timeout: 60
+
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        cd /data/job/build/packages && bash generate_package.sh deb
+    label: ":ubuntu: Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/*.deb"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:ubuntu"
+        workdir: /data/job
+    env:
+      OS: "ubuntu-16.04"
+      PKGTYPE: "deb"
+    timeout: 60
+
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        cd /data/job/build/packages && bash generate_package.sh deb
+    label: ":ubuntu: 18.04 Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/*.deb"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:ubuntu18"
+        workdir: /data/job
+    env:
+      OS: "ubuntu-18.04"
+      PKGTYPE: "deb"
+    timeout: 60
+
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        yum install -y rpm-build && \
+        mkdir -p /root/rpmbuild/BUILD && \
+        mkdir -p /root/rpmbuild/BUILDROOT && \
+        mkdir -p /root/rpmbuild/RPMS && \
+        mkdir -p /root/rpmbuild/SOURCES && \
+        mkdir -p /root/rpmbuild/SPECS && \
+        mkdir -p /root/rpmbuild/SRPMS && \
+        cd /data/job/build/packages && bash generate_package.sh rpm
+    label: ":fedora: Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/x86_64/*.rpm"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:fedora"
+        workdir: /data/job
+    env:
+      OS: "fedora"
+      PKGTYPE: "rpm"
+    timeout: 60
+
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        yum install -y rpm-build && \
+        mkdir -p /root/rpmbuild/BUILD && \
+        mkdir -p /root/rpmbuild/BUILDROOT && \
+        mkdir -p /root/rpmbuild/RPMS && \
+        mkdir -p /root/rpmbuild/SOURCES && \
+        mkdir -p /root/rpmbuild/SPECS && \
+        mkdir -p /root/rpmbuild/SRPMS && \
+        cd /data/job/build/packages && bash generate_package.sh rpm
+    label: ":centos: Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/x86_64/*.rpm"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:centos"
+        workdir: /data/job
+    env:
+      OS: "centos"
+      PKGTYPE: "rpm"
+    timeout: 60

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -18,8 +18,7 @@ steps:
   #   artifact_paths: "build.tar.gz"
   #   label: ":ubuntu: 16.04 Build"
   #   agents:
-  #     role: "automation-builder-fleet"
-  #     aws:instance-type: "m5d.2xlarge"
+  #     queue: "automation-large-builder-fleet"
   #   plugins:
   #     docker#v2.0.0:
   #       image: "eosio/ci:ubuntu"
@@ -28,15 +27,13 @@ steps:
     
   - command: |
         echo "+++ :hammer: Building" && \
-        free -m && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
     artifact_paths: "build.tar.gz"
     label: ":ubuntu: 18.04 Build"
     agents:
-      role: "automation-builder-fleet"
-      aws:instance-type: "m5d.2xlarge"
+      queue: "automation-large-builder-fleet"
     plugins:
       docker#v2.0.0:
         image: "eosio/ci:ubuntu18"
@@ -51,8 +48,7 @@ steps:
   #   artifact_paths: "build.tar.gz"
   #   label: ":fedora: Build"
   #   agents:
-  #     role: "automation-builder-fleet"
-  #     aws:instance-type: "m5d.2xlarge"
+  #     queue: "automation-large-builder-fleet"
   #   plugins:
   #     docker#v2.0.0:
   #       image: "eosio/ci:fedora"
@@ -67,8 +63,7 @@ steps:
   #   artifact_paths: "build.tar.gz"
   #   label: ":centos: Build"
   #   agents:
-  #     role: "automation-builder-fleet"
-  #     aws:instance-type: "m5d.2xlarge"
+  #     queue: "automation-large-builder-fleet"
   #   plugins:
   #     docker#v2.0.0:
   #       image: "eosio/ci:centos"
@@ -83,8 +78,7 @@ steps:
   #   artifact_paths: "build.tar.gz"
   #   label: ":aws: Build"
   #   agents:
-  #     role: "automation-builder-fleet"
-  #     aws:instance-type: "m5d.2xlarge"
+  #     queue: "automation-large-builder-fleet"
   #   plugins:
   #     docker#v2.0.0:
   #       image: "eosio/ci:amazonlinux"
@@ -101,8 +95,7 @@ steps:
   #       cd /data/job/build/packages && bash generate_package.sh deb
   #   label: ":ubuntu: 16.04 Package builder"
   #   agents:
-  #     role: "automation-builder-fleet"
-  #     aws:instance-type: "m5d.2xlarge"
+  #     queue: "automation-large-builder-fleet"
   #   artifact_paths:
   #     - "build/packages/*.deb"
   #   plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,77 +11,77 @@ steps:
       os: "high-sierra"
     timeout: 60
 
-  # - command: |
-  #     echo "+++ :hammer: Building" && \
-  #     echo 1 | ./build.sh && \
-  #     echo "--- Compressing build directory :compression:" && \
-  #     tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":darwin: Mojave Build"
-  #   agents:
-  #     role: "builder"
-  #     os: "mojave"
-  #   timeout: 60
+  - command: |
+      echo "+++ :hammer: Building" && \
+      echo 1 | ./build.sh && \
+      echo "--- Compressing build directory :compression:" && \
+      tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":darwin: Mojave Build"
+    agents:
+      role: "builder"
+      os: "mojave"
+    timeout: 60
     
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":ubuntu: 18.04 Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:ubuntu18"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":ubuntu: 18.04 Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:ubuntu18"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":fedora: Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:fedora"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":fedora: Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:fedora"
+        workdir: /data/job
+    timeout: 60
 
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":centos: Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:centos"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":centos: Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:centos"
+        workdir: /data/job
+    timeout: 60
   
-  # - command: |
-  #       echo "+++ :hammer: Building" && \
-  #       echo 1 | ./build.sh && \
-  #       echo "--- Compressing build directory :compression:" && \
-  #       tar -pczf build.tar.gz build/
-  #   artifact_paths: "build.tar.gz"
-  #   label: ":aws: Build"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   plugins:
-  #     docker#v2.0.0:
-  #       image: "eosio/ci:amazonlinux"
-  #       workdir: /data/job
-  #   timeout: 60
+  - command: |
+        echo "+++ :hammer: Building" && \
+        echo 1 | ./build.sh && \
+        echo "--- Compressing build directory :compression:" && \
+        tar -pczf build.tar.gz build/
+    artifact_paths: "build.tar.gz"
+    label: ":aws: Build"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:amazonlinux"
+        workdir: /data/job
+    timeout: 60
 
   - wait
 
@@ -97,92 +97,92 @@ steps:
       os: "high-sierra"
     artifact_paths:
       - "build/packages/*.tar.gz"
-    timeout: 60
+    timeout: 15
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-  #   label: ":darwin: Mojave Package Builder"
-  #   agents:
-  #     role: "builder"
-  #     os: "mojave"
-  #   artifact_paths:
-  #     - "build/packages/*.tar.gz"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+    label: ":darwin: Mojave Package Builder"
+    agents:
+      role: "builder"
+      os: "mojave"
+    artifact_paths:
+      - "build/packages/*.tar.gz"
+    timeout: 15
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       cd /data/job/build/packages && bash generate_package.sh deb
-  #   label: ":ubuntu: 18.04 Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/*.deb"
-  #   plugins:
-  #     docker#v1.4.0:
-  #       image: "eosio/ci:ubuntu18"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "ubuntu-18.04"
-  #     PKGTYPE: "deb"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        cd /data/job/build/packages && bash generate_package.sh deb
+    label: ":ubuntu: 18.04 Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/*.deb"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:ubuntu18"
+        workdir: /data/job
+    env:
+      OS: "ubuntu-18.04"
+      PKGTYPE: "deb"
+    timeout: 15
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       yum install -y rpm-build && \
-  #       mkdir -p /root/rpmbuild/BUILD && \
-  #       mkdir -p /root/rpmbuild/BUILDROOT && \
-  #       mkdir -p /root/rpmbuild/RPMS && \
-  #       mkdir -p /root/rpmbuild/SOURCES && \
-  #       mkdir -p /root/rpmbuild/SPECS && \
-  #       mkdir -p /root/rpmbuild/SRPMS && \
-  #       cd /data/job/build/packages && bash generate_package.sh rpm
-  #   label: ":fedora: Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/x86_64/*.rpm"
-  #   plugins:
-  #     docker#v1.4.0:
-  #       image: "eosio/ci:fedora"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "fedora"
-  #     PKGTYPE: "rpm"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        yum install -y rpm-build && \
+        mkdir -p /root/rpmbuild/BUILD && \
+        mkdir -p /root/rpmbuild/BUILDROOT && \
+        mkdir -p /root/rpmbuild/RPMS && \
+        mkdir -p /root/rpmbuild/SOURCES && \
+        mkdir -p /root/rpmbuild/SPECS && \
+        mkdir -p /root/rpmbuild/SRPMS && \
+        cd /data/job/build/packages && bash generate_package.sh rpm
+    label: ":fedora: Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/x86_64/*.rpm"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:fedora"
+        workdir: /data/job
+    env:
+      OS: "fedora"
+      PKGTYPE: "rpm"
+    timeout: 15
 
-  # - command: |
-  #       echo "--- :arrow_down: Downloading build directory" && \
-  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
-  #       tar -zxf build.tar.gz && \
-  #       echo "+++ :microscope: Starting package build" && \
-  #       yum install -y rpm-build && \
-  #       mkdir -p /root/rpmbuild/BUILD && \
-  #       mkdir -p /root/rpmbuild/BUILDROOT && \
-  #       mkdir -p /root/rpmbuild/RPMS && \
-  #       mkdir -p /root/rpmbuild/SOURCES && \
-  #       mkdir -p /root/rpmbuild/SPECS && \
-  #       mkdir -p /root/rpmbuild/SRPMS && \
-  #       cd /data/job/build/packages && bash generate_package.sh rpm
-  #   label: ":centos: Package builder"
-  #   agents:
-  #     queue: "automation-large-builder-fleet"
-  #   artifact_paths:
-  #     - "build/packages/x86_64/*.rpm"
-  #   plugins:
-  #     docker#v1.4.0:
-  #       image: "eosio/ci:centos"
-  #       workdir: /data/job
-  #   env:
-  #     OS: "centos"
-  #     PKGTYPE: "rpm"
-  #   timeout: 60
+  - command: |
+        echo "--- :arrow_down: Downloading build directory" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
+        tar -zxf build.tar.gz && \
+        echo "+++ :microscope: Starting package build" && \
+        yum install -y rpm-build && \
+        mkdir -p /root/rpmbuild/BUILD && \
+        mkdir -p /root/rpmbuild/BUILDROOT && \
+        mkdir -p /root/rpmbuild/RPMS && \
+        mkdir -p /root/rpmbuild/SOURCES && \
+        mkdir -p /root/rpmbuild/SPECS && \
+        mkdir -p /root/rpmbuild/SRPMS && \
+        cd /data/job/build/packages && bash generate_package.sh rpm
+    label: ":centos: Package builder"
+    agents:
+      queue: "automation-large-builder-fleet"
+    artifact_paths:
+      - "build/packages/x86_64/*.rpm"
+    plugins:
+      docker#v1.4.0:
+        image: "eosio/ci:centos"
+        workdir: /data/job
+    env:
+      OS: "centos"
+      PKGTYPE: "rpm"
+    timeout: 15

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,27 +1,27 @@
 steps:
-  - command: |
-      echo "+++ :hammer: Building" && \
-      echo 1 | ./build.sh && \
-      echo "--- Compressing build directory :compression:" && \
-      tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":darwin: High Sierra Build"
-    agents:
-      role: "macos-builder"
-      os: "high-sierra"
-    timeout: 60
+  # - command: |
+  #     echo "+++ :hammer: Building" && \
+  #     echo 1 | ./build.sh && \
+  #     echo "--- Compressing build directory :compression:" && \
+  #     tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":darwin: High Sierra Build"
+  #   agents:
+  #     role: "macos-builder"
+  #     os: "high-sierra"
+  #   timeout: 60
 
-  - command: |
-      echo "+++ :hammer: Building" && \
-      echo 1 | ./build.sh && \
-      echo "--- Compressing build directory :compression:" && \
-      tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":darwin: Mojave Build"
-    agents:
-      role: "builder"
-      os: "mojave"
-    timeout: 60
+  # - command: |
+  #     echo "+++ :hammer: Building" && \
+  #     echo 1 | ./build.sh && \
+  #     echo "--- Compressing build directory :compression:" && \
+  #     tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":darwin: Mojave Build"
+  #   agents:
+  #     role: "builder"
+  #     os: "mojave"
+  #   timeout: 60
     
   - command: |
         echo "+++ :hammer: Building" && \
@@ -38,80 +38,80 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":fedora: Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:fedora"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":fedora: Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:fedora"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":centos: Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:centos"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":centos: Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:centos"
+  #       workdir: /data/job
+  #   timeout: 60
   
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":aws: Build"
-    agents:
-      queue: "automation-large-builder-fleet"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:amazonlinux"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":aws: Build"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:amazonlinux"
+  #       workdir: /data/job
+  #   timeout: 60
 
   - wait
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :package: Starting package build" && \
-        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-    label: ":darwin: High Sierra Package Builder"
-    agents:
-      role: "macos-builder"
-      os: "high-sierra"
-    artifact_paths:
-      - "build/packages/*.tar.gz"
-    timeout: 15
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :package: Starting package build" && \
+  #       ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+  #   label: ":darwin: High Sierra Package Builder"
+  #   agents:
+  #     role: "macos-builder"
+  #     os: "high-sierra"
+  #   artifact_paths:
+  #     - "build/packages/*.tar.gz"
+  #   timeout: 15
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :package: Starting package build" && \
-        ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
-    label: ":darwin: Mojave Package Builder"
-    agents:
-      role: "builder"
-      os: "mojave"
-    artifact_paths:
-      - "build/packages/*.tar.gz"
-    timeout: 15
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :package: Starting package build" && \
+  #       ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
+  #   label: ":darwin: Mojave Package Builder"
+  #   agents:
+  #     role: "builder"
+  #     os: "mojave"
+  #   artifact_paths:
+  #     - "build/packages/*.tar.gz"
+  #   timeout: 15
 
   - command: |
         echo "--- :arrow_down: Downloading build directory" && \
@@ -133,59 +133,59 @@ steps:
       PKGTYPE: "deb"
     timeout: 15
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :package: Starting package build" && \
-        yum install -y rpm-build && \
-        mkdir -p /root/rpmbuild/BUILD && \
-        mkdir -p /root/rpmbuild/BUILDROOT && \
-        mkdir -p /root/rpmbuild/RPMS && \
-        mkdir -p /root/rpmbuild/SOURCES && \
-        mkdir -p /root/rpmbuild/SPECS && \
-        mkdir -p /root/rpmbuild/SRPMS && \
-        cd /data/job/build/packages && bash generate_package.sh rpm
-    label: ":fedora: Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/x86_64/*.rpm"
-    plugins:
-      docker#v1.4.0:
-        image: "eosio/ci:fedora"
-        workdir: /data/job
-    env:
-      OS: "fedora"
-      PKGTYPE: "rpm"
-    timeout: 15
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :package: Starting package build" && \
+  #       yum install -y rpm-build && \
+  #       mkdir -p /root/rpmbuild/BUILD && \
+  #       mkdir -p /root/rpmbuild/BUILDROOT && \
+  #       mkdir -p /root/rpmbuild/RPMS && \
+  #       mkdir -p /root/rpmbuild/SOURCES && \
+  #       mkdir -p /root/rpmbuild/SPECS && \
+  #       mkdir -p /root/rpmbuild/SRPMS && \
+  #       cd /data/job/build/packages && bash generate_package.sh rpm
+  #   label: ":fedora: Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/x86_64/*.rpm"
+  #   plugins:
+  #     docker#v1.4.0:
+  #       image: "eosio/ci:fedora"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "fedora"
+  #     PKGTYPE: "rpm"
+  #   timeout: 15
 
-  - command: |
-        echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
-        tar -zxf build.tar.gz && \
-        echo "+++ :package: Starting package build" && \
-        yum install -y rpm-build && \
-        mkdir -p /root/rpmbuild/BUILD && \
-        mkdir -p /root/rpmbuild/BUILDROOT && \
-        mkdir -p /root/rpmbuild/RPMS && \
-        mkdir -p /root/rpmbuild/SOURCES && \
-        mkdir -p /root/rpmbuild/SPECS && \
-        mkdir -p /root/rpmbuild/SRPMS && \
-        cd /data/job/build/packages && bash generate_package.sh rpm
-    label: ":centos: Package builder"
-    agents:
-      queue: "automation-large-builder-fleet"
-    artifact_paths:
-      - "build/packages/x86_64/*.rpm"
-    plugins:
-      docker#v1.4.0:
-        image: "eosio/ci:centos"
-        workdir: /data/job
-    env:
-      OS: "centos"
-      PKGTYPE: "rpm"
-    timeout: 15
+  # - command: |
+  #       echo "--- :arrow_down: Downloading build directory" && \
+  #       buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
+  #       tar -zxf build.tar.gz && \
+  #       echo "+++ :package: Starting package build" && \
+  #       yum install -y rpm-build && \
+  #       mkdir -p /root/rpmbuild/BUILD && \
+  #       mkdir -p /root/rpmbuild/BUILDROOT && \
+  #       mkdir -p /root/rpmbuild/RPMS && \
+  #       mkdir -p /root/rpmbuild/SOURCES && \
+  #       mkdir -p /root/rpmbuild/SPECS && \
+  #       mkdir -p /root/rpmbuild/SRPMS && \
+  #       cd /data/job/build/packages && bash generate_package.sh rpm
+  #   label: ":centos: Package builder"
+  #   agents:
+  #     queue: "automation-large-builder-fleet"
+  #   artifact_paths:
+  #     - "build/packages/x86_64/*.rpm"
+  #   plugins:
+  #     docker#v1.4.0:
+  #       image: "eosio/ci:centos"
+  #       workdir: /data/job
+  #   env:
+  #     OS: "centos"
+  #     PKGTYPE: "rpm"
+  #   timeout: 15
 
   - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,33 +1,34 @@
 steps:
-  - command: |
-      echo "+++ :hammer: Building" && \
-      echo 1 | ./build.sh && \
-      echo "--- Compressing build directory :compression:" && \
-      tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":darwin: Build"
-    agents:
-      role: "macos-builder"
-    timeout: 60
+  # - command: |
+  #     echo "+++ :hammer: Building" && \
+  #     echo 1 | ./build.sh && \
+  #     echo "--- Compressing build directory :compression:" && \
+  #     tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":darwin: Build"
+  #   agents:
+  #     role: "macos-builder"
+  #   timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":ubuntu: 16.04 Build"
-    agents:
-      role: "automation-builder-fleet"
-      aws:instance-type: "m5d.2xlarge"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:ubuntu"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":ubuntu: 16.04 Build"
+  #   agents:
+  #     role: "automation-builder-fleet"
+  #     aws:instance-type: "m5d.2xlarge"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:ubuntu"
+  #       workdir: /data/job
+  #   timeout: 60
     
   - command: |
         echo "+++ :hammer: Building" && \
+        free -m && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
@@ -42,53 +43,53 @@ steps:
         workdir: /data/job
     timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":fedora: Build"
-    agents:
-      role: "automation-builder-fleet"
-      aws:instance-type: "m5d.2xlarge"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:fedora"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":fedora: Build"
+  #   agents:
+  #     role: "automation-builder-fleet"
+  #     aws:instance-type: "m5d.2xlarge"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:fedora"
+  #       workdir: /data/job
+  #   timeout: 60
 
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":centos: Build"
-    agents:
-      role: "automation-builder-fleet"
-      aws:instance-type: "m5d.2xlarge"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:centos"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":centos: Build"
+  #   agents:
+  #     role: "automation-builder-fleet"
+  #     aws:instance-type: "m5d.2xlarge"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:centos"
+  #       workdir: /data/job
+  #   timeout: 60
   
-  - command: |
-        echo "+++ :hammer: Building" && \
-        echo 1 | ./build.sh && \
-        echo "--- Compressing build directory :compression:" && \
-        tar -pczf build.tar.gz build/
-    artifact_paths: "build.tar.gz"
-    label: ":aws: Build"
-    agents:
-      role: "automation-builder-fleet"
-      aws:instance-type: "m5d.2xlarge"
-    plugins:
-      docker#v2.0.0:
-        image: "eosio/ci:amazonlinux"
-        workdir: /data/job
-    timeout: 60
+  # - command: |
+  #       echo "+++ :hammer: Building" && \
+  #       echo 1 | ./build.sh && \
+  #       echo "--- Compressing build directory :compression:" && \
+  #       tar -pczf build.tar.gz build/
+  #   artifact_paths: "build.tar.gz"
+  #   label: ":aws: Build"
+  #   agents:
+  #     role: "automation-builder-fleet"
+  #     aws:instance-type: "m5d.2xlarge"
+  #   plugins:
+  #     docker#v2.0.0:
+  #       image: "eosio/ci:amazonlinux"
+  #       workdir: /data/job
+  #   timeout: 60
 
   # - wait
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -196,14 +196,14 @@ steps:
         gcloud --quiet auth activate-service-account b1-automation-svc@b1-automation-dev.iam.gserviceaccount.com --key-file=/etc/gcp-service-account.json && \
         docker-credential-gcr configure-docker && \
         echo "--- :hammer_and_wrench: BUILDING BUILD IMAGE" && \
-        cd docker/dev \
+        cd docker/dev && \
         docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT . && \
         docker tag eosio/cdt:$BUILDKITE_COMMIT gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
         docker tag eosio/cdt:latest gcr.io/b1-automation-dev/eosio/cdt:latest && \
         echo "--- :hand: PUSHING DOCKER IMAGES" && \
         docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
         docker push gcr.io/b1-automation-dev/eosio/cdt:latest && \
-        echo "--- :tada: TRASHING OLD IMAGES" && \
+        echo "--- :thought_balloon: TRASHING OLD IMAGES" && \
         docker rmi eosio/cdt:$BUILDKITE_COMMIT && \
         docker rmi eosio/cdt:latest && \
         docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:18.04
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates curl wget && rm -rf /var/lib/apt/lists/*
 
 # Install CDT from deb package
-ADD *.deb /
-RUN for filename in $(ls build/packages/*.deb); do /usr/bin/dpkg -i "$filename" && rm -f "$filename"; done
+ADD build/packages/*.deb /
+RUN for filename in $(ls *.deb); do /usr/bin/dpkg -i "$filename" && rm -f "$filename"; done
 
 USER root

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -5,6 +5,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl 
 
 # Install CDT from deb package
 ADD *.deb /
-RUN for filename in $(ls builder/packages/*.deb); do /usr/bin/dpkg -i "$filename" && rm -f "$filename"; done
+RUN for filename in $(ls build/packages/*.deb); do /usr/bin/dpkg -i "$filename" && rm -f "$filename"; done
 
 USER root

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -5,6 +5,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl 
 
 # Install CDT from deb package
 ADD *.deb /
-RUN for filename in $(ls *.deb); do /usr/bin/dpkg -i "$filename" && rm -f "$filename"; done
+RUN for filename in $(ls builder/packages/*.deb); do /usr/bin/dpkg -i "$filename" && rm -f "$filename"; done
 
 USER root

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+
+# Install required packages
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates curl wget && rm -rf /var/lib/apt/lists/*
+
+# Install CDT from deb package
+ADD *.deb /
+RUN for filename in $(ls *.deb); do /usr/bin/dpkg -i "$filename" && rm -f "$filename"; done
+
+USER root

--- a/scripts/generate_bottle.sh
+++ b/scripts/generate_bottle.sh
@@ -14,6 +14,8 @@ else
    MAC_VERSION="high_sierra"
 fi
 
+NAME="${PROJECT}-${VERSION}.${MAC_VERSION}.bottle.tar.gz"
+
 mkdir -p ${PROJECT}/${VERSION}/opt/eosio_cdt/lib/cmake
 
 PREFIX="${PROJECT}/${VERSION}"

--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-NAME="${PROJECT}-${VERSION}.x86_64"
+NAME="${PROJECT}-${VERSION}-1_amd64"
 PREFIX="usr"
 SPREFIX=${PREFIX}
 SUBPREFIX="opt/${PROJECT}/${VERSION}"

--- a/scripts/generate_rpm.sh
+++ b/scripts/generate_rpm.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-NAME="${PROJECT}-${VERSION}.x86_64"
+NAME="${PROJECT}-${VERSION}-1"
 PREFIX="usr"
 SPREFIX=${PREFIX}
 SUBPREFIX="opt/${PROJECT}/${VERSION}"
@@ -13,7 +13,7 @@ export SSUBPREFIX
 
 bash generate_tarball.sh ${NAME}.tar.gz
 
-RPMBUILD=`realpath ~/rpmbuild/BUILDROOT/${NAME}-0.x86_64`
+RPMBUILD=`realpath ~/rpmbuild/BUILDROOT/${NAME}.x86_64`
 mkdir -p ${RPMBUILD} 
 FILES=$(tar -xvzf ${NAME}.tar.gz -C ${RPMBUILD})
 PFILES=""
@@ -26,14 +26,14 @@ echo -e ${PFILES} &> ~/rpmbuild/BUILD/filenames.txt
 
 mkdir -p ${PROJECT} 
 echo -e "Name: ${PROJECT} 
-Version: ${VERSION}.x86_64
+Version: ${VERSION}
 License: MIT
 Vendor: ${VENDOR} 
 Source: ${URL} 
 URL: ${URL} 
 Packager: ${VENDOR} <${EMAIL}>
 Summary: ${DESC}
-Release: 0
+Release: 1
 %description
 ${DESC}
 %files -f filenames.txt" &> ${PROJECT}.spec

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -40,7 +40,7 @@ ln -sf ../../../${SUBPREFIX}/lib/cmake/${PROJECT}/EosioWasmToolchain.cmake Eosio
 popd &> /dev/null
 
 pushd ${PREFIX}/bin &> /dev/null
-for f in `find ${BUILD_DIR}/bin -name "eosio-*"`; do
+for f in `ls ${BUILD_DIR}/bin/eosio-\*`; do
    bn=$(basename $f)
    ln -sf ../${SUBPREFIX}/bin/$bn $bn
 done


### PR DESCRIPTION
The pipeline builds the supported OSes (Mac High Sierra and Mojave, Ubuntu 18.04, Fedora, CentOS, and Amazon Linux) and creates packages as artifacts for each (where applicable).