### PR TITLE
Throw exception when creating project with invalid identifier

### DIFF
--- a/tools/init/eosio-init.cpp
+++ b/tools/init/eosio-init.cpp
@@ -207,7 +207,7 @@ int main(int argc, const char **argv) {
    cl::ParseCommandLineOptions(argc, argv, std::string("eosio-proj"));
    try {
       if (!std::regex_match(project_name, std::regex("^[_a-zA-Z][_a-zA-Z0-9]*$"))) {
-         throw std::runtime_error("ERROR: invalid identifier: " + project_name);
+         throw std::runtime_error("ERROR: invalid identifier: " + project_name + " (ensure that it is a valid C++ identifier)");
       }
       llvm::SmallString<128> rp;
       std::string path = output_dir;

--- a/tools/init/eosio-init.cpp
+++ b/tools/init/eosio-init.cpp
@@ -206,6 +206,9 @@ int main(int argc, const char **argv) {
 
    cl::ParseCommandLineOptions(argc, argv, std::string("eosio-proj"));
    try {
+      if (!std::regex_match(project_name, std::regex("^[_a-zA-Z][_a-zA-Z0-9]*$"))) {
+         throw std::runtime_error("ERROR: invalid identifier: " + project_name);
+      }
       llvm::SmallString<128> rp;
       std::string path = output_dir;
       if (path.empty())


### PR DESCRIPTION
Fixes #369.

Project name given by the option `-project` of `eosio-init` is used as a class name of contract. It should be a valid c++ identifier.