### PR TITLE
Documentation Updates

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -350,7 +350,7 @@ DISTRIBUTE_GROUP_DOC   = NO
 # \nosubgrouping command.
 # The default value is: YES.
 
-SUBGROUPING            = NO
+SUBGROUPING            = YES
 
 # When the INLINE_GROUPED_CLASSES tag is set to YES, classes, structs and unions
 # are shown inside the group in which they are included (e.g. using \ingroup)
@@ -758,7 +758,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = libraries/eosiolib
+INPUT                  = libraries/eosiolib/core libraries/eosiolib/contracts
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1015,7 +1015,7 @@ IGNORE_PREFIX          =
 # If the GENERATE_HTML tag is set to YES, doxygen will generate HTML output
 # The default value is: YES.
 
-GENERATE_HTML          = NO
+GENERATE_HTML          = YES
 
 # The HTML_OUTPUT tag is used to specify where the HTML docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/libraries/eosiolib/action.hpp
+++ b/libraries/eosiolib/action.hpp
@@ -134,6 +134,8 @@ namespace eosio {
        */
       name    permission;
 
+      /// @cond OPERATORS
+
       /**
        * Check equality of two permissions
        *
@@ -146,6 +148,8 @@ namespace eosio {
       friend constexpr bool operator == ( const permission_level& a, const permission_level& b ) {
          return std::tie( a.actor, a.permission ) == std::tie( b.actor, b.permission );
       }
+
+      /// @endcond
 
       EOSLIB_SERIALIZE( permission_level, (actor)(permission) )
    };
@@ -289,8 +293,6 @@ namespace eosio {
 
    };
 
-   ///@} actioncpp api
-   //
    namespace detail {
       template <typename T>
       struct unwrap { typedef T type; };

--- a/libraries/eosiolib/asset.hpp
+++ b/libraries/eosiolib/asset.hpp
@@ -11,8 +11,8 @@
 
 namespace eosio {
   /**
-   *  Defines %CPP API for managing assets
-   *  @addtogroup asset Asset CPP API
+   *  Defines C++ API for managing assets
+   *  @addtogroup asset Asset C++ API
    *  @ingroup core
    *  @{
    */

--- a/libraries/eosiolib/binary_extension.hpp
+++ b/libraries/eosiolib/binary_extension.hpp
@@ -33,6 +33,9 @@
          {
             ::new (&_data) T(std::move(ext));
          }
+
+         /// @cond IMPLEMENTATIONS
+
           /** construct contained type in place */
          template <typename... Args>
          constexpr binary_extension( std::in_place_t, Args&&... args )
@@ -40,6 +43,8 @@
          {
             ::new (&_data) T(std::forward<Args>(args)...);
          }
+
+         /// @endcond
 
          ~binary_extension() { reset(); }
 
@@ -60,6 +65,7 @@
 
          /** test if container is holding a value */
          constexpr explicit operator bool()const { return _has_value; }
+
          /** test if container is holding a value */
          constexpr bool has_value()const { return _has_value; }
 
@@ -78,9 +84,14 @@
             return _get();
          }
 
-          /** get the contained value or a user specified default
-          * @pre def should be convertible to type T
-          * */
+
+          /// @cond OPERATORS
+
+        /**
+         * Get the contained value or a user specified default
+         *
+         * @pre def should be convertible to type T
+         **/
          template <typename U>
          constexpr auto value_or( U&& def ) -> std::enable_if_t<std::is_convertible<U, T>::value, T&>& {
             if (_has_value)
@@ -130,6 +141,10 @@
             return std::move(_get());
          }
 
+         /// @endcond
+
+         /// @cond IMPLEMENTATIONS
+
          template<typename ...Args>
          T& emplace(Args&& ... args)& {
             if (_has_value) {
@@ -148,6 +163,8 @@
                _has_value = false;
             }
          }
+
+         /// @endcond
 
          /**
            *  Serialize a binary_extension into a stream
@@ -182,6 +199,8 @@
             }
             return ds;
          }
+
+
 
        private:
          bool _has_value = false;

--- a/libraries/eosiolib/contracts/eosio/action.hpp
+++ b/libraries/eosiolib/contracts/eosio/action.hpp
@@ -56,17 +56,14 @@ namespace eosio {
    };
 
    /**
-    *  @addtogroup action Action C++ API
+    *  @defgroup action Action
     *  @ingroup contracts
     *  @brief Defines type-safe C++ wrapers for querying action and sending action
-    *
     *  @note There are some methods from the @ref action that can be used directly from C++
-    *  @{
     */
 
    /**
-    *
-    *  @brief Interpret the action body as type T.
+    *  @ingroup action
     *  @return Unpacked action data casted as T.
     *
     *  Example:
@@ -82,7 +79,6 @@ namespace eosio {
     *  dummy_action msg = unpack_action_data<dummy_action>();
     *  @endcode
     */
