### PR TITLE
Removes the timestamp part of the abigen comment

### DIFF
--- a/tools/abigen/eosio-abigen.cpp.in
+++ b/tools/abigen/eosio-abigen.cpp.in
@@ -291,11 +291,8 @@ class abigen : public generation_utils {
    std::string generate_json_comment() {
       std::stringstream ss;
       ss << "This file was generated with eosio-abigen.";
-      ss << " DO NOT EDIT ";
-      auto t = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-      ss << std::ctime(&t);
-      auto output = ss.str();
-      return output.substr(0, output.length()-1); // remove the newline character
+      ss << " DO NOT EDIT";
+      return ss.str();
    }
 
    ojson struct_to_json( const abi_struct& s ) {


### PR DESCRIPTION
The abigen adds a comment to the generated ABI file. This comment includes a timestamp information at which time the ABI file was generated. This is problematic when trying to reproduce an exact identical ABI file since the timestamp will make the file looks different.

This PR removes the actual timestamp information from the comment and only keep the static text instead.

By not having the timestamp, someone can checkout a particular tag, perform the build step and validate that the sha256 of the ABI file has not changed.