### PR TITLE
Added Unit Tests to Buildkite Pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -115,7 +115,7 @@ steps:
     
   - command: | # Ubuntu 18.04 Unit Tests
       echo "--- :arrow_down: Downloading build directory" && \
-      buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
+      buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: Ubuntu 18.04 Build" && \
       tar -zxf build.tar.gz && \
       echo "+++ :microscope: Running unit tests on Ubuntu" && \
       cd build && \
@@ -131,7 +131,7 @@ steps:
 
   - command: | # Fedora Unit Tests
       echo "--- :arrow_down: Downloading build directory" && \
-      buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
+      buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Fedora Build" && \
       tar -zxf build.tar.gz && \
       echo "+++ :microscope: Running unit tests on Fedora" && \
       cd build && \
@@ -147,7 +147,7 @@ steps:
 
   - command: | # CentOS Unit Tests
       echo "--- :arrow_down: Downloading build directory" && \
-      buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
+      buildkite-agent artifact download "build.tar.gz" . --step ":centos: CentOS Build" && \
       tar -zxf build.tar.gz && \
       echo "+++ :microscope: Running unit tests on CentOS" && \
       cd build && \
@@ -163,7 +163,7 @@ steps:
   
   - command: | # Amazon Unit Tests
       echo "--- :arrow_down: Downloading build directory" && \
-      buildkite-agent artifact download "build.tar.gz" . --step ":aws: Build" && \
+      buildkite-agent artifact download "build.tar.gz" . --step ":aws: Amazon AWS Build" && \
       tar -zxf build.tar.gz && \
       echo "+++ :microscope: Running unit tests on Amazon AWS" && \
       cd build && \
@@ -210,7 +210,7 @@ steps:
 
   - command: | # Ubuntu Packaging
         echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: Ubuntu 18.04 Build" && \
         tar -zxf build.tar.gz && \
         echo "+++ :package: Starting package build" && \
         cd /data/job/build/packages && bash generate_package.sh deb
@@ -230,7 +230,7 @@ steps:
 
   - command: | # Fedora Packaging
         echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Fedora Build" && \
         tar -zxf build.tar.gz && \
         echo "+++ :package: Starting package build" && \
         yum install -y rpm-build && \
@@ -257,7 +257,7 @@ steps:
 
   - command: | # CentOS Packaging
         echo "--- :arrow_down: Downloading build directory" && \
-        buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
+        buildkite-agent artifact download "build.tar.gz" . --step ":centos: CentOS Build" && \
         tar -zxf build.tar.gz && \
         echo "+++ :package: Starting package build" && \
         yum install -y rpm-build && \
@@ -287,7 +287,7 @@ steps:
 
   - command: | # Docker Build
         echo "--- :arrow_down: Downloading package" && \
-        buildkite-agent artifact download "build/packages/*.deb" docker/dev/. --step ":ubuntu: 18.04 Package builder" && \
+        buildkite-agent artifact download "build/packages/*.deb" docker/dev/. --step ":ubuntu: Ubuntu 18.04 Package Builder" && \
         echo "--- :key: AUTHENTICATING GOOGLE SERVICE ACCOUNT" && \
         gcloud --quiet auth activate-service-account b1-automation-svc@b1-automation-dev.iam.gserviceaccount.com --key-file=/etc/gcp-service-account.json && \
         docker-credential-gcr configure-docker && \

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -93,6 +93,7 @@ steps:
       tar -zxf build.tar.gz && \
       echo "+++ :microscope: Running unit tests on macOS High Sierra" && \
       cd build && \
+      CMAKE_BINARY_DIR="$(pwd)/build" && \ # absolute path error workaround
       ctest -V
     label: ":darwin: High Sierra Unit Tests"
     agents:
@@ -106,10 +107,11 @@ steps:
       tar -zxf build.tar.gz && \
       echo "+++ :microscope: Running unit tests on macOS Mojave" && \
       cd build && \
+      CMAKE_BINARY_DIR="$(pwd)/build" && \ # absolute path error workaround
       ctest -V
     label: ":darwin: Mojave Unit Tests"
     agents:
-      role: "macos-tester"
+      role: "tester"
       os: "mojave"
     timeout: 120
     
@@ -185,6 +187,7 @@ steps:
         buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
         tar -zxf build.tar.gz && \
         echo "+++ :package: Starting package build" && \
+        CMAKE_BINARY_DIR="$(pwd)/build" && \ # absolute path error workaround
         ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
     label: ":darwin: High Sierra Package Builder"
     agents:
@@ -199,6 +202,7 @@ steps:
         buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
         tar -zxf build.tar.gz && \
         echo "+++ :package: Starting package build" && \
