### PR TITLE
Allow to instantiate action_wrapper without permission_level

### DIFF
--- a/libraries/eosiolib/contracts/eosio/action.hpp
+++ b/libraries/eosiolib/contracts/eosio/action.hpp
@@ -451,6 +451,10 @@ namespace eosio {
       constexpr action_wrapper(Code&& code, const eosio::permission_level& perm)
          : code_name(std::forward<Code>(code)), permissions({1, perm}) {}
 
+      template <typename Code>
+      constexpr action_wrapper(Code&& code)
+         : code_name(std::forward<Code>(code)) {}
+
       static constexpr eosio::name action_name = eosio::name(Name);
       eosio::name code_name;
       std::vector<eosio::permission_level> permissions;


### PR DESCRIPTION
## Change Description
`context_free_actions` should not contain permission_level, but action_wrapper always requires permission_level to instantiate it. This patch allows action_wrapper without permission_level to wrap context_free_action.

## API Changes
N/A

## Documentation Additions
N/A