### PR TITLE
Fix errors in eosio::asset::to_string()

### DIFF
--- a/libraries/eosiolib/asset.hpp
+++ b/libraries/eosiolib/asset.hpp
@@ -322,7 +322,6 @@ namespace eosio {
       std::string to_string()const {
          int64_t p = (int64_t)symbol.precision();
          int64_t p10 = 1;
-         bool negative = false;
          int64_t invert = 1;
 
          while( p > 0  ) {
@@ -335,7 +334,6 @@ namespace eosio {
 
          if (amount < 0) {
             invert = -1;
-            negative = true;
          }
 
          auto change = (amount % p10) * invert;

--- a/libraries/eosiolib/asset.hpp
+++ b/libraries/eosiolib/asset.hpp
@@ -345,9 +345,11 @@ namespace eosio {
             change /= 10;
          }
          char str[p+32];
-         const char* fmt = negative ? "-%lld.%s %s" : "%lld.%s %s";
-         snprintf(str, sizeof(str), fmt,
-               (int64_t)(amount/p10), fraction, symbol.code().to_string().c_str());
+         snprintf(str, sizeof(str), "%lld%s%s %s",
+            (int64_t)(amount/p10),
+            (fraction[0]) ? "." : "",
+            fraction,
+            symbol.code().to_string().c_str());
          return {str};
       }
 

--- a/libraries/eosiolib/core/eosio/asset.hpp
+++ b/libraries/eosiolib/core/eosio/asset.hpp
@@ -344,9 +344,11 @@ namespace eosio {
             change /= 10;
          }
          char str[p+32];
-         const char* fmt = negative ? "-%lld.%s %s" : "%lld.%s %s";
-         snprintf(str, sizeof(str), fmt,
-               (int64_t)(amount/p10), fraction, symbol.code().to_string().c_str());
+         snprintf(str, sizeof(str), "%lld%s%s %s",
+            (int64_t)(amount/p10),
+            (fraction[0]) ? "." : "",
+            fraction,
+            symbol.code().to_string().c_str());
          return {str};
       }
 

--- a/libraries/eosiolib/core/eosio/asset.hpp
+++ b/libraries/eosiolib/core/eosio/asset.hpp
@@ -321,7 +321,6 @@ namespace eosio {
       std::string to_string()const {
          int64_t p = (int64_t)symbol.precision();
          int64_t p10 = 1;
-         bool negative = false;
          int64_t invert = 1;
 
          while( p > 0  ) {
@@ -334,7 +333,6 @@ namespace eosio {
 
          if (amount < 0) {
             invert = -1;
-            negative = true;
          }
 
          auto change = (amount % p10) * invert;


### PR DESCRIPTION
* fix double minus sign when the amount is negative
* remove redundant decimal dot when fractional part doesn't exist