### PR TITLE
Change to multi_index constructor in examples

### DIFF
--- a/examples/multi_index_example/multi_index_example.cpp
+++ b/examples/multi_index_example/multi_index_example.cpp
@@ -10,7 +10,7 @@ CONTRACT multi_index_example : public contract {
   public:
       using contract::contract;
       multi_index_example( name receiver, name code, datastream<const char*> ds )
-         : contract(receiver, code, ds), testtab(receiver, receiver.value) {}
+         : contract(receiver, code, ds), testtab(receiver, code.value) {}
 
 //      [[eosio::action]]
 //      void set( name user ) {


### PR DESCRIPTION
Looking into the documentation, it is stated that we should pass `code.value` as it is in the `_polls(receiver, code.value)`