### PR TITLE
Quick fixes

### DIFF
--- a/tools/cc/eosio-cpp.cpp.in
+++ b/tools/cc/eosio-cpp.cpp.in
@@ -156,17 +156,15 @@ void generate(const std::vector<std::string>& base_options, std::string input, s
    finder.addMatcher(class_tmp_matcher, &eosio_record_matcher);
 
    int tool_run = -1;
-   if (abigen) {
-      tool_run = ctool.run(newFrontendActionFactory(&finder).get());
-      if (tool_run != 0) {
-         throw std::runtime_error("abigen error");
-      }
-      std::string abi_s;
-      if (get_abigen_ref().is_empty())
-         return;
-      get_abigen_ref().to_json().dump(abi_s);
-      codegen::get().set_abi(abi_s);
+   tool_run = ctool.run(newFrontendActionFactory(&finder).get());
+   if (tool_run != 0) {
+      throw std::runtime_error("abigen error");
    }
+   std::string abi_s;
+   if (get_abigen_ref().is_empty())
+      return;
+   get_abigen_ref().to_json().dump(abi_s);
+   codegen::get().set_abi(abi_s);
    tool_run = ctool.run(newFrontendActionFactory<eosio_codegen_frontend_action>().get());
    if (tool_run != 0) {
       throw std::runtime_error("codegen error");

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -775,10 +775,19 @@ static Options CreateOptions(bool add_defaults=true) {
 
       if (fquery_opt) {
          ldopts.emplace_back("--export-table");
+         ldopts.emplace_back("-other-model");
          ldopts.emplace_back("--only-export \"*:table\"");
-         // fill in other exports for "entry points"
-         //ldopts.emplace_back("--export ");
-         //ldopts.emplace_back("--only-export \":function\"");
+         ldopts.emplace_back("--only-export \"*:memory\"");
+         ldopts.emplace_back("-e initialize ");
+         ldopts.emplace_back("-export create_request ");
+         ldopts.emplace_back("-export decode_response ");
+         ldopts.emplace_back("-export describe_request ");
+         ldopts.emplace_back("-export describe_response ");
+         ldopts.emplace_back("--only-export \"initialize:function\"");
+         ldopts.emplace_back("--only-export \"create_request:function\"");
+         ldopts.emplace_back("--only-export \"decode_response:function\"");
+         ldopts.emplace_back("--only-export \"describe_request:function\"");
+         ldopts.emplace_back("--only-export \"describe_response:function\"");
       } else {
          ldopts.emplace_back("--only-export \"apply:function\"");
       }

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -4,6 +4,7 @@
 #include <vector>
 #include <string>
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
 
 #ifdef ONLY_LD
 #define LD_CAT EosioLdToolCategory
@@ -677,10 +678,27 @@ static Options CreateOptions(bool add_defaults=true) {
    }
    if (o_opt.empty()) {
 #ifndef ONLY_LD
-      ldopts.emplace_back("a.out");
+      if (inputs.size() == 1) {
+         llvm::SmallString<256> fn  = llvm::sys::path::filename(inputs[0]);
+         llvm::SmallString<256> fn2 = fn;
+         llvm::sys::path::replace_extension(fn, ".wasm");
+         output_fn = fn.str();
+         llvm::SmallString<256> res;
+         llvm::sys::path::system_temp_directory(true, res);
+         ldopts.emplace_back(std::string(std::string(res.str())+"/"+std::string(fn2.str())+".o"));
+      } else {
+         ldopts.emplace_back("a.out");
+      }
 #endif
-      ldopts.emplace_back("-o a.out");
-      output_fn = "a.out";
+      if (inputs.size() == 1) {      
+         llvm::SmallString<256> fn = llvm::sys::path::filename(inputs[0]);
+         llvm::sys::path::replace_extension(fn, ".wasm");
+         ldopts.emplace_back("-o "+output_fn);
+         output_fn = fn.str();
+      } else {
+         ldopts.emplace_back("-o a.out");
+         output_fn = "a.out";
+      }
    }
    else {
       ldopts.emplace_back("-o "+o_opt);
@@ -733,8 +751,9 @@ static Options CreateOptions(bool add_defaults=true) {
    if (!contract_name.empty())
       abigen_contract = contract_name;
    else {
-      std::string fn = llvm::sys::path::filename(output_fn);
-      abigen_contract = fn.substr(0, fn.rfind(".wasm"));
+      llvm::SmallString<256> fn = llvm::sys::path::filename(output_fn);
+      llvm::sys::path::replace_extension(fn, "");
+      abigen_contract = fn.str();
    }
 
    for ( auto resource : resources ) {

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -401,24 +401,50 @@ static void GetCompDefaults(std::vector<std::string>& copts) {
 #ifdef ONLY_LD
 static void GetLdDefaults(std::vector<std::string>& ldopts) {
    if (!fnative_opt) {
-      if (fuse_main_opt)
-         ldopts.emplace_back("-e main");
-      else {
-         if (fquery_opt) {
-            // fill in base entry point for query wasm
-            ldopts.emplace_back("-e apply");
-         } else
-            ldopts.emplace_back("-e apply");
-      }
       ldopts.emplace_back("--gc-sections");
       ldopts.emplace_back("--strip-all");
       ldopts.emplace_back("-zstack-size="+std::string("${EOSIO_STACK_SIZE}"));
       ldopts.emplace_back("--merge-data-segments");
+      if (fquery_opt) {
+         ldopts.emplace_back("--export-table");
+         ldopts.emplace_back("-other-model");
+         ldopts.emplace_back("--only-export \"*:table\"");
+         ldopts.emplace_back("--only-export \"*:memory\"");
+         if (fuse_main_opt)
+            ldopts.emplace_back("-e main");
+         else
+            ldopts.emplace_back("-e initialize ");
+         ldopts.emplace_back("-export create_request ");
+         ldopts.emplace_back("-export decode_response ");
+         ldopts.emplace_back("-export describe_request ");
+         ldopts.emplace_back("-export describe_response ");
+         ldopts.emplace_back("--only-export \"initialize:function\"");
+         ldopts.emplace_back("--only-export \"create_request:function\"");
+         ldopts.emplace_back("--only-export \"decode_response:function\"");
+         ldopts.emplace_back("--only-export \"describe_request:function\"");
+         ldopts.emplace_back("--only-export \"describe_response:function\"");
+      } else {
+         if (fuse_main_opt)
+            ldopts.emplace_back("-e main");
+         else
+            ldopts.emplace_back("-e apply");
+         ldopts.emplace_back("--only-export \"apply:function\"");
+      }
+      ldopts.emplace_back("-lc++ -lc -leosio");
+      if (use_old_malloc_opt)
+         ldopts.emplace_back("-leosio_malloc");
+      else
+         ldopts.emplace_back("-leosio_dsm");
+
+      if (use_rt_opt || fquery_opt)
+         ldopts.emplace_back("-lrt -lsf");
+
    } else {
 #ifdef __APPLE__
       ldopts.emplace_back("-arch x86_64 -macosx_version_min 10.13 -framework Foundation -framework System");
 #endif
       ldopts.emplace_back("-static");
+      ldopts.emplace_back("-lnative_c++ -lnative_c -lnative_eosio -lnative");
    }
 }
 #endif
@@ -449,6 +475,11 @@ static Options CreateOptions(bool add_defaults=true) {
       GetLdDefaults(ldopts);
 #endif
    }
+  
+#ifndef ONLY_LD 
+   if (fquery_opt)
+      ldopts.emplace_back("-fquery");
+#endif
 
    if (!pp_path_opt.empty())
       pp_dir = pp_path_opt;
@@ -763,38 +794,6 @@ static Options CreateOptions(bool add_defaults=true) {
       ldopts.emplace_back("-fnative");
    if (fuse_main_opt)
       ldopts.emplace_back("-fuse-main");
-#else
-   if (fnative_opt)
-      ldopts.emplace_back("-lnative_c++ -lnative_c -lnative_eosio -lnative");
-   else {
-      ldopts.emplace_back("-lc++ -lc -leosio");
-      if (use_old_malloc_opt)
-         ldopts.emplace_back("-leosio_malloc");
-      else
-         ldopts.emplace_back("-leosio_dsm");
-
-      if (fquery_opt) {
-         ldopts.emplace_back("--export-table");
-         ldopts.emplace_back("-other-model");
-         ldopts.emplace_back("--only-export \"*:table\"");
-         ldopts.emplace_back("--only-export \"*:memory\"");
-         ldopts.emplace_back("-e initialize ");
-         ldopts.emplace_back("-export create_request ");
-         ldopts.emplace_back("-export decode_response ");
-         ldopts.emplace_back("-export describe_request ");
-         ldopts.emplace_back("-export describe_response ");
-         ldopts.emplace_back("--only-export \"initialize:function\"");
-         ldopts.emplace_back("--only-export \"create_request:function\"");
-         ldopts.emplace_back("--only-export \"decode_response:function\"");
-         ldopts.emplace_back("--only-export \"describe_request:function\"");
-         ldopts.emplace_back("--only-export \"describe_response:function\"");
-      } else {
-         ldopts.emplace_back("--only-export \"apply:function\"");
-      }
-
-   }
-   if ((use_rt_opt && !fnative_opt) || fquery_opt)
-      ldopts.emplace_back("-lrt -lsf");
 #endif
    return {output_fn, inputs, link, abigen, pp_dir, abigen_output, abigen_contract, copts, ldopts, agopts, agresources, fnative_opt};
 }

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -414,11 +414,13 @@ static void GetLdDefaults(std::vector<std::string>& ldopts) {
             ldopts.emplace_back("-e main");
          else
             ldopts.emplace_back("-e initialize ");
+         ldopts.emplace_back("-export startup ");
          ldopts.emplace_back("-export create_request ");
          ldopts.emplace_back("-export decode_response ");
          ldopts.emplace_back("-export describe_request ");
          ldopts.emplace_back("-export describe_response ");
          ldopts.emplace_back("--only-export \"initialize:function\"");
+         ldopts.emplace_back("--only-export \"startup:function\"");
          ldopts.emplace_back("--only-export \"create_request:function\"");
          ldopts.emplace_back("--only-export \"decode_response:function\"");
          ldopts.emplace_back("--only-export \"describe_request:function\"");

--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -412,21 +412,19 @@ namespace eosio { namespace cdt {
                      visitor->get_rewriter().ReplaceText(inc.range,
                            std::string("\"")+inc.file_name+"\"\n");
                   }
-                  if (!cg.abi.empty()) {
-                     // generate apply stub with abi
-                     std::stringstream ss;
-                     ss << "extern \"C\" {\n";
-                     ss << "void eosio_assert_code(uint32_t, uint64_t);";
-                     ss << "\t__attribute__((weak, eosio_wasm_entry, eosio_wasm_abi(";
-                     std::string abi = cg.abi;
-                     ss << "\"" << _quoted(abi) << "\"";
-                     ss << ")))\n";
-                     ss << "\tvoid __insert_eosio_abi(unsigned long long r, unsigned long long c, unsigned long long a){";
-                     ss << "eosio_assert_code(false, 1);";
-                     ss << "}\n";
-                     ss << "}";
-                     visitor->get_rewriter().InsertTextAfter(ci->getSourceManager().getLocForEndOfFile(fid), ss.str());
-                  }
+                  // generate apply stub with abi
+                  std::stringstream ss;
+                  ss << "extern \"C\" {\n";
+                  ss << "void eosio_assert_code(uint32_t, uint64_t);";
+                  ss << "\t__attribute__((weak, eosio_wasm_entry, eosio_wasm_abi(";
+                  std::string abi = cg.abi;
+                  ss << "\"" << _quoted(abi) << "\"";
+                  ss << ")))\n";
+                  ss << "\tvoid __insert_eosio_abi(unsigned long long r, unsigned long long c, unsigned long long a){";
+                  ss << "eosio_assert_code(false, 1);";
+                  ss << "}\n";
+                  ss << "}";
+                  visitor->get_rewriter().InsertTextAfter(ci->getSourceManager().getLocForEndOfFile(fid), ss.str());
                   auto& RewriteBuf = visitor->get_rewriter().getEditBuffer(fid);
                   out << std::string(RewriteBuf.begin(), RewriteBuf.end());
                   cg.tmp_files.emplace(main_file, fn.str());


### PR DESCRIPTION
Fixes for:
1) better auto fill-in of contract name from output filename or input filename if no output filename is given.
2) better handling of error cases where a smart contract is being built with no actions available.
3) `--abigen` option is now pointless, the compiler will try to generate an ABI if it can, and log a message if it can't.
4) add more support for `wasm-ql` stubs for custom entry points, allowing the linker to completely skip any codegen, etc.