### PR TITLE
Fix return codes of build scripts so that buildkite can fail properly

### DIFF
--- a/scripts/generate_deb.sh
+++ b/scripts/generate_deb.sh
@@ -32,5 +32,8 @@ bash generate_tarball.sh ${NAME}.tar.gz
 
 tar -xvzf ${NAME}.tar.gz -C ${PROJECT} 
 dpkg-deb --build ${PROJECT} 
+BUILDSTATUS=$?
 mv ${PROJECT}.deb ${NAME}.deb
 rm -r ${PROJECT}
+
+exit $BUILDSTATUS

--- a/scripts/generate_package.sh.in
+++ b/scripts/generate_package.sh.in
@@ -36,4 +36,9 @@ else
    echo "Error, unknown package type. Use either ['brew', 'deb', 'rpm']."
    exit -1
 fi
+
+BUILDSTATUS=$?
+
 rm -r tmp
+
+exit $BUILDSTATUS

--- a/scripts/generate_rpm.sh
+++ b/scripts/generate_rpm.sh
@@ -46,5 +46,8 @@ ${DESC}
 %files -f filenames.txt" &> ${PROJECT}.spec
 
 rpmbuild -bb ${PROJECT}.spec
+BUILDSTATUS=$?
 mv ~/rpmbuild/RPMS/x86_64 ./
 rm -r ${PROJECT} ~/rpmbuild/BUILD/filenames.txt ${PROJECT}.spec
+
+exit $BUILDSTATUS


### PR DESCRIPTION
In order to properly report status in Buildkite we need the return code of `rpmbuild` and `dpkg-deb` to be bubbled up to `generate_package.sh`.