+        CMAKE_BINARY_DIR="$(pwd)/build" && \ # absolute path error workaround
         ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
     label: ":darwin: Mojave Package Builder"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,6 @@
 steps:
-  - command: |
+  # BUILDS
+  - command: | # High Sierra Build
       echo "+++ :hammer: Building" && \
       echo 1 | ./build.sh && \
       echo "--- Compressing build directory :compression:" && \
@@ -11,7 +12,7 @@ steps:
       os: "high-sierra"
     timeout: 120
 
-  - command: |
+  - command: | # Mojave Build
       echo "+++ :hammer: Building" && \
       echo 1 | ./build.sh && \
       echo "--- Compressing build directory :compression:" && \
@@ -23,7 +24,7 @@ steps:
       os: "mojave"
     timeout: 120
     
-  - command: |
+  - command: | # Ubuntu Build
         echo "+++ :hammer: Building" && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
@@ -38,7 +39,7 @@ steps:
         workdir: /data/job
     timeout: 120
 
-  - command: |
+  - command: | # Fedora Build
         echo "+++ :hammer: Building" && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
@@ -53,7 +54,7 @@ steps:
         workdir: /data/job
     timeout: 120
 
-  - command: |
+  - command: | # CentOS Build
         echo "+++ :hammer: Building" && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
@@ -68,7 +69,7 @@ steps:
         workdir: /data/job
     timeout: 120
   
-  - command: |
+  - command: | # Amazon Build
         echo "+++ :hammer: Building" && \
         echo 1 | ./build.sh && \
         echo "--- Compressing build directory :compression:" && \
@@ -83,9 +84,103 @@ steps:
         workdir: /data/job
     timeout: 120
 
+  # UNIT TESTING
   - wait
 
-  - command: |
+  - command: | # High Sierra Unit Tests
+      echo "--- :arrow_down: Downloading build directory" && \
+      buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
+      tar -zxf build.tar.gz && \
+      echo "+++ :microscope: Running unit tests" && \
+      cd build && \
+      ctest -V
+    label: ":darwin: High Sierra Unit Tests"
+    agents:
+      role: "macos-tester"
+      os: "high-sierra"
+    timeout: 120
+
+  - command: | # Mojave Unit Tests
+      echo "--- :arrow_down: Downloading build directory" && \
+      buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
+      tar -zxf build.tar.gz && \
+      echo "+++ :microscope: Running unit tests" && \
+      cd build && \
+      ctest -V
+    label: ":darwin: Mojave Unit Tests"
+    agents:
+      role: "macos-tester"
+      os: "mojave"
+    timeout: 120
+    
+  - command: | # Ubuntu Unit Tests
+      echo "--- :arrow_down: Downloading build directory" && \
+      buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
+      tar -zxf build.tar.gz && \
+      echo "+++ :microscope: Running unit tests" && \
+      cd build && \
+      ctest -V
+    label: ":ubuntu: 18.04 Unit Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:ubuntu18"
+        workdir: /data/job
+    timeout: 120
+
+  - command: | # Fedora Unit Tests
+      echo "--- :arrow_down: Downloading build directory" && \
+      buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
+      tar -zxf build.tar.gz && \
+      echo "+++ :microscope: Running unit tests" && \
+      cd build && \
+      ctest -V
+    label: ":fedora: Unit Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:fedora"
+        workdir: /data/job
+    timeout: 120
+
+  - command: | # CentOS Unit Tests
+      echo "--- :arrow_down: Downloading build directory" && \
+      buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
+      tar -zxf build.tar.gz && \
+      echo "+++ :microscope: Running unit tests" && \
+      cd build && \
+      ctest -V
+    label: ":centos: Unit Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:centos"
+        workdir: /data/job
+    timeout: 120
+  
+  - command: | # Amazon Unit Tests
+      echo "--- :arrow_down: Downloading build directory" && \
+      buildkite-agent artifact download "build.tar.gz" . --step ":aws: Build" && \
+      tar -zxf build.tar.gz && \
+      echo "+++ :microscope: Running unit tests" && \
+      cd build && \
+      ctest -V
+    label: ":aws: Unit Tests"
+    agents:
+      queue: "automation-large-builder-fleet"
+    plugins:
+      docker#v2.0.0:
+        image: "eosio/ci:amazonlinux"
+        workdir: /data/job
+    timeout: 120
+
+  # PACKAGE BUILDS
+  - wait
+
+  - command: | # High Sierra Packaging
         echo "--- :arrow_down: Downloading build directory" && \
         buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
         tar -zxf build.tar.gz && \
@@ -99,7 +194,7 @@ steps:
       - "build/packages/*.tar.gz"
     timeout: 15
 
