### PR TITLE
Temporary fix for mac packagers in buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -90,6 +90,7 @@ steps:
         buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
         tar -zxf build.tar.gz && \
         echo "+++ :package: Starting package build" && \
+        CMAKE_BINARY_DIR="$(pwd)/build" && \
         ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
     label: ":darwin: High Sierra Package Builder"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -105,6 +105,7 @@ steps:
         buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
         tar -zxf build.tar.gz && \
         echo "+++ :package: Starting package build" && \
+        CMAKE_BINARY_DIR="$(pwd)/build" && \
         ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
     label: ":darwin: Mojave Package Builder"
     agents:


### PR DESCRIPTION
Current CDT build scripts rely on the CMAKE_BINARY_DIR to point to the build artifacts in an absolute path; in the buildkite environment, this can be set by a different host.  The effect was empty bottle files for Mac packages.  It did not affect linux builds, since all of the hosts use the same exact configuration.