### PR TITLE
Include source path for header directory by default

### DIFF
--- a/tools/cc/eosio-cc.cpp.in
+++ b/tools/cc/eosio-cc.cpp.in
@@ -45,6 +45,11 @@ int main(int argc, const char **argv) {
       std::string tmp_file = std::string(res.c_str())+"/"+input+"-tmp.c";
       std::string output;
 
+      auto src = SmallString<64>(input);
+      llvm::sys::path::remove_filename(src);
+      std::string source_path = src.str().empty() ? "." : src.str();
+      new_opts.insert(new_opts.begin(), "-I" + source_path);
+
       output = tmp_file+".o";
 
       new_opts.insert(new_opts.begin(), input);

--- a/tools/cc/eosio-cpp.cpp.in
+++ b/tools/cc/eosio-cpp.cpp.in
@@ -195,8 +195,13 @@ int main(int argc, const char **argv) {
          llvm::sys::path::system_temp_directory(true, res);
          std::string tmp_file = std::string(res.c_str())+"/"+llvm::sys::path::filename(input).str();
          std::string output;
-         
+
          generate(opts.comp_options, input, opts.abigen_contract, opts.abigen_resources, opts.abigen);
+
+         auto src = SmallString<64>(input);
+         llvm::sys::path::remove_filename(src);
+         std::string source_path = src.str().empty() ? "." : src.str();
+         new_opts.insert(new_opts.begin(), "-I" + source_path);
 
          if (llvm::sys::fs::exists(tmp_file)) {
             input = tmp_file;


### PR DESCRIPTION
## Change Description
Because CDT 1.6.x uses system_temp_directory to build source file, so header file in the original path of source file cannot be found, unless explicit `-I./` is given.

For example, project tree is like the next:
```
test
  - test.cpp
  - test.hpp
```

`test.cpp` includes `test.hpp` directly.
``` c++
#include "test.hpp"
....
```

In case of this, `eosio-cpp` 1.6.x fails to compile `test.cpp`. This patch adds `-I + (source file path)` to make `eosio-cpp` find the header file correctly.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
