### PR TITLE
Add missing `break` in build script to pass repo update

### DIFF
--- a/scripts/eosiocdt_build_amazon.sh
+++ b/scripts/eosiocdt_build_amazon.sh
@@ -69,7 +69,8 @@ select yn in "Yes" "No"; do
 				printf "\\nYUM update complete.\\n"
 			fi
 		break;;
-		[Nn]* ) echo "Proceeding without update!";;
+		[Nn]* ) echo "Proceeding without update!"
+		break;;
 		* ) echo "Please type 1 for yes or 2 for no.";;
 	esac
 done

--- a/scripts/eosiocdt_build_fedora.sh
+++ b/scripts/eosiocdt_build_fedora.sh
@@ -70,7 +70,8 @@ select yn in "Yes" "No"; do
 				printf "\\nYUM update complete.\\n"
 			fi
 		break;;
-		[Nn]* ) echo "Proceeding without update!";;
+		[Nn]* ) echo "Proceeding without update!"
+		break;;
 		* ) echo "Please type 1 for yes or 2 for no.";;
 	esac
 done

--- a/scripts/eosiocdt_build_ubuntu.sh
+++ b/scripts/eosiocdt_build_ubuntu.sh
@@ -92,7 +92,8 @@ select yn in "Yes" "No"; do
 				printf "\\nAPT update complete.\\n"
 			fi
 		break;;
-		[Nn]* ) echo "Proceeding without update!";;
+		[Nn]* ) echo "Proceeding without update!"
+		break;;
 		* ) echo "Please type 1 for yes or 2 for no.";;
 	esac
 done


### PR DESCRIPTION
Some build scripts missed `break;;` in their script, so it's not possible to pass updating repositories for build dependencies. This patch adds missing line, so makes scripts available to build without updating repos.