-  - command: |
+  - command: | # Mojave Packaging
         echo "--- :arrow_down: Downloading build directory" && \
         buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
         tar -zxf build.tar.gz && \
@@ -113,7 +208,7 @@ steps:
       - "build/packages/*.tar.gz"
     timeout: 15
 
-  - command: |
+  - command: | # Ubuntu Packaging
         echo "--- :arrow_down: Downloading build directory" && \
         buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
         tar -zxf build.tar.gz && \
@@ -133,7 +228,7 @@ steps:
       PKGTYPE: "deb"
     timeout: 15
 
-  - command: |
+  - command: | # Fedora Packaging
         echo "--- :arrow_down: Downloading build directory" && \
         buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
         tar -zxf build.tar.gz && \
@@ -160,7 +255,7 @@ steps:
       PKGTYPE: "rpm"
     timeout: 15
 
-  - command: |
+  - command: | # CentOS Packaging
         echo "--- :arrow_down: Downloading build directory" && \
         buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
         tar -zxf build.tar.gz && \
@@ -187,9 +282,10 @@ steps:
       PKGTYPE: "rpm"
     timeout: 15
 
+  # DOCKER BUILD
   - wait
 
-  - command: |
+  - command: | # Docker Build
         echo "--- :arrow_down: Downloading package" && \
         buildkite-agent artifact download "build/packages/*.deb" docker/dev/. --step ":ubuntu: 18.04 Package builder" && \
         echo "--- :key: AUTHENTICATING GOOGLE SERVICE ACCOUNT" && \

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -93,7 +93,6 @@ steps:
       tar -zxf build.tar.gz && \
       echo "+++ :microscope: Running unit tests on macOS High Sierra" && \
       cd build && \
-      CMAKE_BINARY_DIR="$(pwd)/build" && \ # absolute path error workaround
       ctest -V
     label: ":darwin: High Sierra Unit Tests"
     agents:
@@ -107,7 +106,6 @@ steps:
       tar -zxf build.tar.gz && \
       echo "+++ :microscope: Running unit tests on macOS Mojave" && \
       cd build && \
-      CMAKE_BINARY_DIR="$(pwd)/build" && \ # absolute path error workaround
       ctest -V
     label: ":darwin: Mojave Unit Tests"
     agents:
@@ -187,7 +185,6 @@ steps:
         buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
         tar -zxf build.tar.gz && \
         echo "+++ :package: Starting package build" && \
-        CMAKE_BINARY_DIR="$(pwd)/build" && \ # absolute path error workaround
         ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
     label: ":darwin: High Sierra Package Builder"
     agents:
@@ -202,7 +199,6 @@ steps:
         buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
         tar -zxf build.tar.gz && \
         echo "+++ :package: Starting package build" && \
-        CMAKE_BINARY_DIR="$(pwd)/build" && \ # absolute path error workaround
         ln -s "$(pwd)" /data/job && cd /data/job/build/packages && bash generate_package.sh brew
     label: ":darwin: Mojave Package Builder"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,7 +30,7 @@ steps:
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
     artifact_paths: "build.tar.gz"
-    label: ":ubuntu: 18.04 Build"
+    label: ":ubuntu: Ubuntu 18.04 Build"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -45,7 +45,7 @@ steps:
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
     artifact_paths: "build.tar.gz"
-    label: ":fedora: Build"
+    label: ":fedora: Fedora Build"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -60,7 +60,7 @@ steps:
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
     artifact_paths: "build.tar.gz"
-    label: ":centos: Build"
+    label: ":centos: CentOS Build"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -75,7 +75,7 @@ steps:
         echo "--- Compressing build directory :compression:" && \
         tar -pczf build.tar.gz build/
     artifact_paths: "build.tar.gz"
-    label: ":aws: Build"
+    label: ":aws: Amazon AWS Build"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -91,7 +91,7 @@ steps:
       echo "--- :arrow_down: Downloading build directory" && \
       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: High Sierra Build" && \
       tar -zxf build.tar.gz && \
-      echo "+++ :microscope: Running unit tests" && \
+      echo "+++ :microscope: Running unit tests on macOS High Sierra" && \
       cd build && \
       ctest -V
     label: ":darwin: High Sierra Unit Tests"
@@ -104,7 +104,7 @@ steps:
       echo "--- :arrow_down: Downloading build directory" && \
       buildkite-agent artifact download "build.tar.gz" . --step ":darwin: Mojave Build" && \
       tar -zxf build.tar.gz && \
-      echo "+++ :microscope: Running unit tests" && \
+      echo "+++ :microscope: Running unit tests on macOS Mojave" && \
       cd build && \
       ctest -V
     label: ":darwin: Mojave Unit Tests"
@@ -113,14 +113,14 @@ steps:
       os: "mojave"
     timeout: 120
     
