### PR TITLE
Add support for uint8_t to eosio::print

### DIFF
--- a/libraries/eosiolib/print.hpp
+++ b/libraries/eosiolib/print.hpp
@@ -77,6 +77,16 @@ namespace eosio {
    inline void print( unsigned int num ) {
       printui(num);
    }
+  
+   /**
+    * Prints 8 bit unsigned integer
+    *
+    * @brief Prints 8 bit unsigned integer as a 64 bit unsigned integer
+    * @param num to be printed
+    */
+   inline void print( uint8_t num ) {
+      printui(num);
+   }
 
    /**
     * Prints 32 bit unsigned integer


### PR DESCRIPTION
This is particularly useful when trying to print uint8_t integers inside an std::vector<uint8_t> array stored in a table.

I know uint8_t and char are the same size. However, storing it in a `vector<uint8_t>` will make the abi type to be an array of uint8_t instead of char "bytes" in a `vector<char>`. In my case, is a lot more convenient to have a sortable array out-the-box. So when users like me have to print any number contained in that array, they need printing support.