### PR TITLE
Deprecate error prone + += -= operators

### DIFF
--- a/libraries/eosiolib/time.hpp
+++ b/libraries/eosiolib/time.hpp
@@ -56,7 +56,7 @@ namespace eosio {
         time_point&  operator += ( const microseconds& m)                           { elapsed+=m; return *this;                 }
         time_point&  operator -= ( const microseconds& m)                           { elapsed-=m; return *this;                 }
         time_point   operator + (const microseconds& m) const { return time_point(elapsed+m); }
-        time_point   operator + (const time_point& m) const { return time_point(elapsed+m.elapsed); }
+        [[deprecated]] time_point   operator + (const time_point& m) const { return time_point(elapsed+m.elapsed); }
         time_point   operator - (const microseconds& m) const { return time_point(elapsed-m); }
         microseconds operator - (const time_point& m) const { return microseconds(elapsed.count() - m.elapsed.count()); }
         microseconds elapsed;
@@ -97,10 +97,10 @@ namespace eosio {
         friend bool      operator != ( const time_point_sec& a, const time_point_sec& b ) { return a.utc_seconds != b.utc_seconds; }
         time_point_sec&  operator += ( uint32_t m ) { utc_seconds+=m; return *this; }
         time_point_sec&  operator += ( microseconds m ) { utc_seconds+=m.to_seconds(); return *this; }
-        time_point_sec&  operator += ( time_point_sec m ) { utc_seconds+=m.utc_seconds; return *this; }
+        [[deprecated]] time_point_sec&  operator += ( time_point_sec m ) { utc_seconds+=m.utc_seconds; return *this; }
         time_point_sec&  operator -= ( uint32_t m ) { utc_seconds-=m; return *this; }
         time_point_sec&  operator -= ( microseconds m ) { utc_seconds-=m.to_seconds(); return *this; }
-        time_point_sec&  operator -= ( time_point_sec m ) { utc_seconds-=m.utc_seconds; return *this; }
+        [[deprecated]] time_point_sec&  operator -= ( time_point_sec m ) { utc_seconds-=m.utc_seconds; return *this; }
         time_point_sec   operator +( uint32_t offset )const { return time_point_sec(utc_seconds + offset); }
         time_point_sec   operator -( uint32_t offset )const { return time_point_sec(utc_seconds - offset); }
 


### PR DESCRIPTION
## Change Description

- Deprecate error prone `time_point::operator+` and `time_point_sec::operator+=` and `time_point_sec::operator-=`
- today@1pm + today@1pm == year4039  <= clearly not what is expected
- today@5pm - today@4pm == year1970 <= clearly not what is expected

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
