### PR TITLE
New flag: `-fno-abigen`

### DIFF
--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -19,6 +19,10 @@ static llvm::cl::OptionCategory EosioLdToolCategory("ld options");
 #endif
 
 /// begin ld options
+static cl::opt<bool> disable_abigen_opt(
+    "disable-abigen",
+    cl::desc("Do not generate a corresponding abi file"),
+    cl::cat(LD_CAT));
 static cl::opt<bool> fquery_opt(
     "fquery",
     cl::desc("Produce binaries for wasmql"),
@@ -826,5 +830,6 @@ static Options CreateOptions(bool add_defaults=true) {
    if (fuse_main_opt)
       ldopts.emplace_back("-fuse-main");
 #endif
+   std::cout << "VALUE OF ABIGEN: " << abigen << "\n";
    return {output_fn, inputs, link, abigen, pp_dir, abigen_output, abigen_contract, copts, ldopts, agopts, agresources, debug, fnative_opt};
 }

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -19,9 +19,9 @@ static llvm::cl::OptionCategory EosioLdToolCategory("ld options");
 #endif
 
 /// begin ld options
-static cl::opt<bool> disable_abigen_opt(
-    "disable-abigen",
-    cl::desc("Do not generate a corresponding abi file"),
+static cl::opt<bool> no_abigen_opt(
+    "no-abigen",
+    cl::desc("Disable ABI file generation"),
     cl::cat(LD_CAT));
 static cl::opt<bool> fquery_opt(
     "fquery",
@@ -499,6 +499,10 @@ static Options CreateOptions(bool add_defaults=true) {
    debug = g_opt;
 #endif
 
+   if (no_abigen_opt) {
+      ldopts.emplace_back("-no-abigen");
+   }
+
    if (add_defaults) {
       GetCompDefaults(copts);
       GetCompDefaults(agopts);
@@ -830,6 +834,6 @@ static Options CreateOptions(bool add_defaults=true) {
    if (fuse_main_opt)
       ldopts.emplace_back("-fuse-main");
 #endif
-   std::cout << "VALUE OF ABIGEN: " << abigen << "\n";
+   
    return {output_fn, inputs, link, abigen, pp_dir, abigen_output, abigen_contract, copts, ldopts, agopts, agresources, debug, fnative_opt};
 }


### PR DESCRIPTION
Cross reference to the change in repository `EOSIO/lld` [#6](https://github.com/EOSIO/lld/pull/6).
The default behavior of `eosio-ld` is to automatically generate an `.abi` file for the user. With the additional of this new flag, `-fno-abigen`, the user can now specify whether or not an `.abi` should be generated by the linker.