-
    template<typename T>
    T unpack_action_data() {
       constexpr size_t max_stack_buffer_size = 512;
@@ -95,6 +91,7 @@ namespace eosio {
    /**
     *  Add the specified account to set of accounts to be notified
     *
+    *  @ingroup action
     *  @brief Add the specified account to set of accounts to be notified
     *  @param notify_account - name of the account to be verified
     */
@@ -108,11 +105,10 @@ namespace eosio {
     *  This helper method enables you to add multiple accounts to accounts to be notified list with a single
     *  call rather than having to call the similar C API multiple times.
     *
-    *  @note action.code is also considered as part of the set of notified accounts
-    *
-    *  @brief Notify an account for this action
+    *  @ingroup action
     *  @param notify_account account to be notified
     *  @param remaining_accounts accounts to be notified
+    *  @note action.code is also considered as part of the set of notified accounts
     *
     *  Example:
     *
@@ -129,7 +125,7 @@ namespace eosio {
    /**
     *  Verifies that @ref name exists in the set of provided auths on a action. Fails if not found.
     *
-    *  @brief Verify specified account exists in the set of provided auths
+    *  @ingroup action
     *  @param name - name of the account to be verified
     */
    inline void require_auth( name n ) {
@@ -138,7 +134,8 @@ namespace eosio {
 
    /**
    *  Returns the time in microseconds from 1970 of the publication_time
-   *  @brief Get the publication time
+   *
+   *  @ingroup action
    *  @return the time in microseconds from 1970 of the publication_time
    */
    inline time_point  publication_time() {
@@ -147,7 +144,6 @@ namespace eosio {
 
    /**
    *  Get the current receiver of the action
-   *  @brief Get the current receiver of the action
    *  @return the account which specifies the current receiver of the action
    */
    inline name current_receiver() {
@@ -157,7 +153,7 @@ namespace eosio {
    /**
     *  Copy up to length bytes of current action data to the specified location
     *
-    *  @brief Copy current action data to the specified location
+    *  @ingroup action
     *  @param msg - a pointer where up to length bytes of the current action data will be copied
     *  @param len - len of the current action data to be copied, 0 to report required size
     *  @return the number of bytes copied to msg, or number of bytes that can be copied if len==0 passed
@@ -171,7 +167,6 @@ namespace eosio {
    /**
     * Get the length of the current action's data field. This method is useful for dynamically sized actions
     *
-    * @brief Get the length of current action's data field
     * @return the length of the current action's data field
     */
    inline uint32_t action_data_size() {
@@ -180,13 +175,12 @@ namespace eosio {
    /**
     * Packed representation of a permission level (Authorization)
     *
-    * @brief Packed representation of a permission level (Authorization)
+    * @ingroup action
     */
    struct permission_level {
       /**
        * Construct a new permission level object with actor name and permission name
        *
-       * @brief Construct a new permission level object
        * @param a - Name of the account who owns this authorization
        * @param p - Name of the permission
        */
@@ -195,27 +189,21 @@ namespace eosio {
       /**
        * Default Constructor
        *
-       * @brief Construct a new permission level object
        */
       permission_level(){}
 
       /**
        * Name of the account who owns this permission
-       *
-       * @brief Name of the account who owns this permission
        */
       name    actor;
       /**
        * Name of the permission
-       *
-       * @brief Name of the permission
        */
       name    permission;
 
       /**
        * Check equality of two permissions
        *
-       * @brief Check equality of two permissions
        * @param a - first permission to compare
        * @param b - second permission to compare
        * @return true if equal
@@ -229,11 +217,10 @@ namespace eosio {
    };
 
    /**
-    * Require the specified authorization for this action. If this action doesn't contain the specified auth, it will fail.
+    *  Require the specified authorization for this action. If this action doesn't contain the specified auth, it will fail.
     *
-    * @brief Require the specified authorization for this action
-    *
-    * @param level - Authorization to be required
+    *  @ingroup action
+    *  @param level - Authorization to be required
     */
    inline void require_auth( const permission_level& level ) {
       internal_use_do_not_use::require_auth2( level.actor.value, level.permission.value );
@@ -242,7 +229,7 @@ namespace eosio {
    /**
     *  Verifies that @ref n has auth.
     *
-    *  @brief Verifies that @ref n has auth.
+    *  @ingroup action
     *  @param n - name of the account to be verified
     */
    inline bool has_auth( name n ) {
@@ -252,7 +239,7 @@ namespace eosio {
    /**
     *  Verifies that @ref n is an existing account.
     *
-    *  @brief Verifies that @ref n is an existing account.
+    *  @ingroup action
     *  @param n - name of the account to check
     */
    inline bool is_account( name n ) {
@@ -260,51 +247,40 @@ namespace eosio {
    }
 
    /**
-    * This is the packed representation of an action along with
-    * meta-data about the authorization levels.
+    *  This is the packed representation of an action along with
+    *  meta-data about the authorization levels.
     *
-    * @brief Packed representation of an action
+    *  @ingroup action
     */
    struct action {
       /**
-       * Name of the account the action is intended for
-       *
-       * @brief Name of the account the action is intended for
+       *  Name of the account the action is intended for
        */
       name                       account;
 
       /**
-       * Name of the action
-       *
-       * @brief Name of the action
+       *  Name of the action
        */
       name                       name;
 
       /**
-       * List of permissions that authorize this action
-       *
-       * @brief List of permissions that authorize this action
+       *  List of permissions that authorize this action
        */
       std::vector<permission_level>   authorization;
 
       /**
-       * Payload data
-       *
-       * @brief Payload data
+       *  Payload data
        */
       std::vector<char>               data;
 
       /**
-       * Default Constructor
-       *
-       * @brief Construct a new action object
+       *  Default Constructor
        */
       action() = default;
 
       /**
-       * Construct a new action object with the given action struct
+       * Construct a new action object with the given permission, action receiver, action name, action struct
        *
-       * @brief Construct a new action object with the given permission, action receiver, action name, action struct
        * @tparam T  - Type of action struct, must be serializable by `pack(...)`
        * @param auth - The permissions that authorizes this action
        * @param a -  The name of the account this action is intended for (action receiver)
@@ -316,9 +292,8 @@ namespace eosio {
       :account(a), name(n), authorization(1,auth), data(pack(std::forward<T>(value))) {}
 
       /**
-       * Construct a new action object with the given action struct
+       * Construct a new action object with the given list of permissions, action receiver, action name, action struct
        *
-       * @brief Construct a new action object with the given list of permissions, action receiver, action name, action struct
        * @tparam T  - Type of action struct, must be serializable by `pack(...)`
        * @param auths - The list of permissions that authorize this action
        * @param a -  The name of the account this action is intended for (action receiver)
@@ -329,12 +304,14 @@ namespace eosio {
       action( std::vector<permission_level> auths, struct name a, struct name n, T&& value )
       :account(a), name(n), authorization(std::move(auths)), data(pack(std::forward<T>(value))) {}
 
+      /// @cond INTERNAL
+
       EOSLIB_SERIALIZE( action, (account)(name)(authorization)(data) )
+
+      /// @endcond
 
       /**
        * Send the action as inline action
-       *
-       * @brief Send the action as inline action
        */
       void send() const {
          auto serialize = pack(*this);
@@ -344,7 +321,6 @@ namespace eosio {
       /**
        * Send the action as inline context free action
        *
-       * @brief Send the action as inline context free action
        * @pre This action should not contain any authorizations
        */
       void send_context_free() const {
@@ -356,7 +332,6 @@ namespace eosio {
       /**
        * Retrieve the unpacked data as T
        *
-       * @brief Retrieve the unpacked data as T
        * @tparam T expected type of data
        * @return the action data
        */
@@ -367,9 +342,12 @@ namespace eosio {
 
    };
 
-   ///@} actioncpp api
-   //
+
+
    namespace detail {
+
+      /// @cond INTERNAL
+
       template <typename T>
       struct unwrap { typedef T type; };
 
@@ -436,7 +414,11 @@ namespace eosio {
          static_assert(sizeof...(Ts) == std::tuple_size<deduced<Action>>::value);
          return check_types<Action, 0, Ts...>::value;
       }
+
+      /// @endcond
    }
+
+
 
    template <eosio::name::raw Name, auto Action>
    struct action_wrapper {
@@ -560,14 +542,9 @@ INLINE_ACTION_SENDER3( CONTRACT_CLASS, NAME, ::eosio::name(#NAME) )
 #define INLINE_ACTION_SENDER(...) BOOST_PP_OVERLOAD(INLINE_ACTION_SENDER,__VA_ARGS__)(__VA_ARGS__)
 
 /**
- * @addtogroup action
- * @{
- */
-
-/**
- * Send inline action
+ * Send an inline-action from inside a contract.
  *
- * @brief Send inline action
+ * @ingroup action
  * @param CONTRACT - The account this action is intended for
  * @param NAME - The name of the action
  * @param ... - The member of the action specified as ("action_member1_name", action_member1_value)("action_member2_name", action_member2_value)
@@ -575,5 +552,3 @@ INLINE_ACTION_SENDER3( CONTRACT_CLASS, NAME, ::eosio::name(#NAME) )
 #define SEND_INLINE_ACTION( CONTRACT, NAME, ... )\
 INLINE_ACTION_SENDER(std::decay_t<decltype(CONTRACT)>, NAME)( (CONTRACT).get_self(),\
 BOOST_PP_TUPLE_ENUM(BOOST_PP_VARIADIC_SIZE(__VA_ARGS__), BOOST_PP_VARIADIC_TO_TUPLE(__VA_ARGS__)) );
-
-   /// @}

--- a/libraries/eosiolib/contracts/eosio/contract.hpp
+++ b/libraries/eosiolib/contracts/eosio/contract.hpp
@@ -7,12 +7,13 @@
 /**
  * @defgroup contract Contract
  * @ingroup contracts
+ * @ingroup types
  * @brief Defines contract type which is %base class for every EOSIO contract
- * @{
  */
 
 /**
  * Helper macros to reduce the verbosity for common contracts
+ * @ingroup contract
  */
 #define CONTRACT class [[eosio::contract]]
 #define ACTION   [[eosio::action]] void
@@ -21,7 +22,9 @@
 namespace eosio {
 
 /**
- * @brief %Base class for EOSIO contract.
+ * %Base class for EOSIO contract.
+ *
+ * @ingroup contract
  * @details %Base class for EOSIO contract. %A new contract should derive from this class, so it can make use of EOSIO_ABI macro.
  */
 class contract {
@@ -30,7 +33,7 @@ class contract {
        * Construct a new contract given the contract name
        *
        * @param self - The name of the account this contract is deployed on
-       * @param first_receiver - The account the incoming action was first received at. 
+       * @param first_receiver - The account the incoming action was first received at.
        * @param ds - The datastream used
        */
       contract( name self, name first_receiver, datastream<const char*> ds ):_self(self),_first_receiver(first_receiver),_ds(ds) {}
@@ -52,7 +55,7 @@ class contract {
       inline name get_code()const { return _first_receiver; }
 
       /**
-       * The account the incoming action was first received at. 
+       * The account the incoming action was first received at.
        *
        * @return name - The first_receiver name of the action this contract is processing.
        */
@@ -72,7 +75,7 @@ class contract {
       name _self;
 
       /**
-       * The account the incoming action was first received at. 
+       * The account the incoming action was first received at.
        */
       name _first_receiver;
 

--- a/libraries/eosiolib/contracts/eosio/dispatcher.hpp
+++ b/libraries/eosiolib/contracts/eosio/dispatcher.hpp
@@ -8,6 +8,15 @@
 
 namespace eosio {
 
+  /**
+   * @defgroup dispatcher Dispatcher
+   * @ingroup contracts
+   * @brief Defines C++ functions to dispatch action to proper action handler inside a contract
+   */
+
+
+   /// @cond IMPLEMENTATIONS
+
    template<typename Contract, typename FirstAction>
    bool dispatch( uint64_t code, uint64_t act ) {
       if( code == FirstAction::get_account() && FirstAction::get_name() == act ) {
@@ -17,6 +26,7 @@ namespace eosio {
       return false;
    }
 
+   /// @endcond
 
    /**
     * This method will dynamically dispatch an incoming set of actions to
@@ -26,6 +36,8 @@ namespace eosio {
     * ```
     *
     * For this to work the Actions must be derived from eosio::contract
+    *
+    * @ingroup dispatcher
     *
     */
    template<typename Contract, typename FirstAction, typename SecondAction, typename... Actions>
@@ -37,16 +49,13 @@ namespace eosio {
       return eosio::dispatch<Contract,SecondAction,Actions...>( code, act );
    }
 
-   /**
-    * @addtogroup dispatcher Dispatcher C++ API
-    * @ingroup contracts
-    * @brief Defines C++ functions to dispatch action to proper action handler inside a contract
-    * @{
-    */
+
+
 
    /**
     * Unpack the received action and execute the correponding action handler
     *
+    * @ingroup dispatcher
     * @tparam T - The contract class that has the correponding action handler, this contract should be derived from eosio::contract
     * @tparam Q - The namespace of the action handler function
     * @tparam Args - The arguments that the action handler accepts, i.e. members of the action
@@ -83,9 +92,7 @@ namespace eosio {
       return true;
    }
 
-/// @}
-
-
+  /// @cond INTERNAL
 
  // Helper macro for EOSIO_DISPATCH_INTERNAL
  #define EOSIO_DISPATCH_INTERNAL( r, OP, elem ) \
@@ -97,12 +104,12 @@ namespace eosio {
  #define EOSIO_DISPATCH_HELPER( TYPE,  MEMBERS ) \
     BOOST_PP_SEQ_FOR_EACH( EOSIO_DISPATCH_INTERNAL, TYPE, MEMBERS )
 
-
+/// @endcond
 
 /**
- * @addtogroup dispatcher
  * Convenient macro to create contract apply handler
  *
+ * @ingroup dispatcher
  * @note To be able to use this macro, the contract needs to be derived from eosio::contract
  * @param TYPE - The class name of the contract
  * @param MEMBERS - The sequence of available actions supported by this contract

--- a/libraries/eosiolib/contracts/eosio/eosio.hpp
+++ b/libraries/eosiolib/contracts/eosio/eosio.hpp
@@ -15,7 +15,7 @@ static_assert( sizeof(long) == sizeof(int), "unexpected size difference" );
 
 /**
  * @defgroup core Core API
- * @brief C++ Core API for chain-agnostic smart-contract functionality 
+ * @brief C++ Core API for chain-agnostic smart-contract functionality
  */
 
  /**

--- a/libraries/eosiolib/contracts/eosio/multi_index.hpp
+++ b/libraries/eosiolib/contracts/eosio/multi_index.hpp
@@ -334,8 +334,8 @@ namespace _multi_index_detail {
 
 /**
  *  The indexed_by struct is used to instantiate the indices for the Multi-Index table. In EOSIO, up to 16 secondary indices can be specified.
- *  @brief The indexed_by struct is used to instantiate the indices for the Multi-Index table. In EOSIO, up to 16 secondary indices can be specified.
  *
+ *  @ingroup multiindex
  *  @tparam IndexName - is the name of the index. The name must be provided as an EOSIO base32 encoded 64-bit integer and must conform to the EOSIO naming requirements of a maximum of 13 characters, the first twelve from the lowercase characters a-z, digits 1-5, and ".", and if there is a 13th character, it is restricted to lowercase characters a-p and ".".
  *  @tparam Extractor - is a function call operator that takes a const reference to the table object type and returns either a secondary key type or a reference to a secondary key type. It is recommended to use the `eosio::const_mem_fun` template, which is a type alias to the `boost::multi_index::const_mem_fun`. See the documentation for the Boost `const_mem_fun` key extractor for more details.
  *
@@ -372,9 +372,9 @@ struct indexed_by {
 
 /**
  *  @defgroup multiindex Multi Index Table
- *  @brief Defines EOSIO Multi Index Table
  *  @ingroup contracts
  *
+ *  @brief Defines EOSIO Multi Index Table
  *  @details EOSIO Multi-Index API provides a C++ interface to the EOSIO database. It is patterned after Boost Multi Index Container.
  *  EOSIO Multi-Index table requires exactly a uint64_t primary key. For the table to be able to retrieve the primary key,
  *  the object stored inside the table is required to have a const member function called primary_key() that returns uint64_t.
@@ -425,7 +425,6 @@ struct indexed_by {
  *  }
  *  EOSIO_DISPATCH( mycontract, (myaction) )
  *  @endcode
- *  @{
  */
 
 template<name::raw TableName, typename T, typename... Indices>
@@ -806,7 +805,7 @@ class multi_index
    public:
       /**
        *  Constructs an instance of a Multi-Index table.
-       *  @brief Constructs an instance of a Multi-Index table.
+       *  @ingroup multiindex
        *
        *  @param code - Account that owns table
        *  @param scope - Scope identifier within the code hierarchy
@@ -857,6 +856,7 @@ class multi_index
 
       /**
        *  Returns the `code` member property.
+       *  @ingroup multiindex
        *
        *  @return Account name of the Code that owns the Primary Table.
        *
@@ -877,6 +877,7 @@ class multi_index
 
       /**
        *  Returns the `scope` member property.
+       *  @ingroup multiindex
        *
        *  @return Scope id of the Scope within the Code of the Current Receiver under which the desired Primary Table instance can be found.
        *
@@ -960,6 +961,7 @@ class multi_index
 
       /**
        *  Returns an iterator pointing to the object_type with the lowest primary key value in the Multi-Index table.
+       *  @ingroup multiindex
        *
        *  @return An iterator pointing to the object_type with the lowest primary key value in the Multi-Index table.
        *
@@ -985,6 +987,7 @@ class multi_index
 
       /**
        *  Returns an iterator pointing to the object_type with the lowest primary key value in the Multi-Index table.
+       *  @ingroup multiindex
        *
        *  @return An iterator pointing to the object_type with the lowest primary key value in the Multi-Index table.
        *
@@ -1008,6 +1011,7 @@ class multi_index
 
       /**
        *  Returns an iterator pointing to the `object_type` with the highest primary key value in the Multi-Index table.
+       *  @ingroup multiindex
        *
        *  @return An iterator pointing to the `object_type` with the highest primary key value in the Multi-Index table.
        *
@@ -1031,6 +1035,7 @@ class multi_index
 
       /**
        *  Returns an iterator pointing to the `object_type` with the highest primary key value in the Multi-Index table.
+       *  @ingroup multiindex
        *
        *  @return An iterator pointing to the `object_type` with the highest primary key value in the Multi-Index table.
        *
@@ -1054,6 +1059,7 @@ class multi_index
 
       /**
        *  Returns a reverse iterator pointing to the `object_type` with the highest primary key value in the Multi-Index table.
+       *  @ingroup multiindex
        *
        *  @return A reverse iterator pointing to the `object_type` with the highest primary key value in the Multi-Index table.
        *
@@ -1088,6 +1094,7 @@ class multi_index
 
       /**
        *  Returns a reverse iterator pointing to the `object_type` with the highest primary key value in the Multi-Index table.
+       *  @ingroup multiindex
        *
        *  @return A reverse iterator pointing to the `object_type` with the highest primary key value in the Multi-Index table.
        *
@@ -1122,6 +1129,7 @@ class multi_index
 
       /**
        *  Returns an iterator pointing to the `object_type` with the lowest primary key value in the Multi-Index table.
+       *  @ingroup multiindex
        *
        *  @return An iterator pointing to the `object_type` with the lowest primary key value in the Multi-Index table.
        *
@@ -1157,6 +1165,7 @@ class multi_index
 
       /**
        *  Returns an iterator pointing to the `object_type` with the lowest primary key value in the Multi-Index table.
+       *  @ingroup multiindex
        *
        *  @return An iterator pointing to the `object_type` with the lowest primary key value in the Multi-Index table.
        *
@@ -1192,6 +1201,7 @@ class multi_index
 
       /**
        *  Searches for the `object_type` with the lowest primary key that is greater than or equal to a given primary key.
+       *  @ingroup multiindex
        *
        *  @param primary - Primary key that establishes the target value for the lower bound search.
        *  @return An iterator pointing to the `object_type` that has the lowest primary key that is greater than or equal to `primary`. If an object could not be found, it will return the `end` iterator. If the table does not exist** it will return `-1`.
@@ -1237,6 +1247,7 @@ class multi_index
 
       /**
        *  Searches for the `object_type` with the highest primary key that is less than or equal to a given primary key.
+       *  @ingroup multiindex
        *
        *  @param primary - Primary key that establishes the target value for the upper bound search
        *  @return An iterator pointing to the `object_type` that has the highest primary key that is less than or equal to `primary`. If an object could not be found, it will return the `end` iterator. If the table does not exist** it will return `-1`.
@@ -1280,6 +1291,7 @@ class multi_index
 
       /**
        *  Returns an available primary key.
+       *  @ingroup multiindex
        *
        *  @return An available (unused) primary key value.
        *
@@ -1329,6 +1341,7 @@ class multi_index
 
       /**
        *  Returns an appropriately typed Secondary Index.
+       *  @ingroup multiindex
        *
        *  @tparam IndexName - the ID of the desired secondary index
        *
@@ -1382,6 +1395,7 @@ class multi_index
 
       /**
        *  Returns an appropriately typed Secondary Index.
+       *  @ingroup multiindex
        *
        *  @tparam IndexName - the ID of the desired secondary index
        *
@@ -1432,6 +1446,7 @@ class multi_index
 
       /**
        *  Returns an iterator to the given object in a Multi-Index table.
+       *  @ingroup multiindex
        *
        *  @param obj - A reference to the desired object
        *
@@ -1471,6 +1486,7 @@ class multi_index
       }
       /**
        *  Adds a new object (i.e., row) to the table.
+       *  @ingroup multiindex
        *
        *  @param payer - Account name of the payer for the Storage usage of the new object
        *  @param constructor - Lambda function that does an in-place initialization of the object to be created in the table
@@ -1552,6 +1568,7 @@ class multi_index
 
       /**
        *  Modifies an existing object in a table.
+       *  @ingroup multiindex
        *
        *  @param itr - an iterator pointing to the object to be updated
        *  @param payer - account name of the payer for the Storage usage of the updated row
@@ -1598,6 +1615,7 @@ class multi_index
 
       /**
        *  Modifies an existing object in a table.
+       *  @ingroup multiindex
        *
        *  @param obj - a reference to the object to be updated
        *  @param payer - account name of the payer for the Storage usage of the updated row
@@ -1694,6 +1712,7 @@ class multi_index
 
       /**
        *  Retrieves an existing object from a table using its primary key.
+       *  @ingroup multiindex
        *
        *  @param primary - Primary key value of the object
        *  @return A constant reference to the object containing the specified primary key.
@@ -1724,6 +1743,7 @@ class multi_index
 
       /**
        *  Search for an existing object in a table using its primary key.
+       *  @ingroup multiindex
        *
        *  @param primary - Primary key value of the object
        *  @return An iterator to the found object which has a primary key equal to `primary` OR the `end` iterator of the referenced table if an object with primary key `primary` is not found.
@@ -1760,6 +1780,7 @@ class multi_index
 
       /**
        *  Search for an existing object in a table using its primary key.
+       *  @ingroup multiindex
        *
        *  @param primary - Primary key value of the object
        *  @param error_msg - error message if an object with primary key `primary` is not found.
@@ -1782,6 +1803,7 @@ class multi_index
 
       /**
        *  Remove an existing object from a table using its primary key.
+       *  @ingroup multiindex
        *
        *  @param itr - An iterator pointing to the object to be removed
        *
@@ -1828,6 +1850,7 @@ class multi_index
 
       /**
        *  Remove an existing object from a table using its primary key.
+       *  @ingroup multiindex
        *
        *  @param obj - Object to be removed
        *
@@ -1889,5 +1912,4 @@ class multi_index
       }
 
 };
-  /// @}
 }  /// eosio

--- a/libraries/eosiolib/contracts/eosio/permission.hpp
+++ b/libraries/eosiolib/contracts/eosio/permission.hpp
@@ -34,6 +34,7 @@ namespace eosio {
 
    /**
    *  Checks if a transaction is authorized by a provided set of keys and permissions
+   *  @ingroup permission
    *
    *  @param trx_data - pointer to the start of the serialized transaction
    *  @param trx_size - size (in bytes) of the serialized transaction
@@ -44,7 +45,7 @@ namespace eosio {
    *
    *  @return 1 if the transaction is authorized, 0 otherwise
    */
-   bool 
+   bool
    check_transaction_authorization( const char* trx_data,     uint32_t trx_size,
                                     const char* pubkeys_data, uint32_t pubkeys_size,
                                     const char* perms_data,   uint32_t perms_size ) {
@@ -53,6 +54,7 @@ namespace eosio {
 
    /**
    *  Checks if a permission is authorized by a provided delay and a provided set of keys and permissions
+   *  @ingroup permission
    *
    *  @param account - the account owner of the permission
    *  @param permission - the name of the permission to check for authorization
@@ -77,14 +79,15 @@ namespace eosio {
 
 
   /**
-   * @addtogroup permission Permission C++ API
-   * @brief Defines C++ API functions for validating authorization of keys and permissions
+   * @defgroup permission Permission
    * @ingroup contracts
-   * @{
+   * @ingroup types
+   * @brief Defines C++ API functions for validating authorization of keys and permissions
    */
 
    /**
     *  Checks if a transaction is authorized by a provided set of keys and permissions
+    *  @ingroup permission
     *
     *  @param trx - the transaction for which to check authorizations
     *  @param provided_permissions - the set of permissions which have authorized the transaction (empty permission name acts as wildcard)
@@ -125,6 +128,8 @@ namespace eosio {
 
    /**
     *  Checks if a permission is authorized by a provided delay and a provided set of keys and permissions
+    *
+    *  @ingroup permission
     *
     *  @param account    - the account owner of the permission
     *  @param permission - the permission name to check for authorization
@@ -171,6 +176,8 @@ namespace eosio {
    /**
     *  Returns the last used time of a permission
     *
+    *  @ingroup permission
+    *
     *  @param account    - the account owner of the permission
     *  @param permission - the name of the permission
     *
@@ -185,6 +192,8 @@ namespace eosio {
 
    /**
     *  Returns the creation time of an account
+    *
+    *  @ingroup permission
     *
     *  @param account - the account
     *

--- a/libraries/eosiolib/contracts/eosio/privileged.hpp
+++ b/libraries/eosiolib/contracts/eosio/privileged.hpp
@@ -32,14 +32,14 @@ namespace eosio {
    }
 
   /**
-   * @addtogroup privileged Privileged C++ API
-   * @ingroup contracts
-   * Defines C++ Privileged API
-   * @{
+   *  @defgroup privileged Privileged
+   *  @ingroup contracts
+   *  @brief Defines C++ Privileged API
    */
 
    /**
-    * Tunable blockchain configuration that can be changed via consensus
+    *  Tunable blockchain configuration that can be changed via consensus
+    *  @ingroup privileged
     */
    struct blockchain_parameters {
 
@@ -160,73 +160,79 @@ namespace eosio {
    };
 
    /**
-    * @brief Set the blockchain parameters
-    * Set the blockchain parameters
-    * @param params - New blockchain parameters to set
+    *  Set the blockchain parameters
+    *
+    *  @ingroup privileged
+    *  @param params - New blockchain parameters to set
     */
    void set_blockchain_parameters(const eosio::blockchain_parameters& params);
 
    /**
-    * @brief Retrieve the blolckchain parameters
-    * Retrieve the blolckchain parameters
-    * @param params - It will be replaced with the retrieved blockchain params
+    *  Retrieve the blolckchain parameters
+    *
+    *  @ingroup privileged
+    *  @param params - It will be replaced with the retrieved blockchain params
     */
    void get_blockchain_parameters(eosio::blockchain_parameters& params);
 
     /**
-    * Get the resource limits of an account
+    *  Get the resource limits of an account
     *
-    * @param account - name of the account whose resource limit to get
-    * @param ram_bytes -  output to hold retrieved ram limit in absolute bytes
-    * @param net_weight - output to hold net limit
-    * @param cpu_weight - output to hold cpu limit
+    *  @ingroup privileged
+    *  @param account - name of the account whose resource limit to get
+    *  @param ram_bytes -  output to hold retrieved ram limit in absolute bytes
+    *  @param net_weight - output to hold net limit
+    *  @param cpu_weight - output to hold cpu limit
     */
    inline void get_resource_limits( name account, int64_t& ram_bytes, int64_t& net_weight, int64_t& cpu_weight ) {
       internal_use_do_not_use::get_resource_limits( account.value, &ram_bytes, &net_weight, &cpu_weight );
    }
 
    /**
-    * Set the resource limits of an account
+    *  Set the resource limits of an account
     *
-    * @param account - name of the account whose resource limit to be set
-    * @param ram_bytes - ram limit in absolute bytes
-    * @param net_weight - fractionally proportionate net limit of available resources based on (weight / total_weight_of_all_accounts)
-    * @param cpu_weight - fractionally proportionate cpu limit of available resources based on (weight / total_weight_of_all_accounts)
+    *  @ingroup privileged
+    *  @param account - name of the account whose resource limit to be set
+    *  @param ram_bytes - ram limit in absolute bytes
+    *  @param net_weight - fractionally proportionate net limit of available resources based on (weight / total_weight_of_all_accounts)
+    *  @param cpu_weight - fractionally proportionate cpu limit of available resources based on (weight / total_weight_of_all_accounts)
     */
    inline void set_resource_limits( name account, int64_t ram_bytes, int64_t net_weight, int64_t cpu_weight ) {
       internal_use_do_not_use::set_resource_limits( account.value, ram_bytes, net_weight, cpu_weight );
    }
 
    /**
-    * Proposes a schedule change
+    *  Proposes a schedule change
     *
-    * @note Once the block that contains the proposal becomes irreversible, the schedule is promoted to "pending" automatically. Once the block that promotes the schedule is irreversible, the schedule will become "active"
-    * @param producers - vector of producer keys 
+    *  @ingroup privileged
+    *  @note Once the block that contains the proposal becomes irreversible, the schedule is promoted to "pending" automatically. Once the block that promotes the schedule is irreversible, the schedule will become "active"
+    *  @param producers - vector of producer keys
     *
-    * @return an optional value of the version of the new proposed schedule if successful
+    *  @return an optional value of the version of the new proposed schedule if successful
     */
    std::optional<uint64_t> set_proposed_producers( const std::vector<producer_key>& prods );
 
    /**
-    * Check if an account is privileged
+    *  Check if an account is privileged
     *
-    * @param account - name of the account to be checked
-    * @return true if the account is privileged
-    * @return false if the account is not privileged
+    *  @ingroup privileged
+    *  @param account - name of the account to be checked
+    *  @return true if the account is privileged
+    *  @return false if the account is not privileged
     */
    inline bool is_privileged( name account ) {
       return internal_use_do_not_use::is_privileged( account.value );
    }
 
    /**
-    * Set the privileged status of an account
+    *  Set the privileged status of an account
     *
-    * @param account - name of the account whose privileged account to be set
-    * @param is_priv - privileged status
+    *  @ingroup privileged
+    *  @param account - name of the account whose privileged account to be set
+    *  @param is_priv - privileged status
     */
    inline void set_privileged( name account, bool is_priv ) {
       internal_use_do_not_use::set_privileged( account.value, is_priv );
    }
 
-   ///@}
 }

--- a/libraries/eosiolib/contracts/eosio/producer_schedule.hpp
+++ b/libraries/eosiolib/contracts/eosio/producer_schedule.hpp
@@ -6,46 +6,56 @@
 namespace eosio {
 
   /**
-   *  @defgroup producer_key
-   *  @ingroup  contracts
-   *  @{
+   *  @defgroup producer_key Producer Key
+   *  @ingroup contracts
+   *  @ingroup types
+   *  @brief Maps producer with its signing key, used for producer schedule
    */
 
   /**
-   * Maps producer with its signing key, used for producer schedule
+   *  Maps producer with its signing key, used for producer schedule
    *
-   * @brief Maps producer with its signing key
+   *  @ingroup producer_key
    */
   struct producer_key {
 
     /**
-     * Name of the producer
+     *  Name of the producer
      *
-     * @brief Name of the producer
+     *  @ingroup producer_key
      */
     name             producer_name;
 
     /**
-     * Block signing key used by this producer
+     *  Block signing key used by this producer
      *
-     * @brief Block signing key used by this producer
+     *  @ingroup producer_key
      */
     public_key       block_signing_key;
+
+    /// @cond OPERATORS
 
     friend constexpr bool operator < ( const producer_key& a, const producer_key& b ) {
       return a.producer_name < b.producer_name;
     }
 
+    /// @endcond
+
     EOSLIB_SERIALIZE( producer_key, (producer_name)(block_signing_key) )
   };
 
    /**
-   *  @defgroup producer_schedule
-   *  @ingroup contracts 
-   *  @brief Defines both the order, account name, and signing keys of the active set of producers.
-   *
-   *  @{
-   */
+    *  @defgroup producer_schedule Producer Schedule
+    *  @ingroup contracts
+    *  @ingroup types
+    *  @brief Defines both the order, account name, and signing keys of the active set of producers.
+    */
+
+   /**
+    * Defines both the order, account name, and signing keys of the active set of producers.
+    *
+    * @ingroup producer_schedule
+    */
    struct producer_schedule {
       /**
        * Version number of the schedule. It is sequentially incrementing version number
@@ -57,13 +67,11 @@ namespace eosio {
        */
       std::vector<producer_key>    producers;
    };
-   /// @} producer_schedule
 
    /**
-    *  @ingroup contracts 
-    *  @brief Returns back the list of active producer names.
+    *  Returns back the list of active producer names.
     *
-    *  @{
+    *  @ingroup producer_schedule
     */
    std::vector<name> get_active_producers();
 

--- a/libraries/eosiolib/contracts/eosio/singleton.hpp
+++ b/libraries/eosiolib/contracts/eosio/singleton.hpp
@@ -8,12 +8,12 @@ namespace  eosio {
     *  @defgroup singleton Singleton Table
     *  @ingroup contracts
     *  @brief Defines EOSIO Singleton Table used with %multiindex
-    *  @{
     */
 
    /**
     *  This wrapper uses a single table to store named objects various types.
     *
+    *  @ingroup singleton
     *  @tparam SingletonName - the name of this singleton variable
     *  @tparam T - the type of the singleton
     */
@@ -130,6 +130,4 @@ namespace  eosio {
       private:
          table _t;
    };
-
-/// @} singleton
 } /// namespace eosio

--- a/libraries/eosiolib/contracts/eosio/system.hpp
+++ b/libraries/eosiolib/contracts/eosio/system.hpp
@@ -15,15 +15,15 @@ namespace eosio {
   }
 
   /**
-   *  @addtogroup system System C++ API
+   *  @addtogroup system System
    *  @ingroup contracts
-   *  @brief Defines time related functions and eosio_exit 
-   *  @{
+   *  @brief Defines time related functions and eosio_exit
    */
 
    /**
     *  This method will abort execution of wasm without failing the contract. This is used to bypass all cleanup / destructors that would normally be called.
     *
+    *  @ingroup system
     *  @param code - the exit code
     *  Example:
     *
@@ -41,6 +41,7 @@ namespace eosio {
    /**
    *  Returns the time in microseconds from 1970 of the current block as a time_point
    *
+   *  @ingroup system
    *  @return time in microseconds from 1970 of the current block as a time_point
    */
    time_point current_time_point();
@@ -48,6 +49,7 @@ namespace eosio {
    /**
    *  Returns the time in microseconds from 1970 of the current block as a block_timestamp
    *
+   *  @ingroup system
    *  @return time in microseconds from 1970 of the current block as a block_timestamp
    */
    block_timestamp current_block_time();

--- a/libraries/eosiolib/contracts/eosio/transaction.hpp
+++ b/libraries/eosiolib/contracts/eosio/transaction.hpp
@@ -43,42 +43,40 @@ namespace eosio {
    }
 
   /**
-   * @defgroup transaction Transaction C++ API
-   * @ingroup contracts 
-   * @brief Type-safe C++ wrappers for transaction C API
+   *  @defgroup transaction Transaction
+   *  @ingroup contracts
+   *  @brief Type-safe C++ wrappers for transaction C API
    *
-   * @details An inline message allows one contract to send another contract a message
-   * which is processed immediately after the current message's processing
-   * ends such that the success or failure of the parent transaction is
-   * dependent on the success of the message. If an inline message fails in
-   * processing then the whole tree of transactions and actions rooted in the
-   * block will me marked as failing and none of effects on the database will
-   * persist.
+   *  @details An inline message allows one contract to send another contract a message
+   *  which is processed immediately after the current message's processing
+   *  ends such that the success or failure of the parent transaction is
+   *  dependent on the success of the message. If an inline message fails in
+   *  processing then the whole tree of transactions and actions rooted in the
+   *  block will me marked as failing and none of effects on the database will
+   *  persist.
    *
-   * Inline actions and Deferred transactions must adhere to the permissions
-   * available to the parent transaction or, in the future, delegated to the
-   * contract account for future use.
+   *  Inline actions and Deferred transactions must adhere to the permissions
+   *  available to the parent transaction or, in the future, delegated to the
+   *  contract account for future use.
+   *
+   *  @note There are some methods from the @ref transactioncapi that can be used directly from C++
+   */
 
-   * @note There are some methods from the @ref transactioncapi that can be used directly from C++
-   * @{
+  /**
+   *  @ingroup transaction
    */
    typedef std::tuple<uint16_t, std::vector<char>> extension;
+
+   /**
+    *  @ingroup transaction
+    */
    typedef std::vector<extension> extensions_type;
 
-
    /**
-    * @defgroup transactioncppapi Transaction C++ API
-    * @ingroup transactionapi
-    * @brief Type-safe C++ wrappers for transaction C API
+    *  Class transaction_header contains details about the transaction
     *
-    * @note There are some methods from the @ref transactioncapi that can be used directly from C++
-    *
-    * @{
-    */
-
-   /**
-    * Class transaction_header contains details about the transaction
-    * @brief Contains details about the transaction
+    *  @ingroup transaction
+    *  @brief Contains details about the transaction
     */
 
    class transaction_header {
@@ -104,23 +102,22 @@ namespace eosio {
    };
 
    /**
-    * Class transaction contains the actions, context_free_actions and extensions type for a transaction
-    * @brief Contains the actions, context_free_actions and extensions type for a transaction
+    *  Class transaction contains the actions, context_free_actions and extensions type for a transaction
+    *
+    *  @ingroup transaction
     */
    class transaction : public transaction_header {
    public:
 
       /**
        * Construct a new transaction with an expiration of now + 60 seconds.
-       *
-       * @brief Construct a new transaction object initialising the transaction header expiration to now + 60 seconds
        */
       transaction(time_point_sec exp = time_point_sec(current_time_point()) + 60) : transaction_header( exp ) {}
 
       /**
        *  Sends this transaction, packs the transaction then sends it as a deferred transaction
        *
-       *  @brief Writes the symbol_code as a string to the provided char buffer
+       *  @details Writes the symbol_code as a string to the provided char buffer
        *  @param sender_id - ID of sender
        *  @param payer - Account paying for RAM
        *  @param replace_existing - Defaults to false, if this is `0`/false then if the provided sender_id is already in use by an in-flight transaction from this contract, which will be a failing assert. If `1` then transaction will atomically cancel/replace the inflight transaction
@@ -138,24 +135,25 @@ namespace eosio {
    };
 
    /**
-    * Struct onerror contains and sender id and packed transaction
-    * @brief  Contains and sender id and packed transaction
+    *  Struct onerror contains and sender id and packed transaction
+    *
+    *  @ingroup transaction
     */
    struct onerror {
       uint128_t          sender_id;
       std::vector<char> sent_trx;
 
      /**
-      * from_current_action unpacks and returns a onerror struct
-      * @brief Unpacks and returns a onerror struct
+      *  from_current_action unpacks and returns a onerror struct
+      *
+      *  @ingroup transaction
       */
       static onerror from_current_action() {
          return unpack_action_data<onerror>();
       }
 
      /**
-      * unpack_sent_trx unpacks and returns a transaction
-      * @brief Unpacks and returns a transaction
+      * Unpacks and returns a transaction
       */
       transaction unpack_sent_trx() const {
          return unpack<transaction>(sent_trx);
@@ -164,15 +162,26 @@ namespace eosio {
       EOSLIB_SERIALIZE( onerror, (sender_id)(sent_trx) )
    };
 
+   /**
+    *  Send a deferred transaction
+    *
+    *  @ingroup transaction
+    *  @param sender_id - Account name of the sender of this deferred transaction
+    *  @param payer - Account name responsible for paying the RAM for this deferred transaction
+    *  @param serialized_transaction - The packed transaction to be deferred
+    *  @param size - The size of the packed transaction, required for persistence.
+    *  @param replace - If true, will replace an existing transaction.
+    */
    void send_deferred(const uint128_t& sender_id, name payer, const char* serialized_transaction, size_t size, bool replace = false) {
      internal_use_do_not_use::send_deferred(sender_id, payer.value, serialized_transaction, size, replace);
    }
    /**
-    * Retrieve the indicated action from the active transaction.
+    *  Retrieve the indicated action from the active transaction.
     *
-    * @param type - 0 for context free action, 1 for action
-    * @param index - the index of the requested action
-    * @return the indicated action
+    *  @ingroup transaction
+    *  @param type - 0 for context free action, 1 for action
+    *  @param index - the index of the requested action
+    *  @return the indicated action
     */
    inline action get_action( uint32_t type, uint32_t index ) {
       constexpr size_t max_stack_buffer_size = 512;
@@ -186,10 +195,10 @@ namespace eosio {
    }
 
    /**
-    * Access a copy of the currently executing transaction.
+    *  Access a copy of the currently executing transaction.
     *
-    * @brief Access a copy of the currently executing transaction.
-    * @return the currently executing transaction
+    *  @ingroup transaction
+    *  @return the currently executing transaction
     */
    inline size_t read_transaction(char* ptr, size_t sz) {
       return internal_use_do_not_use::read_transaction( ptr, sz );
@@ -198,7 +207,7 @@ namespace eosio {
     /**
      *  Cancels a deferred transaction.
      *
-     *  @brief Cancels a deferred transaction.
+     *  @ingroup transaction
      *  @param sender_id - The id of the sender
      *
      *  @pre The deferred transaction ID exists.
@@ -219,48 +228,49 @@ namespace eosio {
    }
 
    /**
-    * Gets the size of the currently executing transaction.
+    *  Gets the size of the currently executing transaction.
     *
-    * @brief Gets the size of the currently executing transaction.
-    * @return size of the currently executing transaction
+    *  @ingroup transaction
+    *  @return size of the currently executing transaction
     */
    inline size_t transaction_size() {
       return internal_use_do_not_use::transaction_size();
    }
 
    /**
-    * Gets the block number used for TAPOS on the currently executing transaction.
+    *  Gets the block number used for TAPOS on the currently executing transaction.
     *
-    * @brief Gets the block number used for TAPOS on the currently executing transaction.
-    * @return block number used for TAPOS on the currently executing transaction
-    * Example:
-    * @code
-    * int tbn = tapos_block_num();
-    * @endcode
+    *  @ingroup transaction
+    *  @return block number used for TAPOS on the currently executing transaction
+    *  Example:
+    *  @code
+    *  int tbn = tapos_block_num();
+    *  @endcode
     */
    inline int tapos_block_num() {
       return internal_use_do_not_use::tapos_block_num();
    }
 
    /**
-    * Gets the block prefix used for TAPOS on the currently executing transaction.
+    *  Gets the block prefix used for TAPOS on the currently executing transaction.
     *
-    * @brief Gets the block prefix used for TAPOS on the currently executing transaction.
-    * @return block prefix used for TAPOS on the currently executing transaction
-    * Example:
-    * @code
-    * int tbp = tapos_block_prefix();
-    * @endcode
+    *  @ingroup transaction
+    *  @return block prefix used for TAPOS on the currently executing transaction
+    *  Example:
+    *  @code
+    *  int tbp = tapos_block_prefix();
+    *  @endcode
     */
    inline int tapos_block_prefix() {
       return internal_use_do_not_use::tapos_block_prefix();
    }
 
    /**
-    * Gets the expiration of the currently executing transaction.
+    *  Gets the expiration of the currently executing transaction.
     *
-    * @brief Gets the expiration of the currently executing transaction.
-    * @return expiration of the currently executing transaction in seconds since Unix epoch
+    *  @ingroup transaction
+    *  @brief Gets the expiration of the currently executing transaction.
+    *  @return expiration of the currently executing transaction in seconds since Unix epoch
     */
    inline uint32_t expiration() {
       return internal_use_do_not_use::expiration();
@@ -269,14 +279,13 @@ namespace eosio {
    /**
     * Retrieve the signed_transaction.context_free_data[index].
     *
-    * @brief Retrieve the signed_transaction.context_free_data[index].
-    * @param index - the index of the context_free_data entry to retrieve
-    * @param buff - output buff of the context_free_data entry
-    * @param size - amount of context_free_data[index] to retrieve into buff, 0 to report required size
-    * @return size copied, or context_free_data[index].size() if 0 passed for size, or -1 if index not valid
+    *  @ingroup transaction
+    *  @param index - the index of the context_free_data entry to retrieve
+    *  @param buff - output buff of the context_free_data entry
+    *  @param size - amount of context_free_data[index] to retrieve into buff, 0 to report required size
+    *  @return size copied, or context_free_data[index].size() if 0 passed for size, or -1 if index not valid
     */
    inline int get_context_free_data( uint32_t index, char* buff, size_t size ) {
       return internal_use_do_not_use::get_context_free_data(index, buff, size);
    }
-   ///}@
 }

--- a/libraries/eosiolib/core/eosio/asset.hpp
+++ b/libraries/eosiolib/core/eosio/asset.hpp
@@ -10,16 +10,16 @@
 
 namespace eosio {
   /**
-   *  Defines %CPP API for managing assets
-   *  @addtogroup asset Asset CPP API
-   *  @ingroup core 
-   *  @{
+   *  @defgroup asset Asset
+   *  @ingroup core
+   *  @brief Defines C++ API for managing assets
    */
 
    /**
-    * @struct Stores information for owner of asset
+    *  Stores information for owner of asset
+    *
+    *  @ingroup asset
     */
-
    struct asset {
       /**
        * The amount of the asset
@@ -76,6 +76,8 @@ namespace eosio {
          amount = a;
          eosio::check( is_amount_within_range(), "magnitude of asset amount must be less than 2^62" );
       }
+
+      /// @cond OPERATORS
 
       /**
        * Unary minus operator
@@ -145,7 +147,7 @@ namespace eosio {
       }
 
       /**
-       * @brief Multiplication assignment operator, with a number
+       * Multiplication assignment operator, with a number
        *
        * @details Multiplication assignment operator. Multiply the amount of this asset with a number and then assign the value to itself.
        * @param a - The multiplier for the asset's amount
@@ -313,6 +315,8 @@ namespace eosio {
          return a.amount >= b.amount;
       }
 
+      /// @endcond
+
       /**
        * %asset to std::string
        *
@@ -363,7 +367,9 @@ namespace eosio {
    };
 
   /**
-   * @struct Extended asset which stores the information of the owner of the asset
+   *  Extended asset which stores the information of the owner of the asset
+   *
+   *  @ingroup asset
    */
    struct extended_asset {
       /**
@@ -405,38 +411,20 @@ namespace eosio {
          ::eosio::print("@", contract);
       }
 
-       /**
-       *  Unary minus operator
-       *
-       *  @return extended_asset - New extended asset with its amount is the negative amount of this extended asset
-       */
+      /// @cond OPERATORS
+
+      // Unary minus operator
       extended_asset operator-()const {
          return {-quantity, contract};
       }
 
-      /**
-       * @brief Subtraction operator
-       *
-       * @details Subtraction operator. This subtracts the amount of the extended asset.
-       * @param a - The extended asset to be subtracted
-       * @param b - The extended asset used to subtract
-       * @return extended_asset - New extended asset as the result of subtraction
-       * @pre The owner of both extended asset need to be the same
-       */
+      // Subtraction operator
       friend extended_asset operator - ( const extended_asset& a, const extended_asset& b ) {
          eosio::check( a.contract == b.contract, "type mismatch" );
          return {a.quantity - b.quantity, a.contract};
       }
 
-      /**
-       * @brief Addition operator
-       *
-       * @details Addition operator. This adds the amount of the extended asset.
-       * @param a - The extended asset to be added
-       * @param b - The extended asset to be added
-       * @return extended_asset - New extended asset as the result of addition
-       * @pre The owner of both extended asset need to be the same
-       */
+      // Addition operator
       friend extended_asset operator + ( const extended_asset& a, const extended_asset& b ) {
          eosio::check( a.contract == b.contract, "type mismatch" );
          return {a.quantity + b.quantity, a.contract};
@@ -485,8 +473,8 @@ namespace eosio {
          return a.quantity >= b.quantity;
       }
 
+      /// @endcond
+
       EOSLIB_SERIALIZE( extended_asset, (quantity)(contract) )
    };
-
-/// @} asset type
 }

--- a/libraries/eosiolib/core/eosio/binary_extension.hpp
+++ b/libraries/eosiolib/core/eosio/binary_extension.hpp
@@ -4,18 +4,17 @@
 
 namespace eosio {
     /**
+    *  @defgroup binary_extension Binary Extension
+    *  @ingroup core
+    *  @ingroup types
+    *  @brief Container to hold a binary payload for an extension
+    */
+
+    /**
     *  Container to hold a binary payload for an extension
     *
-    *  @defgroup binary_extension Binary Extension
-    *  @ingroup core 
-    *  @ingroup types
-    *  @{
-    */
-     /**
-    *  Binary Extension
-    *  @brief container to hold a binary payload for an extension
+    *  @ingroup binary_extension
     *  @tparam T - Contained typed
-    *  @ingroup types
     */
    template <typename T>
    class binary_extension {
@@ -70,6 +69,9 @@ namespace eosio {
             }
             return _get();
          }
+
+         /// @cond INTERNAL
+
           /** get the contained value */
          constexpr const T& value()const & {
             if (!_has_value) {
@@ -149,6 +151,8 @@ namespace eosio {
             }
          }
 
+         /// @endcond
+
        private:
          bool _has_value = false;
          typename std::aligned_storage<sizeof(T), alignof(T)>::type _data;
@@ -162,9 +166,12 @@ namespace eosio {
          }
    };
 
+   /// @cond IMPLEMENTATIONS
+
    /**
     *  Serialize a binary_extension into a stream
     *
+    *  @ingroup binary_extension
     *  @brief Serialize a binary_extension
     *  @param ds - The stream to write
     *  @param opt - The value to serialize
@@ -180,6 +187,7 @@ namespace eosio {
    /**
     *  Deserialize a binary_extension from a stream
     *
+    *  @ingroup binary_extension
     *  @brief Deserialize a binary_extension
     *  @param ds - The stream to read
     *  @param opt - The destination for deserialized value
@@ -195,5 +203,7 @@ namespace eosio {
      }
      return ds;
    }
+
+   /// @endcond
 
 } // namespace eosio

--- a/libraries/eosiolib/core/eosio/check.hpp
+++ b/libraries/eosiolib/core/eosio/check.hpp
@@ -8,7 +8,7 @@
 #include <string>
 
 namespace eosio {
-   
+
    namespace internal_use_do_not_use {
       extern "C" {
          __attribute__((eosio_wasm_import))
@@ -23,19 +23,17 @@ namespace eosio {
    }
 
    /**
-    *  @addtogroup system System C++ API
+    *  @defgroup system System
     *  @ingroup core
-    *  @brief Defines wrappers over eosio_assert 
-    *
-    *  @{
+    *  @brief Defines wrappers over eosio_assert
     */
 
    /**
+    *  Assert if the predicate fails and use the supplied message.
     *
-    *  @brief Assert if the predicate fails and use the supplied message.
+    *  @ingroup system
     *
     *  Example:
-    *
     *  @code
     *  eosio::check(a == b, "a does not equal b");
     *  @endcode
@@ -47,11 +45,11 @@ namespace eosio {
    }
 
     /**
+    *  Assert if the predicate fails and use the supplied message.
     *
-    *  @brief Assert if the predicate fails and use the supplied message.
+    *  @ingroup system
     *
     *  Example:
-    *
     *  @code
     *  eosio::check(a == b, "a does not equal b");
     *  @endcode
@@ -63,11 +61,11 @@ namespace eosio {
    }
 
    /**
+    *  Assert if the predicate fails and use the supplied message.
     *
-    *  @brief Assert if the predicate fails and use the supplied message.
+    *  @ingroup system
     *
     *  Example:
-    *
     *  @code
     *  eosio::check(a == b, "a does not equal b");
     *  @endcode
@@ -79,11 +77,11 @@ namespace eosio {
    }
 
    /**
+    *  Assert if the predicate fails and use a subset of the supplied message.
     *
-    *  @brief Assert if the predicate fails and use a subset of the supplied message.
+    *  @ingroup system
     *
     *  Example:
-    *
     *  @code
     *  const char* msg = "a does not equal b b does not equal a";
     *  eosio::check(a == b, "a does not equal b", 18);
@@ -96,11 +94,11 @@ namespace eosio {
    }
 
    /**
+    *  Assert if the predicate fails and use a subset of the supplied message.
     *
-    *  @brief Assert if the predicate fails and use a subset of the supplied message.
+    *  @ingroup system
     *
     *  Example:
-    *
     *  @code
     *  std::string msg = "a does not equal b b does not equal a";
     *  eosio::check(a == b, msg, 18);
@@ -113,11 +111,11 @@ namespace eosio {
    }
 
     /**
+    *  Assert if the predicate fails and use the supplied error code.
     *
-    *  @brief Assert if the predicate fails and use the supplied error code.
+    *  @ingroup system
     *
     *  Example:
-    *
     *  @code
     *  eosio::check(a == b, 13);
     *  @endcode
@@ -128,4 +126,3 @@ namespace eosio {
       }
    }
 } // namespace eosio
-/// @}

--- a/libraries/eosiolib/core/eosio/crypto.hpp
+++ b/libraries/eosiolib/core/eosio/crypto.hpp
@@ -13,31 +13,29 @@
 namespace eosio {
 
    /**
-   *  @defgroup publickeytype Public Key Type
-   *  @ingroup core
-   *  @ingroup types
-   *  @brief Specifies public key type
-   *
-   *  @{
-   */
+    *  @defgroup public_key Public Key Type
+    *  @ingroup core
+    *  @ingroup types
+    *  @brief Specifies public key type
+    */
 
    /**
-    * EOSIO Public Key
-    * @brief EOSIO Public Key
+    *  EOSIO Public Key
+    *
+    *  @ingroup public_key
     */
    struct public_key {
       /**
-       * Type of the public key, could be either K1 or R1
-       * @brief Type of the public key
+       *  Type of the public key, could be either K1 or R1
        */
       unsigned_int        type;
 
       /**
-       * Bytes of the public key
-       *
-       * @brief Bytes of the public key
+       *  Bytes of the public key
        */
       std::array<char,33> data;
+
+      /// @cond OPERATORS
 
       friend bool operator == ( const public_key& a, const public_key& b ) {
         return std::tie(a.type,a.data) == std::tie(b.type,b.data);
@@ -45,12 +43,16 @@ namespace eosio {
       friend bool operator != ( const public_key& a, const public_key& b ) {
         return std::tie(a.type,a.data) != std::tie(b.type,b.data);
       }
+
+      /// @cond
    };
+
+   /// @cond IMPLEMENTATIONS
 
    /**
     *  Serialize an eosio::public_key into a stream
     *
-    *  @brief Serialize an eosio::public_key
+    *  @ingroup public_key
     *  @param ds - The stream to write
     *  @param pubkey - The value to serialize
     *  @tparam DataStream - Type of datastream buffer
@@ -66,7 +68,7 @@ namespace eosio {
    /**
     *  Deserialize an eosio::public_key from a stream
     *
-    *  @brief Deserialize an eosio::public_key
+    *  @ingroup public_key
     *  @param ds - The stream to read
     *  @param pubkey - The destination for deserialized value
     *  @tparam DataStream - Type of datastream buffer
@@ -79,33 +81,33 @@ namespace eosio {
       return ds;
    }
 
-   /// @} publickeytype
+   /// @endcond
 
    /**
-   *  @defgroup signature Public Key Type
-   *  @ingroup core
-   *  @brief Specifies signature type
-   *
-   *  @{
-   */
+    *  @defgroup signature Signature
+    *  @ingroup core
+    *  @ingroup types
+    *  @brief Specifies signature type
+    */
 
    /**
-    * EOSIO Signature
-    * @brief EOSIO Signature
+    *  EOSIO Signature
+    *
+    *  @ingroup signature
     */
    struct signature {
+
       /**
-       * Type of the signature, could be either K1 or R1
-       * @brief Type of the signature
+       *  Type of the signature, could be either K1 or R1
        */
       unsigned_int        type;
 
       /**
-       * Bytes of the signature
-       *
-       * @brief Bytes of the signature
+       *  Bytes of the signature
        */
       std::array<char,65> data;
+
+      /// @cond OPERATORS
 
       friend bool operator == ( const signature& a, const signature& b ) {
         return std::tie(a.type,a.data) == std::tie(b.type,b.data);
@@ -113,12 +115,15 @@ namespace eosio {
       friend bool operator != ( const signature& a, const signature& b ) {
         return std::tie(a.type,a.data) != std::tie(b.type,b.data);
       }
+
+      /// @endcond
    };
+
+   /// @cond IMPLEMENTATIONS
 
    /**
     *  Serialize an eosio::signature into a stream
     *
-    *  @brief Serialize an eosio::signature
     *  @param ds - The stream to write
     *  @param sig - The value to serialize
     *  @tparam DataStream - Type of datastream buffer
@@ -134,7 +139,6 @@ namespace eosio {
    /**
     *  Deserialize an eosio::signature from a stream
     *
-    *  @brief Deserialize an eosio::signature
     *  @param ds - The stream to read
     *  @param sig - The destination for deserialized value
     *  @tparam DataStream - Type of datastream buffer
@@ -147,52 +151,51 @@ namespace eosio {
       return ds;
    }
 
-   /// @} signaturetype
+   /// @endcond
 
    /**
-    *  @defgroup crypto Chain API
-    *  @ingroup core 
+    *  @defgroup crypto Crypto
+    *  @ingroup core
     *  @brief Defines API for calculating and checking hashes
-    *  @{
     */
 
    /**
     *  Tests if the SHA256 hash generated from data matches the provided digest.
-    *  This method is optimized to a NO-OP when in fast evaluation mode.
-    *  @brief Tests if the sha256 hash generated from data matches the provided digest.
     *
+    *  @ingroup crypto
     *  @param data - Data you want to hash
     *  @param length - Data length
     *  @param hash - digest to compare to
+    *  @note This method is optimized to a NO-OP when in fast evaluation mode.
     */
    void assert_sha256( const char* data, uint32_t length, const eosio::checksum256& hash );
 
    /**
     *  Tests if the SHA1 hash generated from data matches the provided digest.
-    *  This method is optimized to a NO-OP when in fast evaluation mode.
-    *  @brief Tests if the sha1 hash generated from data matches the provided digest.
     *
+    *  @ingroup crypto
     *  @param data - Data you want to hash
     *  @param length - Data length
     *  @param hash - digest to compare to
+    *  @note This method is optimized to a NO-OP when in fast evaluation mode.
     */
    void assert_sha1( const char* data, uint32_t length, const eosio::checksum160& hash );
 
    /**
     *  Tests if the SHA512 hash generated from data matches the provided digest.
-    *  This method is optimized to a NO-OP when in fast evaluation mode.
-    *  @brief Tests if the sha512 hash generated from data matches the provided digest.
     *
+    *  @ingroup crypto
     *  @param data - Data you want to hash
     *  @param length - Data length
     *  @param hash - digest to compare to
+    *  @note This method is optimized to a NO-OP when in fast evaluation mode.
     */
    void assert_sha512( const char* data, uint32_t length, const eosio::checksum512& hash );
 
    /**
     *  Tests if the RIPEMD160 hash generated from data matches the provided digest.
-    *  @brief Tests if the ripemd160 hash generated from data matches the provided digest.
     *
+    *  @ingroup crypto
     *  @param data - Data you want to hash
     *  @param length - Data length
     *  @param hash - digest to compare to
@@ -201,8 +204,8 @@ namespace eosio {
 
    /**
     *  Hashes `data` using SHA256.
-    *  @brief Hashes `data` using SHA256.
     *
+    *  @ingroup crypto
     *  @param data - Data you want to hash
     *  @param length - Data length
     *  @return eosio::checksum256 - Computed digest
@@ -211,7 +214,8 @@ namespace eosio {
 
    /**
     *  Hashes `data` using SHA1.
-    *  @brief Hashes `data` using SHA1.
+    *
+    *  @ingroup crypto
     *
     *  @param data - Data you want to hash
     *  @param length - Data length
@@ -221,8 +225,8 @@ namespace eosio {
 
    /**
     *  Hashes `data` using SHA512.
-    *  @brief Hashes `data` using SHA512.
     *
+    *  @ingroup crypto
     *  @param data - Data you want to hash
     *  @param length - Data length
     *  @return eosio::checksum512 - Computed digest
@@ -231,8 +235,8 @@ namespace eosio {
 
    /**
     *  Hashes `data` using RIPEMD160.
-    *  @brief Hashes `data` using RIPEMD160.
     *
+    *  @ingroup crypto
     *  @param data - Data you want to hash
     *  @param length - Data length
     *  @return eosio::checksum160 - Computed digest
@@ -241,8 +245,8 @@ namespace eosio {
 
    /**
     *  Calculates the public key used for a given signature on a given digest.
-    *  @brief Calculates the public key used for a given signature on a given digest.
     *
+    *  @ingroup crypto
     *  @param digest - Digest of the message that was signed
     *  @param sig - Signature
     *  @return eosio::public_key - Recovered public key
@@ -251,13 +255,11 @@ namespace eosio {
 
    /**
     *  Tests a given public key with the recovered public key from digest and signature.
-    *  @brief Tests a given public key with the recovered public key from digest and signature.
     *
+    *  @ingroup crypto
     *  @param digest - Digest of the message that was signed
     *  @param sig - Signature
     *  @param pubkey - Public key
     */
    void assert_recover_key( const eosio::checksum256& digest, const eosio::signature& sig, const eosio::public_key& pubkey );
-
-   /// }@cryptoapi
 }

--- a/libraries/eosiolib/core/eosio/datastream.hpp
+++ b/libraries/eosiolib/core/eosio/datastream.hpp
@@ -24,6 +24,12 @@
 namespace eosio {
 
 /**
+ * @defgroup datastream Data Stream
+ * @ingroup core
+ * @brief Defines data stream for reading and writing data in the form of bytes
+ */
+
+/**
  *  A data stream for reading and writing data in the form of bytes
  *
  *  @tparam T - Type of the datastream buffer
@@ -32,7 +38,7 @@ template<typename T>
 class datastream {
    public:
       /**
-       * @brief Construct a new datastream object
+       * Construct a new datastream object
        *
        * @details Construct a new datastream object given the size of the buffer and start position of the buffer
        * @param start - The start position of the buffer
@@ -170,7 +176,6 @@ class datastream {
 };
 
 /**
- * @brief Specialization of datastream used to help determine the final size of a serialized value.
  * Specialization of datastream used to help determine the final size of a serialized value
  */
 template<>
@@ -179,7 +184,6 @@ class datastream<size_t> {
       /**
        * Construct a new specialized datastream object given the initial size
        *
-       * @brief Construct a new specialized datastream object
        * @param init_size - The initial size
        */
      datastream( size_t init_size = 0):_size(init_size){}
@@ -187,7 +191,6 @@ class datastream<size_t> {
      /**
       *  Increment the size by s. This behaves the same as write( const char* ,size_t s ).
       *
-      *  @brief Increase the size by s
       *  @param s - The amount of size to increase
       *  @return true
       */
@@ -196,7 +199,6 @@ class datastream<size_t> {
      /**
       *  Increment the size by s. This behaves the same as skip( size_t s )
       *
-      *  @brief Increase the size by s
       *  @param s - The amount of size to increase
       *  @return true
       */
@@ -205,7 +207,6 @@ class datastream<size_t> {
      /**
       *  Increment the size by one
       *
-      *  @brief Increase the size by one
       *  @return true
       */
      inline bool     put(char )                      { ++_size; return  true;    }
@@ -213,7 +214,6 @@ class datastream<size_t> {
      /**
       *  Check validity. It's always valid
       *
-      *  @brief Check validity
       *  @return true
       */
      inline bool     valid()const                     { return true;              }
@@ -230,7 +230,6 @@ class datastream<size_t> {
      /**
       * Get the size
       *
-      * @brief Get the size
       * @return size_t - The size
       */
      inline size_t   tellp()const                     { return _size;             }
@@ -238,15 +237,12 @@ class datastream<size_t> {
      /**
       * Always returns 0
       *
-      * @brief Always returns 0
       * @return size_t - 0
       */
      inline size_t   remaining()const                 { return 0;                 }
   private:
      /**
       * The size used to determine the final size of a serialized value.
-      *
-      * @brief The size used to determine the final size of a serialized value.
       */
      size_t _size;
 };
@@ -254,7 +250,6 @@ class datastream<size_t> {
 /**
  *  Serialize an std::list into a stream
  *
- *  @brief Serialize an std::list 
  *  @param ds - The stream to write
  *  @param opt - The value to serialize
  *  @tparam Stream - Type of datastream buffer
@@ -271,7 +266,6 @@ inline datastream<Stream>& operator<<(datastream<Stream>& ds, const std::list<T>
 /**
  *  Deserialize an std::list from a stream
  *
- *  @brief Deserialize an std::list
  *  @param ds - The stream to read
  *  @param opt - The destination for deserialized value
  *  @tparam Stream - Type of datastream buffer
@@ -290,7 +284,6 @@ inline datastream<Stream>& operator>>(datastream<Stream>& ds, std::list<T>& l) {
 /**
  *  Serialize an std::deque into a stream
  *
- *  @brief Serialize an std::queue 
  *  @param ds - The stream to write
  *  @param opt - The value to serialize
  *  @tparam Stream - Type of datastream buffer
@@ -307,7 +300,6 @@ inline datastream<Stream>& operator<<(datastream<Stream>& ds, const std::deque<T
 /**
  *  Deserialize an std::deque from a stream
  *
- *  @brief Deserialize an std::deque
  *  @param ds - The stream to read
  *  @param opt - The destination for deserialized value
  *  @tparam Stream - Type of datastream buffer
@@ -326,7 +318,6 @@ inline datastream<Stream>& operator>>(datastream<Stream>& ds, std::deque<T>& d) 
 /**
  *  Serialize an std::variant into a stream
  *
- *  @brief Serialize an std::variant
  *  @param ds - The stream to write
  *  @param opt - The value to serialize
  *  @tparam Stream - Type of datastream buffer
@@ -358,7 +349,6 @@ void deserialize(datastream<Stream>& ds, std::variant<Ts...>& var, int i) {
 /**
  *  Deserialize an std::variant from a stream
  *
- *  @brief Deserialize an std::variant
  *  @param ds - The stream to read
  *  @param opt - The destination for deserialized value
  *  @tparam Stream - Type of datastream buffer
@@ -375,7 +365,6 @@ inline datastream<Stream>& operator>>(datastream<Stream>& ds, std::variant<Ts...
 /**
  *  Serialize an std::pair
  *
- *  @brief Serialize an std::pair
  *  @param ds - The stream to write
  *  @param t - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -392,7 +381,6 @@ DataStream& operator<<( DataStream& ds, const std::pair<T1, T2>& t ) {
 /**
  *  Deserialize an std::pair
  *
- *  @brief Deserialize an std::pair
  *  @param ds - The stream to read
  *  @param t - The destination for deserialized value
  *  @tparam DataStream - Type of datastream
@@ -412,7 +400,6 @@ DataStream& operator>>( DataStream& ds, std::pair<T1, T2>& t ) {
 /**
  *  Serialize an optional into a stream
  *
- *  @brief Serialize an optional
  *  @param ds - The stream to write
  *  @param opt - The value to serialize
  *  @tparam Stream - Type of datastream buffer
@@ -430,7 +417,6 @@ inline datastream<Stream>& operator<<(datastream<Stream>& ds, const std::optiona
 /**
  *  Deserialize an optional from a stream
  *
- *  @brief Deserialize an optional
  *  @param ds - The stream to read
  *  @param opt - The destination for deserialized value
  *  @tparam Stream - Type of datastream buffer
@@ -452,7 +438,6 @@ inline datastream<Stream>& operator>>(datastream<Stream>& ds, std::optional<T>& 
 /**
  *  Serialize a bool into a stream
  *
- *  @brief  Serialize a bool into a stream
  *  @param ds - The stream to read
  *  @param d - The value to serialize
  *  @tparam Stream - Type of datastream buffer
@@ -483,7 +468,6 @@ inline datastream<Stream>& operator>>(datastream<Stream>& ds, bool& d) {
 /**
  *  Serialize a string into a stream
  *
- *  @brief Serialize a string
  *  @param ds - The stream to write
  *  @param v - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -500,7 +484,6 @@ DataStream& operator << ( DataStream& ds, const std::string& v ) {
 /**
  *  Deserialize a string from a stream
  *
- *  @brief Deserialize a string
  *  @param ds - The stream to read
  *  @param v - The destination for deserialized value
  *  @tparam DataStream - Type of datastream
@@ -520,7 +503,6 @@ DataStream& operator >> ( DataStream& ds, std::string& v ) {
 /**
  *  Serialize a fixed size std::array
  *
- *  @brief Serialize a fixed size std::array
  *  @param ds - The stream to write
  *  @param v - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -947,16 +929,9 @@ DataStream& operator>>( DataStream& ds, T& v ) {
 }
 
 /**
- * Defines data stream for reading and writing data in the form of bytes
- *
- * @addtogroup datastream Data Stream
- * @ingroup core
- * @{
- */
-
-/**
  * Unpack data inside a fixed size buffer as T
  *
+ * @ingroup datastream
  * @brief Unpack data inside a fixed size buffer as T
  * @tparam T - Type of the unpacked data
  * @param buffer - Pointer to the buffer
@@ -974,6 +949,7 @@ T unpack( const char* buffer, size_t len ) {
 /**
  * Unpack data inside a variable size buffer as T
  *
+ * @ingroup datastream
  * @brief Unpack data inside a variable size buffer as T
  * @tparam T - Type of the unpacked data
  * @param bytes - Buffer
@@ -987,6 +963,7 @@ T unpack( const std::vector<char>& bytes ) {
 /**
  * Get the size of the packed data
  *
+ * @ingroup datastream
  * @brief Get the size of the packed data
  * @tparam T - Type of the data to be packed
  * @param value - Data to be packed
@@ -1002,6 +979,7 @@ size_t pack_size( const T& value ) {
 /**
  * Get packed data
  *
+ * @ingroup datastream
  * @brief Get packed data
  * @tparam T - Type of the data to be packed
  * @param value - Data to be packed
@@ -1016,6 +994,4 @@ std::vector<char> pack( const T& value ) {
   ds << value;
   return result;
 }
-
-///@}
 }

--- a/libraries/eosiolib/core/eosio/fixed_bytes.hpp
+++ b/libraries/eosiolib/core/eosio/fixed_bytes.hpp
@@ -12,6 +12,8 @@
 
 namespace eosio {
 
+   /// @cond IMPLEMENTATIONS
+
    template<size_t Size>
    class fixed_bytes;
 
@@ -33,20 +35,20 @@ namespace eosio {
    template<size_t Size>
    bool operator <=(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
+   /// @endcond
+
     /**
-    *  @defgroup fixed_bytes Fixed Size Byte Array
-    *  @ingroup core 
-    *  @brief Fixed size array of bytes sorted lexicographically
-    *  @ingroup types
-    *  @{
-    */
+     *  @defgroup fixed_bytes Fixed Size Byte Array
+     *  @ingroup core
+     *  @ingroup types
+     *  @brief Fixed size array of bytes sorted lexicographically
+     */
 
    /**
     *  Fixed size byte array sorted lexicographically
     *
-    *  @brief Fixed size array of bytes sorted lexicographically
+    *  @ingroup fixed_bytes
     *  @tparam Size - Size of the fixed_bytes object
-    *  @ingroup core 
     */
    template<size_t Size>
    class fixed_bytes {
@@ -93,8 +95,6 @@ namespace eosio {
 
          /**
           * Get number of words contained in this fixed_bytes object. A word is defined to be 16 bytes in size
-          *
-          * @brief Get number of words contained in this fixed_bytes object
           */
 
          static constexpr size_t num_words() { return (Size + sizeof(word_t) - 1) / sizeof(word_t); }
@@ -102,22 +102,17 @@ namespace eosio {
          /**
           * Get number of padded bytes contained in this fixed_bytes object. Padded bytes are the remaining bytes
           * inside the fixed_bytes object after all the words are allocated
-          *
-          * @brief Get number of padded bytes contained in this fixed_bytes object
           */
          static constexpr size_t padded_bytes() { return num_words() * sizeof(word_t) - Size; }
 
          /**
-         * @brief Default constructor to fixed_bytes object
-         *
-         * @details Default constructor to fixed_bytes object which initializes all bytes to zero
+         * Default constructor to fixed_bytes object which initializes all bytes to zero
          */
          constexpr fixed_bytes() : _data() {}
 
          /**
-         * @brief Constructor to fixed_bytes object from std::array of num_words() word_t types
+         * Constructor to fixed_bytes object from std::array of num_words() word_t types
          *
-         * @details Constructor to fixed_bytes object from std::array of num_words() word_t types
          * @param arr    data
          */
          fixed_bytes(const std::array<word_t, num_words()>& arr)
@@ -126,9 +121,8 @@ namespace eosio {
          }
 
          /**
-         * @brief Constructor to fixed_bytes object from std::array of Word types smaller in size than word_t
+         * Constructor to fixed_bytes object from std::array of Word types smaller in size than word_t
          *
-         * @details Constructor to fixed_bytes object from std::array of Word types smaller in size than word_t
          * @param arr - Source data
          */
          template<typename Word, size_t NumWords,
@@ -146,9 +140,8 @@ namespace eosio {
          }
 
          /**
-         * @brief Constructor to fixed_bytes object from fixed-sized C array of Word types smaller in size than word_t
+         * Constructor to fixed_bytes object from fixed-sized C array of Word types smaller in size than word_t
          *
-         * @details Constructor to fixed_bytes object from fixed-sized C array of Word types smaller in size than word_t
          * @param arr - Source data
          */
          template<typename Word, size_t NumWords,
@@ -166,13 +159,12 @@ namespace eosio {
          }
 
          /**
-         * @brief Create a new fixed_bytes object from a sequence of words
+         *  Create a new fixed_bytes object from a sequence of words
          *
-         * @details Create a new fixed_bytes object from a sequence of words
-         * @tparam FirstWord - The type of the first word in the sequence
-         * @tparam Rest - The type of the remaining words in the sequence
-         * @param first_word - The first word in the sequence
-         * @param rest - The remaining words in the sequence
+         *  @tparam FirstWord - The type of the first word in the sequence
+         *  @tparam Rest - The type of the remaining words in the sequence
+         *  @param first_word - The first word in the sequence
+         *  @param rest - The remaining words in the sequence
          */
          template<typename FirstWord, typename... Rest>
          static
@@ -197,32 +189,32 @@ namespace eosio {
 
          /**
           * Get the contained std::array
-          * @brief Get the contained std::array
           */
          const auto& get_array()const { return _data; }
 
          /**
           * Get the underlying data of the contained std::array
-          * @brief Get the underlying data of the contained std::array
           */
          auto data() { return _data.data(); }
 
+         /// @cond INTERNAL
+
          /**
           * Get the underlying data of the contained std::array
-          * @brief Get the underlying data of the contained std::array
           */
          auto data()const { return _data.data(); }
 
+         /// @endcond
+
          /**
           * Get the size of the contained std::array
-          * @brief Get the size of the contained std::array
           */
          auto size()const { return _data.size(); }
 
 
          /**
           * Extract the contained data as an array of bytes
-          * @brief Extract the contained data as an array of bytes
+          *
           * @return - the extracted data as array of bytes
           */
          std::array<uint8_t, Size> extract_as_byte_array()const {
@@ -250,11 +242,10 @@ namespace eosio {
 
             return arr;
          }
-         
+
          /**
           * Prints fixed_bytes as a hexidecimal string
           *
-          * @brief Prints fixed_bytes as a hexidecimal string
           * @param val to be printed
           */
          inline void print()const {
@@ -262,7 +253,8 @@ namespace eosio {
             printhex(static_cast<const void*>(arr.data()), arr.size());
          }
 
-         // Comparison operators
+         /// @cond OPERATORS
+
          friend bool operator == <>(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
          friend bool operator != <>(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
@@ -275,15 +267,18 @@ namespace eosio {
 
          friend bool operator <= <>(const fixed_bytes<Size> &c1, const fixed_bytes<Size> &c2);
 
+         /// @endcond
+
       private:
 
          std::array<word_t, num_words()> _data;
     };
 
+  /// @cond IMPLEMENTATIONS
+
    /**
-    * @brief Compares two fixed_bytes variables c1 and c2
+    * Lexicographically compares two fixed_bytes variables c1 and c2
     *
-    * @details Lexicographically compares two fixed_bytes variables c1 and c2
     * @param c1 - First fixed_bytes object to compare
     * @param c2 - Second fixed_bytes object to compare
     * @return if c1 == c2, return true, otherwise false
@@ -294,9 +289,8 @@ namespace eosio {
    }
 
    /**
-    * @brief Compares two fixed_bytes variables c1 and c2
+    * Lexicographically compares two fixed_bytes variables c1 and c2
     *
-    * @details Lexicographically compares two fixed_bytes variables c1 and c2
     * @param c1 - First fixed_bytes object to compare
     * @param c2 - Second fixed_bytes object to compare
     * @return if c1 != c2, return true, otherwise false
@@ -307,9 +301,8 @@ namespace eosio {
    }
 
    /**
-    * @brief Compares two fixed_bytes variables c1 and c2
+    * Lexicographically compares two fixed_bytes variables c1 and c2
     *
-    * @details Lexicographically compares two fixed_bytes variables c1 and c2
     * @param c1 - First fixed_bytes object to compare
     * @param c2 - Second fixed_bytes object to compare
     * @return if c1 > c2, return true, otherwise false
@@ -320,9 +313,8 @@ namespace eosio {
    }
 
    /**
-    * @brief Compares two fixed_bytes variables c1 and c2
+    * Lexicographically compares two fixed_bytes variables c1 and c2
     *
-    * @details Lexicographically compares two fixed_bytes variables c1 and c2
     * @param c1 - First fixed_bytes object to compare
     * @param c2 - Second fixed_bytes object to compare
     * @return if c1 < c2, return true, otherwise false
@@ -333,9 +325,8 @@ namespace eosio {
    }
 
    /**
-    * @brief Compares two fixed_bytes variables c1 and c2
+    * Lexicographically compares two fixed_bytes variables c1 and c2
     *
-    * @details Lexicographically compares two fixed_bytes variables c1 and c2
     * @param c1 - First fixed_bytes object to compare
     * @param c2 - Second fixed_bytes object to compare
     * @return if c1 >= c2, return true, otherwise false
@@ -346,9 +337,8 @@ namespace eosio {
    }
 
    /**
-    * @brief Compares two fixed_bytes variables c1 and c2
+    * Lexicographically compares two fixed_bytes variables c1 and c2
     *
-    * @details Lexicographically compares two fixed_bytes variables c1 and c2
     * @param c1 - First fixed_bytes object to compare
     * @param c2 - Second fixed_bytes object to compare
     * @return if c1 <= c2, return true, otherwise false
@@ -358,7 +348,6 @@ namespace eosio {
       return c1._data <= c2._data;
    }
 
-   /// @} fixed_bytes
 
    using checksum160 = fixed_bytes<20>;
    using checksum256 = fixed_bytes<32>;
@@ -396,4 +385,6 @@ namespace eosio {
       d = fixed_bytes<Size>( arr );
       return ds;
    }
+
+   /// @endcond
 }

--- a/libraries/eosiolib/core/eosio/ignore.hpp
+++ b/libraries/eosiolib/core/eosio/ignore.hpp
@@ -4,12 +4,17 @@
 
 namespace eosio {
    /**
-    * @brief Tells the datastream to ignore this type, but allows the abi generator to add the correct type.
-    * 
+    * @defgroup ignore
+    * @ingroup core
+    * @brief Enables telling the datastream to ignore this type, but allowing abi generator to add the correct type.
+    */
+
+   /**
+    * Tells the datastream to ignore this type, but allows the abi generator to add the correct type.
+    *
+    * @ingroup ignore
     * @details Currently non-ignore types can not succeed an ignore type in a method definition, i.e. void foo(float, ignore<int>) is allowed and void foo(float, ignore<int>, int) is not allowed.
-    * @note This restriction will be relaxed in a later release.
-    * Currently non-ignore types can not succeed an ignore type in a method definition, i.e. void foo(float, ignore<int>) is allowed and void foo(float, ignore<int>, int) is not allowed.
-    * This restriction will be relaxed in a later release.
+    * @note This restriction will be relaxed in a later release. Currently non-ignore types can not succeed an ignore type in a method definition, i.e. void foo(float, ignore<int>) is allowed and void foo(float, ignore<int>, int) is not allowed.
     */
    template <typename T>
    struct [[eosio::ignore]] ignore {};
@@ -70,4 +75,4 @@ namespace eosio {
    inline DataStream& operator>>(DataStream& ds, ::eosio::ignore<T>&) {
      return ds;
    }
-} //ns eosio
+}

--- a/libraries/eosiolib/core/eosio/name.hpp
+++ b/libraries/eosiolib/core/eosio/name.hpp
@@ -20,14 +20,17 @@ namespace eosio {
 
    /**
     * @defgroup name
-    * @ingroup core 
-    * @brief EOSIO Types
-    * @{
+    * @ingroup core
+    * @ingroup types
+    * @brief EOSIO Name Type
     */
+
    /**
     * Wraps a %uint64_t to ensure it is only passed to methods that expect a %name.
     * Ensures value is only passed to methods that expect a %name and that no mathematical
     * operations occur.  Also enables specialization of print
+    *
+    * @ingroup name
     */
    struct name {
    public:
@@ -229,6 +232,8 @@ namespace eosio {
         internal_use_do_not_use::printn(value);
       }
 
+      /// @cond INTERNAL
+
       /**
        * Equivalency operator. Returns true if a == b (are the same)
        *
@@ -256,6 +261,7 @@ namespace eosio {
          return a.value < b.value;
       }
 
+      /// @endcond
 
       uint64_t value = 0;
 
@@ -270,9 +276,12 @@ namespace eosio {
    } /// namespace detail
 } /// namespace eosio
 
+/// @cond IMPLEMENTATIONS
+
 /**
  * %name literal operator
  *
+ * @ingroup name
  * @brief "foo"_n is a shortcut for name("foo")
  */
 #pragma clang diagnostic push
@@ -283,3 +292,5 @@ inline constexpr eosio::name operator""_n() {
    return x;
 }
 #pragma clang diagnostic pop
+
+/// @endcond

--- a/libraries/eosiolib/core/eosio/print.hpp
+++ b/libraries/eosiolib/core/eosio/print.hpp
@@ -6,28 +6,7 @@
 #include <utility>
 #include <string>
 
-/**
-   *  @defgroup console Console C++ API
-   *  @ingroup core
-   *  @brief Defines C++ wrapper to log/print text messages
-   *
-   *  @details This API uses C++ variadic templates and type detection to
-   *  make it easy to print any native type. You can even overload
-   *  the `print()` method for your own custom types.
-   *
-   *  **Example:**
-   *  ```
-   *     print( "hello world, this is a number: ", 5 );
-   *  ```
-   *
-   *  @section override Overriding Print for your Types
-   *
-   *  There are two ways to overload print:
-   *  1. implement void print( const T& )
-   *  2. implement T::print()const
-   *
-   *  @{
-   */
+
 
 namespace eosio {
    namespace internal_use_do_not_use {
@@ -68,8 +47,30 @@ namespace eosio {
    };
 
    /**
+    *  @defgroup console Console
+    *  @ingroup core
+    *  @brief Defines C++ wrapper to log/print text messages
+    *
+    *  @details This API uses C++ variadic templates and type detection to
+    *  make it easy to print any native type. You can even overload
+    *  the `print()` method for your own custom types.
+    *
+    *  **Example:**
+    *  ```
+    *     print( "hello world, this is a number: ", 5 );
+    *  ```
+    *
+    *  @section override Overriding Print for your Types
+    *
+    *  There are two ways to overload print:
+    *  1. implement void print( const T& )
+    *  2. implement T::print()const
+    */
+
+   /**
     *  Prints a block of bytes in hexadecimal
     *
+    *  @ingroup console
     *  @param ptr  - pointer to bytes of interest
     *  @param size - number of bytes to print
     */
@@ -80,6 +81,7 @@ namespace eosio {
    /**
     *  Prints string to a given length
     *
+    *  @ingroup console
     *  @param ptr - a string
     *  @param len - number of chars to print
     */
@@ -90,6 +92,7 @@ namespace eosio {
    /**
     *  Prints string
     *
+    *  @ingroup console
     *  @param ptr - a null terminated string
     */
    inline void print( const char* ptr ) {
@@ -101,7 +104,7 @@ namespace eosio {
     *
     * @param num to be printed
     */
-   template <typename T, std::enable_if_t<std::is_integral<std::decay_t<T>>::value && 
+   template <typename T, std::enable_if_t<std::is_integral<std::decay_t<T>>::value &&
                                           std::is_signed<std::decay_t<T>>::value, int> = 0>
    inline void print( T num ) {
       if constexpr(std::is_same<T, int128_t>::value)
@@ -113,11 +116,11 @@ namespace eosio {
    }
 
    /**
-    * Prints 8-128 bit unsigned integer
+    *  Prints 8-128 bit unsigned integer
     *
-    * @param num to be printed
+    *  @param num to be printed
     */
-   template <typename T, std::enable_if_t<std::is_integral<std::decay_t<T>>::value && 
+   template <typename T, std::enable_if_t<std::is_integral<std::decay_t<T>>::value &&
                                           !std::is_signed<std::decay_t<T>>::value, int> = 0>
    inline void print( T num ) {
       if constexpr(std::is_same<T, uint128_t>::value)
@@ -129,31 +132,35 @@ namespace eosio {
    }
 
    /**
-    * Prints single-precision floating point number (i.e. float)
+    *  Prints single-precision floating point number (i.e. float)
     *
-    * @param num to be printed
+    *  @ingroup console
+    *  @param num to be printed
     */
    inline void print( float num ) { internal_use_do_not_use::printsf( num ); }
 
    /**
-    * Prints double-precision floating point number (i.e. double)
+    *  Prints double-precision floating point number (i.e. double)
     *
-    * @param num to be printed
+    *  @ingroup console
+    *  @param num to be printed
     */
    inline void print( double num ) { internal_use_do_not_use::printdf( num ); }
 
    /**
-    * Prints quadruple-precision floating point number (i.e. long double)
+    *  Prints quadruple-precision floating point number (i.e. long double)
     *
-    * @param num to be printed
+    *  @ingroup console
+    *  @param num to be printed
     */
    inline void print( long double num ) { internal_use_do_not_use::printqf( &num ); }
 
   /**
-    * Prints class object
+    *  Prints class object
     *
-    * @param t to be printed
-    * @pre T must implements print() function
+    *  @ingroup console
+    *  @param t to be printed
+    *  @pre T must implements print() function
     */
    template<typename T, std::enable_if_t<!std::is_integral<std::decay_t<T>>::value, int> = 0>
    inline void print( T&& t ) {
@@ -166,27 +173,28 @@ namespace eosio {
    }
 
    /**
-    * Prints null terminated string
+    *  Prints null terminated string
     *
-    * @param s null terminated string to be printed
+    *  @ingroup console
+    *  @param s null terminated string to be printed
     */
    inline void print_f( const char* s ) {
      internal_use_do_not_use::prints(s);
    }
 
    /**
-    * Prints formatted string. It behaves similar to C printf/
+    *  Prints formatted string. It behaves similar to C printf/
     *
-    * @tparam Arg - Type of the value used to replace the format specifier
-    * @tparam Args - Type of the value used to replace the format specifier
-    * @param s - Null terminated string with to be printed (it can contains format specifier)
-    * @param val - The value used to replace the format specifier
-    * @param rest - The values used to replace the format specifier
+    *  @tparam Arg - Type of the value used to replace the format specifier
+    *  @tparam Args - Type of the value used to replace the format specifier
+    *  @param s - Null terminated string with to be printed (it can contains format specifier)
+    *  @param val - The value used to replace the format specifier
+    *  @param rest - The values used to replace the format specifier
     *
-    * Example:
-    * @code
-    * print_f("Number of apples: %", 10);
-    * @endcode
+    *  Example:
+    *  @code
+    *  print_f("Number of apples: %", 10);
+    *  @endcode
     */
    template <typename Arg, typename... Args>
    inline void print_f( const char* s, Arg val, Args... rest ) {
@@ -228,8 +236,12 @@ namespace eosio {
 
    /**
     * Simulate C++ style streams
+    *
+    * @ingroup console
     */
    class iostream {};
+
+   /// @cond OPERATORS
 
    /**
     *  Overload c++ iostream
@@ -257,7 +269,7 @@ namespace eosio {
       return out;
    }
 
-   static iostream cout;
+   /// @endcond
 
-   /// @} consolecppapi
+   static iostream cout;
 }

--- a/libraries/eosiolib/core/eosio/serialize.hpp
+++ b/libraries/eosiolib/core/eosio/serialize.hpp
@@ -8,17 +8,15 @@
   OP t.elem
 
 /**
- * @addtogroup serialize Serialize C++ API
- * @brief Defines C++ API to serialize and deserialize object
- * @ingroup core 
- * @{
+ *  @defgroup serialize Serialize
+ *  @ingroup core
+ *  @brief Defines C++ API to serialize and deserialize object
  */
 
 /**
  *  Defines serialization and deserialization for a class
  *
- *  @brief Defines serialization and deserialization for a class
- *
+ *  @ingroup serialize
  *  @param TYPE - the class to have its serialization and deserialization defined
  *  @param MEMBERS - a sequence of member names.  (field1)(field2)(field3)
  */
@@ -36,9 +34,7 @@
  *  Defines serialization and deserialization for a class which inherits from other classes that
  *  have their serialization and deserialization defined
  *
- *  @brief Defines serialization and deserialization for a class which inherits from other classes that
- *  have their serialization and deserialization defined
- *
+ *  @ingroup serialize
  *  @param TYPE - the class to have its serialization and deserialization defined
  *  @param BASE - a sequence of base class names (basea)(baseb)(basec)
  *  @param MEMBERS - a sequence of member names.  (field1)(field2)(field3)
@@ -54,4 +50,3 @@
     ds >> static_cast<BASE&>(t); \
     return ds BOOST_PP_SEQ_FOR_EACH( EOSLIB_REFLECT_MEMBER_OP, >>, MEMBERS );\
  }
-///@} serializecpp

--- a/libraries/eosiolib/core/eosio/symbol.hpp
+++ b/libraries/eosiolib/core/eosio/symbol.hpp
@@ -16,15 +16,15 @@
 
 namespace eosio {
   /**
-   *  @addtogroup symbol Symbol CPP API
+   *  @defgroup symbol Symbol
    *  @ingroup core
-   *  @brief Defines %CPP API for managing symbols
-   *  @{
+   *  @brief Defines C++ API for managing symbols
    */
 
    /**
-    * @class Stores the symbol code
-    * @brief Stores the symbol code as a uint64_t value
+    *  Stores the symbol code as a uint64_t value
+    *
+    *  @ingroup symbol
     */
    class symbol_code {
    public:
@@ -149,9 +149,7 @@ namespace eosio {
       }
 
       /**
-       *  Returns the symbol_code as a string.
-       *
-       *  @brief Returns the name value as a string by calling write_as_string() and returning the buffer produced by write_as_string()
+       *  Returns the name value as a string by calling write_as_string() and returning the buffer produced by write_as_string()
        */
       std::string to_string()const {
          char buffer[7];
@@ -174,7 +172,6 @@ namespace eosio {
       /**
        * Equivalency operator. Returns true if a == b (are the same)
        *
-       * @brief Equivalency operator
        * @return boolean - true if both provided symbol_codes are the same
        */
       friend constexpr bool operator == ( const symbol_code& a, const symbol_code& b ) {
@@ -184,7 +181,6 @@ namespace eosio {
       /**
        * Inverted equivalency operator. Returns true if a != b (are different)
        *
-       * @brief Inverted equivalency operator
        * @return boolean - true if both provided symbol_codes are not the same
        */
       friend constexpr bool operator != ( const symbol_code& a, const symbol_code& b ) {
@@ -207,7 +203,6 @@ namespace eosio {
    /**
     *  Serialize a symbol_code into a stream
     *
-    *  @brief Serialize a symbol_code
     *  @param ds - The stream to write
     *  @param sym - The value to serialize
     *  @tparam DataStream - Type of datastream buffer
@@ -223,7 +218,6 @@ namespace eosio {
    /**
     *  Deserialize a symbol_code from a stream
     *
-    *  @brief Deserialize a symbol_code
     *  @param ds - The stream to read
     *  @param symbol - The destination for deserialized value
     *  @tparam DataStream - Type of datastream buffer
@@ -238,36 +232,29 @@ namespace eosio {
    }
 
    /**
-    * @struct Stores information about a symbol, the symbol can be 7 characters long.
+    *  Stores information about a symbol, the symbol can be 7 characters long.
     *
-    * @brief Stores information about a symbol
+    *  @ingroup symbol
     */
    class symbol {
    public:
       /**
-       * Default constructor, construct a new symbol
-       *
-       * @brief Construct a new symbol object defaulting to a value of 0
-       *
+       * Construct a new symbol object defaulting to a value of 0
        */
       constexpr symbol() : value(0) {}
 
       /**
        * Construct a new symbol given a scoped enumerated type of raw (uint64_t).
        *
-       * @brief Construct a new symbol object initialising value with raw
        * @param raw - The raw value which is a scoped enumerated type of unit64_t
-       *
        */
       constexpr explicit symbol( uint64_t raw ) : value(raw) {}
 
       /**
        * Construct a new symbol given a symbol_code and a uint8_t precision.
        *
-       * @brief Construct a new symbol object initialising value with a symbol maximum of 7 characters, packs the symbol and precision into the uint64_t value.
        * @param sc - The symbol_code
        * @param precision - The number of decimal places used for the symbol
-       *
        */
       constexpr symbol( symbol_code sc, uint8_t precision )
       : value( (sc.raw() << 8) | static_cast<uint64_t>(precision) )
@@ -276,10 +263,8 @@ namespace eosio {
       /**
        * Construct a new symbol given a string and a uint8_t precision.
        *
-       * @brief Construct a new symbol object initialising value with a symbol maximum of 7 characters, packs the symbol and precision into the uint64_t value.
        * @param ss - The string containing the symbol
        * @param precision - The number of decimal places used for the symbol
-       *
        */
       constexpr symbol( std::string_view ss, uint8_t precision )
       : value( (symbol_code(ss).raw() << 8)  | static_cast<uint64_t>(precision) )
@@ -309,8 +294,6 @@ namespace eosio {
 
       /**
        * %Print the symbol
-       *
-       * @brief %Print the symbol
        */
       void print( bool show_precision = true )const {
          if( show_precision ){
@@ -325,7 +308,6 @@ namespace eosio {
       /**
        * Equivalency operator. Returns true if a == b (are the same)
        *
-       * @brief Equivalency operator
        * @return boolean - true if both provided symbols are the same
        */
       friend constexpr bool operator == ( const symbol& a, const symbol& b ) {
@@ -335,7 +317,6 @@ namespace eosio {
       /**
        * Inverted equivalency operator. Returns true if a != b (are different)
        *
-       * @brief Inverted equivalency operator
        * @return boolean - true if both provided symbols are not the same
        */
       friend constexpr bool operator != ( const symbol& a, const symbol& b ) {
@@ -389,8 +370,9 @@ namespace eosio {
    }
 
    /**
-    * @struct Extended asset which stores the information of the owner of the symbol
+    *  Extended asset which stores the information of the owner of the symbol
     *
+    *  @ingroup symbol
     */
    class extended_symbol
    {
@@ -398,19 +380,14 @@ namespace eosio {
 
       /**
        * Default constructor, construct a new extended_symbol
-       *
-       * @brief Construct a new empty extended_symbol object
-       *
        */
       constexpr extended_symbol() {}
 
       /**
-       * Construct a new symbol_code given a symbol and a name.
+       * Construct a new symbol_code object initialising symbol and contract with the passed in symbol and name
        *
-       * @brief Construct a new symbol_code object initialising symbol and contract with the passed in symbol and name
        * @param sym - The symbol
        * @param con - The name of the contract
-       *
        */
       constexpr extended_symbol( symbol sym, name con ) : symbol(sym), contract(con) {}
 
@@ -441,7 +418,6 @@ namespace eosio {
       /**
        * Equivalency operator. Returns true if a == b (are the same)
        *
-       * @brief Equivalency operator
        * @return boolean - true if both provided extended_symbols are the same
        */
       friend constexpr bool operator == ( const extended_symbol& a, const extended_symbol& b ) {
@@ -451,7 +427,6 @@ namespace eosio {
       /**
        * Inverted equivalency operator. Returns true if a != b (are different)
        *
-       * @brief Inverted equivalency operator
        * @return boolean - true if both provided extended_symbols are not the same
        */
       friend constexpr bool operator != ( const extended_symbol& a, const extended_symbol& b ) {
@@ -460,7 +435,7 @@ namespace eosio {
 
       /**
        * Less than operator. Returns true if a < b.
-       * @brief Less than operator
+       *
        * @return boolean - true if extended_symbol `a` is less than `b`
        */
       friend constexpr bool operator < ( const extended_symbol& a, const extended_symbol& b ) {
@@ -473,6 +448,4 @@ namespace eosio {
 
       EOSLIB_SERIALIZE( extended_symbol, (symbol)(contract) )
    };
-
-   /// @}
 }

--- a/libraries/eosiolib/core/eosio/time.hpp
+++ b/libraries/eosiolib/core/eosio/time.hpp
@@ -5,13 +5,18 @@
 
 namespace eosio {
   /**
-   * @addtogroup time
-   * @ingroup cpp_api
-   * @{
+   *  @defgroup time
+   *  @ingroup core
+   *  @brief Classes for working with time.
    */
+
+
+
   class microseconds {
     public:
         explicit microseconds( int64_t c = 0) :_count(c){}
+
+        /// @cond INTERNAL
         static microseconds maximum() { return microseconds(0x7fffffffffffffffll); }
         friend microseconds operator + (const  microseconds& l, const microseconds& r ) { return microseconds(l._count+r._count); }
         friend microseconds operator - (const  microseconds& l, const microseconds& r ) { return microseconds(l._count-r._count); }
@@ -29,6 +34,7 @@ namespace eosio {
         int64_t to_seconds()const { return _count/1000000; }
 
         int64_t _count;
+        /// @endcond
         EOSLIB_SERIALIZE( microseconds, (_count) )
     private:
         friend class time_point;
@@ -40,11 +46,18 @@ namespace eosio {
   inline microseconds hours(int64_t h) { return minutes(60*h); }
   inline microseconds days(int64_t d) { return hours(24*d); }
 
+  /**
+   *  High resolution time point in microseconds
+   *
+   *  @ingroup time
+   */
   class time_point {
     public:
         explicit time_point( microseconds e = microseconds() ) :elapsed(e){}
         const microseconds& time_since_epoch()const { return elapsed; }
         uint32_t            sec_since_epoch()const  { return uint32_t(elapsed.count() / 1000000); }
+
+        /// @cond INTERNAL
         bool   operator > ( const time_point& t )const                              { return elapsed._count > t.elapsed._count; }
         bool   operator >=( const time_point& t )const                              { return elapsed._count >=t.elapsed._count; }
         bool   operator < ( const time_point& t )const                              { return elapsed._count < t.elapsed._count; }
@@ -58,11 +71,15 @@ namespace eosio {
         time_point   operator - (const microseconds& m) const { return time_point(elapsed-m); }
         microseconds operator - (const time_point& m) const { return microseconds(elapsed.count() - m.elapsed.count()); }
         microseconds elapsed;
+        /// @endcond
+
         EOSLIB_SERIALIZE( time_point, (elapsed) )
   };
 
   /**
    *  A lower resolution time_point accurate only to seconds from 1970
+   *
+   *  @ingroup time
    */
   class time_point_sec
   {
@@ -82,6 +99,7 @@ namespace eosio {
         operator time_point()const { return time_point( eosio::seconds( utc_seconds) ); }
         uint32_t sec_since_epoch()const { return utc_seconds; }
 
+        /// @cond INTERNAL
         time_point_sec operator = ( const eosio::time_point& t )
         {
           utc_seconds = uint32_t(t.time_since_epoch().count() / 1000000ll);
@@ -108,13 +126,17 @@ namespace eosio {
         friend microseconds operator - ( const time_point& t, const time_point_sec& m ) { return time_point(t) - time_point(m); }
         uint32_t utc_seconds;
 
+        /// @endcond
+
         EOSLIB_SERIALIZE( time_point_sec, (utc_seconds) )
   };
 
    /**
-   * This class is used in the block headers to represent the block time
-   * It is a parameterised class that takes an Epoch in milliseconds and
-   * and an interval in milliseconds and computes the number of slots.
+   *  This class is used in the block headers to represent the block time
+   *  It is a parameterised class that takes an Epoch in milliseconds and
+   *  and an interval in milliseconds and computes the number of slots.
+   *
+   *  @ingroup time
    **/
    class block_timestamp {
       public:
@@ -148,6 +170,7 @@ namespace eosio {
             return time_point(milliseconds(msec));
          }
 
+          /// @cond INTERNAL
          void operator = (const time_point& t ) {
             set_time_point(t);
          }
@@ -161,6 +184,7 @@ namespace eosio {
          uint32_t slot;
          static constexpr int32_t block_interval_ms = 500;
          static constexpr int64_t block_timestamp_epoch = 946684800000ll;  // epoch is year 2000
+         /// @endcond
 
          EOSLIB_SERIALIZE( block_timestamp, (slot) )
       private:
@@ -178,8 +202,9 @@ namespace eosio {
       }
    }; // block_timestamp
 
-
+   /**
+    *  @ingroup time
+    */
    typedef block_timestamp block_timestamp_type;
 
-   /// @}
 } // namespace eosio

--- a/libraries/eosiolib/core/eosio/varint.hpp
+++ b/libraries/eosiolib/core/eosio/varint.hpp
@@ -7,16 +7,17 @@
 namespace eosio {
    /**
     * @defgroup varint Variable Length Integer Type
-    * @brief Defines variable length integer type which provides more efficient serialization
     * @ingroup core
-    * @{/
+    * @ingroup types
+    * @brief Defines variable length integer type which provides more efficient serialization
     */
+
    /**
-    * Variable Length Unsigned Integer. This provides more efficient serialization of 32-bit unsigned int.
-    * It serialuzes a 32-bit unsigned integer in as few bytes as possible
-    * `varuint32` is unsigned and uses [VLQ or Base-128 encoding](https://en.wikipedia.org/wiki/Variable-length_quantity)
+    *  Variable Length Unsigned Integer. This provides more efficient serialization of 32-bit unsigned int.
+    *  It serialuzes a 32-bit unsigned integer in as few bytes as possible
+    *  `varuint32` is unsigned and uses [VLQ or Base-128 encoding](https://en.wikipedia.org/wiki/Variable-length_quantity)
     *
-    * @brief Variable Length Unsigned Integer
+    *  @ingroup varint
     */
    struct unsigned_int {
        /**
@@ -48,6 +49,8 @@ namespace eosio {
        template<typename T>
        operator T()const { return static_cast<T>(value); }
 
+       /// @cond OPERATORS
+
        /**
         * Assign 32-bit unsigned integer
         *
@@ -56,10 +59,14 @@ namespace eosio {
         */
        unsigned_int& operator=( uint32_t v ) { value = v; return *this; }
 
+       /// @endcond
+
        /**
         * Contained value
         */
        uint32_t value;
+
+       /// @cond OPERATORS
 
        /**
         * Check equality between a unsigned_int object and 32-bit unsigned integer
@@ -181,6 +188,11 @@ namespace eosio {
         */
        friend bool operator>=( const unsigned_int& i, const unsigned_int& v ) { return i.value >= v.value; }
 
+
+       /// @endcond
+
+       /// @cond IMPLEMENTATIONS
+
        /**
         *  Serialize an unsigned_int object with as few bytes as possible
         *
@@ -220,13 +232,16 @@ namespace eosio {
          vi.value = static_cast<uint32_t>(v);
          return ds;
        }
+
+       /// @endcond
    };
 
    /**
-    * Variable Length Signed Integer. This provides more efficient serialization of 32-bit signed int.
-    * It serializes a 32-bit signed integer in as few bytes as possible.
+    *  Variable Length Signed Integer. This provides more efficient serialization of 32-bit signed int.
+    *  It serializes a 32-bit signed integer in as few bytes as possible.
     *
-    * @note `varint32' is signed and uses [Zig-Zag encoding](https://developers.google.com/protocol-buffers/docs/encoding#signed-integers)
+    *  @ingroup varint
+    *  @note `varint32' is signed and uses [Zig-Zag encoding](https://developers.google.com/protocol-buffers/docs/encoding#signed-integers)
     */
    struct signed_int {
        /**
@@ -235,6 +250,8 @@ namespace eosio {
         * @param v - Source
         */
        signed_int( int32_t v = 0 ):value(v){}
+
+       /// @cond OPERATORS
 
        /**
         * Convert signed_int to primitive 32-bit signed integer
@@ -268,10 +285,14 @@ namespace eosio {
         */
        signed_int& operator++(){ ++value; return *this; }
 
+       /// @endcond
+
        /**
         * Contained value
         */
        int32_t value;
+
+       /// @cond OPERATORS
 
        /**
         * Check equality between a signed_int object and 32-bit integer
@@ -395,6 +416,9 @@ namespace eosio {
         */
        friend bool operator>=( const signed_int& i, const signed_int& v ) { return i.value >= v.value; }
 
+       /// @endcond
+
+       /// @cond IMPLEMENTATIONS
 
        /**
         *  Serialize an signed_int object with as few bytes as possible
@@ -432,9 +456,10 @@ namespace eosio {
             v |= uint32_t(uint8_t(b) & 0x7f) << by;
             by += 7;
          } while( uint8_t(b) & 0x80 );
-         vi.value = (v>>1) ^ (~(v&1)+1ull);         
+         vi.value = (v>>1) ^ (~(v&1)+1ull);
          return ds;
        }
+
+       /// @endcond
    };
-   /// @}
 }

--- a/libraries/eosiolib/symbol.hpp
+++ b/libraries/eosiolib/symbol.hpp
@@ -17,9 +17,9 @@
 namespace eosio {
 
   /**
-   *  @addtogroup symbol Symbol CPP API
+   *  @addtogroup symbol Symbol C++ API
    *  @ingroup core
-   *  @brief Defines %CPP API for managing symbols
+   *  @brief Defines C++ API for managing symbols
    *  @{
    */
 


### PR DESCRIPTION
# Convention Changes
- Stopped used curly-bracket grouping, started using explicit `ingroup` notations to have more control over parsed annotations. 
- Utilizing `@cond` so that hidden documentation can be optionally generated. 

# Removals
- Any extraneous implementation documentation has been excluded.
- Extraneous operator documentation removed. 

# Other Changes
- Minor alterations to Doxyfile.

[Demo](https://eosio.github.io/eosio.cdt/1.6.0-rc2/group__contract.html)
