### PR TITLE
Feature/configurable stack size

### DIFF
--- a/docs/tools/eosio-cpp.md
+++ b/docs/tools/eosio-cpp.md
@@ -54,6 +54,7 @@ compiler options:
   -fno-lto                 - Disable LTO
   -fno-post-pass           - Don't run post processing pass
   -fno-stack-first         - Don't set the stack first in memory
+  -stack-size              - Specifies the maximum stack size for the contract
   -fstack-protector        - Enable stack protectors for functions potentially vulnerable to stack smashing
   -fstack-protector-all    - Force the usage of stack protectors for all functions
   -fstack-protector-strong - Use a strong heuristic to apply stack protectors to functions

--- a/docs/tools/eosio-ld.md
+++ b/docs/tools/eosio-ld.md
@@ -20,6 +20,7 @@ ld options:
   -fno-lto          - Disable LTO
   -fno-post-pass    - Don't run post processing pass
   -fno-stack-first  - Don't set the stack first in memory
+  -stack-size       - Specifies the maximum stack size for the contract
   -fuse-main        - Use main as entry
   -l=<string>       - Root name of library to link
   -lto-opt=<string> - LTO Optimization level (O0-O3)

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -63,6 +63,11 @@ static cl::opt<bool> fno_stack_first_opt(
       "fno-stack-first",
       cl::desc("Don't set the stack first in memory"),
       cl::cat(LD_CAT));
+static cl::opt<int> stack_size_opt(
+      "stack-size",
+      cl::desc("Specifies the maximum stack size for the contract. Defaults to ${EOSIO_STACK_SIZE} bytes."),
+      cl::init(${EOSIO_STACK_SIZE}),
+      cl::cat(LD_CAT));
 static cl::opt<bool> fno_post_pass_opt(
       "fno-post-pass",
       cl::desc("Don't run post processing pass"),
@@ -413,7 +418,6 @@ static void GetLdDefaults(std::vector<std::string>& ldopts) {
    if (!fnative_opt) {
       ldopts.emplace_back("--gc-sections");
       ldopts.emplace_back("--strip-all");
-      ldopts.emplace_back("-zstack-size="+std::string("${EOSIO_STACK_SIZE}"));
       ldopts.emplace_back("--merge-data-segments");
       if (fquery_opt || fquery_server_opt || fquery_client_opt) {
          ldopts.emplace_back("--export-table");
@@ -715,10 +719,12 @@ static Options CreateOptions(bool add_defaults=true) {
       else {
          ldopts.emplace_back("--lto-O3");
       }
+      ldopts.emplace_back("-zstack-size=" + std::to_string(stack_size_opt));
 #else
       if (fno_stack_first_opt) {
          ldopts.emplace_back("-fno-stack-first");
       }
+      ldopts.emplace_back("-stack-size=" + std::to_string(stack_size_opt));
       if (fno_lto_opt) {
          ldopts.emplace_back("-fno-lto-opt");
       }


### PR DESCRIPTION
Adds support for setting the stack size at link time with the parameter `-stack-size` to eosio-cpp or eosio-ld. This can be useful for contracts that make use of stack more aggressively. Expecially with the combination of `-fno-stack-first`.

 