### PR TITLE
Fix duplicated symbol error

### DIFF
--- a/libraries/eosiolib/contracts/eosio/transaction.hpp
+++ b/libraries/eosiolib/contracts/eosio/transaction.hpp
@@ -172,7 +172,7 @@ namespace eosio {
     *  @param size - The size of the packed transaction, required for persistence.
     *  @param replace - If true, will replace an existing transaction.
     */
-   void send_deferred(const uint128_t& sender_id, name payer, const char* serialized_transaction, size_t size, bool replace = false) {
+   inline void send_deferred(const uint128_t& sender_id, name payer, const char* serialized_transaction, size_t size, bool replace = false) {
      internal_use_do_not_use::send_deferred(sender_id, payer.value, serialized_transaction, size, replace);
    }
    /**


### PR DESCRIPTION
## Change Description
This PR fixes #486 duplicated symbol linker error for function `eosio::send_deferred`.
