### PR TITLE
Testing "legacy-os" Buildkite Pipeline Option

### DIFF
--- a/.pipelinebranch
+++ b/.pipelinebranch
@@ -1,0 +1,1 @@
+zcb-deprecation

--- a/.pipelinebranch
+++ b/.pipelinebranch
@@ -1,1 +1,1 @@
-zcb-deprecation
+legacy-os


### PR DESCRIPTION
## Change Description
With eosio [release 1.7.1](https://github.com/EOSIO/eos/releases/tag/v1.7.1) we have announced the deprecation of support for the following operating systems:
- Mint 18
- Fedora 27
- Amazon Linux 1
- macOS High Sierra

I have spoken with Santhosh and Bucky, and they have asked me to remove these operating systems from the eosio.cdt pipelines.

To build and test against these operating systems, add a file named ".pipelinebranch" to the root of eosio on your branch containing only the text "legacy-os":
```$ echo 'legacy-os' > .pipelinebranch```

**This branch is being used to test this feature in Buildkite and will not be merged.**

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.