### PR TITLE
Help Doxygen interpret otherwise valid C++ syntax

### DIFF
--- a/libraries/eosiolib/fixed_bytes.hpp
+++ b/libraries/eosiolib/fixed_bytes.hpp
@@ -134,7 +134,7 @@ namespace eosio {
          template<typename Word, size_t NumWords,
                   typename Enable = typename std::enable_if<std::is_integral<Word>::value &&
                                                              !std::is_same<Word, bool>::value &&
-                                                             sizeof(Word) < sizeof(word_t)>::type >
+                                                             std::less( sizeof(Word), sizeof(word_t))>::type >
          fixed_bytes(const std::array<Word, NumWords>& arr)
          {
             static_assert( sizeof(word_t) == (sizeof(word_t)/sizeof(Word)) * sizeof(Word),
@@ -153,7 +153,7 @@ namespace eosio {
          template<typename Word, size_t NumWords,
                   typename Enable = typename std::enable_if<std::is_integral<Word>::value &&
                                                              !std::is_same<Word, bool>::value &&
-                                                             sizeof(Word) < sizeof(word_t)>::type >
+                                                             std::less( sizeof(Word), sizeof(word_t))>::type >
          fixed_bytes(const Word(&arr)[NumWords])
          {
             static_assert( sizeof(word_t) == (sizeof(word_t)/sizeof(Word)) * sizeof(Word),

--- a/libraries/eosiolib/fixed_bytes.hpp
+++ b/libraries/eosiolib/fixed_bytes.hpp
@@ -134,7 +134,7 @@ namespace eosio {
          template<typename Word, size_t NumWords,
                   typename Enable = typename std::enable_if<std::is_integral<Word>::value &&
                                                              !std::is_same<Word, bool>::value &&
-                                                             std::less( sizeof(Word), sizeof(word_t))>::type >
+                                                             std::less<size_t>{}( sizeof(Word), sizeof(word_t))>::type >
          fixed_bytes(const std::array<Word, NumWords>& arr)
          {
             static_assert( sizeof(word_t) == (sizeof(word_t)/sizeof(Word)) * sizeof(Word),
@@ -153,7 +153,7 @@ namespace eosio {
          template<typename Word, size_t NumWords,
                   typename Enable = typename std::enable_if<std::is_integral<Word>::value &&
                                                              !std::is_same<Word, bool>::value &&
-                                                             std::less( sizeof(Word), sizeof(word_t))>::type >
+                                                             std::less<size_t>{}( sizeof(Word), sizeof(word_t))>::type >
          fixed_bytes(const Word(&arr)[NumWords])
          {
             static_assert( sizeof(word_t) == (sizeof(word_t)/sizeof(Word)) * sizeof(Word),


### PR DESCRIPTION
## Fix
Problematic Code:
```
         template<typename Word, size_t NumWords,
                  typename Enable = typename std::enable_if<std::is_integral<Word>::value &&
                                                             !std::is_same<Word, bool>::value &&
                                                             sizeof(Word) < sizeof(word_t)>::type >
```
The Fix: 
```
       template<typename Word, size_t NumWords,
                  typename Enable = typename std::enable_if<std::is_integral<Word>::value &&
                                                             !std::is_same<Word, bool>::value &&
                                                             std::less( sizeof(Word), sizeof(word_t))>::type >
```
Problem occurred in two places.

## Causes
Doxygen did not interpret the `<` operator in the `sizeof(Word) < sizeof(word_t)>::type` as less than.

## Observations
This only seems to affect `<`, until issue is addressed in Doxygen, should consider a temporary convention. 

## Conclusion
Doxygen now works as expected for `fixed_bytes.hpp`

Resolves #382 