### PR TITLE
Use the amount of available memory to get the number of JOBS

### DIFF
--- a/scripts/eosiocdt_build.sh
+++ b/scripts/eosiocdt_build.sh
@@ -138,7 +138,7 @@ if [ "$ARCH" == "Darwin" ]; then
    read -ra FREE_MEM <<< "$FREE_MEM"
    FREE_MEM=$((${FREE_MEM[2]%?}*(4096))) # free pages * page size
 else
-   FREE_MEM=`LC_ALL=C free | grep "Mem:" | awk '{print $4}'`
+   FREE_MEM=`LC_ALL=C free | grep "Mem:" | awk '{print $7}'`
 fi
 
 cd $SRC_LOCATION


### PR DESCRIPTION
Build script divides `free memory` by 4 GB to get the number of JOBS when executing `make`, but the amount of free memory is usually very small. In my machine, it executes `make -j1`, even though it has hexa-core CPU (i7-8700) and 16 GB memory. IMHO, the dividend might need to be `available memory` instead of free. If there is another rationale that I miss, feel free to reject this.