### PR TITLE
Add `eosio-ar` support in toolchain cmake to build static libarary

### DIFF
--- a/modules/EosioWasmToolchain.cmake.in
+++ b/modules/EosioWasmToolchain.cmake.in
@@ -14,6 +14,7 @@ set(EOSIO_WASMSDK_VERSION "@VERSION_FULL@")
 set(CMAKE_C_COMPILER "@CDT_ROOT_DIR@/bin/eosio-cc")
 set(CMAKE_CXX_COMPILER "@CDT_ROOT_DIR@/bin/eosio-cpp")
 set(CMAKE_ASM_COMPILER "@CDT_ROOT_DIR@/bin/eosio-cc")
+set(CMAKE_AR "@CDT_ROOT_DIR@/bin/eosio-ar" CACHE FILEPATH "Archiver")
 
 set(CMAKE_C_FLAGS " -O3 ")
 set(CMAKE_CXX_FLAGS " -O3 ")

--- a/modules/EosioWasmToolchain.cmake.in
+++ b/modules/EosioWasmToolchain.cmake.in
@@ -14,7 +14,6 @@ set(EOSIO_WASMSDK_VERSION "@VERSION_FULL@")
 set(CMAKE_C_COMPILER "@CDT_ROOT_DIR@/bin/eosio-cc")
 set(CMAKE_CXX_COMPILER "@CDT_ROOT_DIR@/bin/eosio-cpp")
 set(CMAKE_ASM_COMPILER "@CDT_ROOT_DIR@/bin/eosio-cc")
-set(CMAKE_AR "@CDT_ROOT_DIR@/bin/eosio-ar" CACHE FILEPATH "Archiver")
 
 set(CMAKE_C_FLAGS " -O3 ")
 set(CMAKE_CXX_FLAGS " -O3 ")

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -53,6 +53,7 @@ create_symlink eosio-init eosio-init
 create_symlink eosio-abigen eosio-abigen
 create_symlink eosio-wasm2wast eosio-wasm2wast
 create_symlink eosio-wast2wasm eosio-wast2wasm
+create_symlink eosio-ar eosio-ar
 
 echo "Generating Tarball $NAME.tar.gz..."
 tar -cvzf $NAME.tar.gz ./${PREFIX}/* || exit 1


### PR DESCRIPTION
Install `eosio-ar` to `bin` to make it available to build static library.