### PR TITLE
Fix typo and error in action_wrapper documentation

### DIFF
--- a/libraries/eosiolib/contracts/eosio/action.hpp
+++ b/libraries/eosiolib/contracts/eosio/action.hpp
@@ -425,7 +425,7 @@ namespace eosio {
     * Example:
     * @code
     * // defined by contract writer of the actions
-    * using transfer act = action_wrapper<"transfer"_n, &token::transfer>;( *this, transfer, {st.issuer,N(active)}, {st.issuer, to, quantity, memo} );
+    * using transfer_act = action_wrapper<"transfer"_n, &token::transfer>;
     * // usage by different contract writer
     * transfer_act{"eosio.token"_n, {st.issuer, "active"_n}}.send(st.issuer, to, quantity, memo);
     * // or


### PR DESCRIPTION
## Change Description
Fix a typo and remove unnecessary part from `action_wrapper` documentation

## API Changes
N/A

## Documentation Additions
N/A