-  - command: | # Ubuntu Unit Tests
+  - command: | # Ubuntu 18.04 Unit Tests
       echo "--- :arrow_down: Downloading build directory" && \
       buildkite-agent artifact download "build.tar.gz" . --step ":ubuntu: 18.04 Build" && \
       tar -zxf build.tar.gz && \
-      echo "+++ :microscope: Running unit tests" && \
+      echo "+++ :microscope: Running unit tests on Ubuntu" && \
       cd build && \
       ctest -V
-    label: ":ubuntu: 18.04 Unit Tests"
+    label: ":ubuntu: Ubuntu 18.04 Unit Tests"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -133,10 +133,10 @@ steps:
       echo "--- :arrow_down: Downloading build directory" && \
       buildkite-agent artifact download "build.tar.gz" . --step ":fedora: Build" && \
       tar -zxf build.tar.gz && \
-      echo "+++ :microscope: Running unit tests" && \
+      echo "+++ :microscope: Running unit tests on Fedora" && \
       cd build && \
       ctest -V
-    label: ":fedora: Unit Tests"
+    label: ":fedora: Fedora Unit Tests"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -149,10 +149,10 @@ steps:
       echo "--- :arrow_down: Downloading build directory" && \
       buildkite-agent artifact download "build.tar.gz" . --step ":centos: Build" && \
       tar -zxf build.tar.gz && \
-      echo "+++ :microscope: Running unit tests" && \
+      echo "+++ :microscope: Running unit tests on CentOS" && \
       cd build && \
       ctest -V
-    label: ":centos: Unit Tests"
+    label: ":centos: CentOS Unit Tests"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -165,10 +165,10 @@ steps:
       echo "--- :arrow_down: Downloading build directory" && \
       buildkite-agent artifact download "build.tar.gz" . --step ":aws: Build" && \
       tar -zxf build.tar.gz && \
-      echo "+++ :microscope: Running unit tests" && \
+      echo "+++ :microscope: Running unit tests on Amazon AWS" && \
       cd build && \
       ctest -V
-    label: ":aws: Unit Tests"
+    label: ":aws: Amazon AWS Unit Tests"
     agents:
       queue: "automation-large-builder-fleet"
     plugins:
@@ -214,7 +214,7 @@ steps:
         tar -zxf build.tar.gz && \
         echo "+++ :package: Starting package build" && \
         cd /data/job/build/packages && bash generate_package.sh deb
-    label: ":ubuntu: 18.04 Package builder"
+    label: ":ubuntu: Ubuntu 18.04 Package Builder"
     agents:
       queue: "automation-large-builder-fleet"
     artifact_paths:
@@ -241,7 +241,7 @@ steps:
         mkdir -p /root/rpmbuild/SPECS && \
         mkdir -p /root/rpmbuild/SRPMS && \
         cd /data/job/build/packages && bash generate_package.sh rpm
-    label: ":fedora: Package builder"
+    label: ":fedora: Fedora Package Builder"
     agents:
       queue: "automation-large-builder-fleet"
     artifact_paths:
@@ -268,7 +268,7 @@ steps:
         mkdir -p /root/rpmbuild/SPECS && \
         mkdir -p /root/rpmbuild/SRPMS && \
         cd /data/job/build/packages && bash generate_package.sh rpm
-    label: ":centos: Package builder"
+    label: ":centos: CentOS Package Builder"
     agents:
       queue: "automation-large-builder-fleet"
     artifact_paths:
@@ -304,7 +304,7 @@ steps:
         docker rmi eosio/cdt:latest && \
         docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
         docker rmi gcr.io/b1-automation-dev/eosio/cdt:latest
-    label: "Docker build builder"
+    label: "Docker Build Builder"
     agents:
       queue: "automation-docker-builder-fleet"
     timeout: 300


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
I have configured the Buildkite pipeline to run unit tests on each platform after the builds but before the package creation. Unit testing (ctest) already exists in the repo and has not been updated. All changes have been made in the Buildkite configuration file here:
/.buildkite/pipeline.yml
I have also added some comments to make the file easier to navigate, and have made the build step labels slightly more descriptive and uniformly stylized.

Currently all unit test build steps fail, and this is expected. All macintosh builds fail with file/folder not found errors if and only if the scheduler runs the unit tests on a different virtual machine than the build. This is due to absolute paths being used for the configuration of CMAKE_BUILD_DIR where relative paths should be used, and Nathan Pierce is fixing this. If the same macOS VM is used for the build and unit tests, they run the same as the linux unit tests. The linux unit tests fail due to the is_account_test failure, which Bucky said is currently an expected failure.

## API Changes
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
None.

## Documentation Additions
<!-- Describe what must be added to the documentation after merge. -->
None.