### PR TITLE
CHECK_PRINT bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 
 # Build
 build/*
+*.bin
+*.ipch

--- a/libraries/native/native/eosio/tester.hpp
+++ b/libraries/native/native/eosio/tester.hpp
@@ -65,7 +65,7 @@ inline bool expect_print(bool check, const std::string& li, Pred&& pred, F&& fun
    if (!check)
       eosio::check(passed, std::string("error : wrong print message {"+li+"}").c_str());
    if (!passed)
-      eosio::print("error : wrong print message9 {"+li+"}\n");
+      eosio::print("error : wrong print message {"+li+"}\n");
    silence_output(disable_out);
    return passed;
 }
@@ -74,7 +74,7 @@ template <size_t N, typename F, typename... Args>
 inline bool expect_print(bool check, const std::string& li, const char (&expected)[N], F&& func, Args... args) {
    return expect_print(check, li, 
          [&](const std::string& s) { 
-            return std_out.index == N-1 &&
+            return std_out.index == N &&
             memcmp(expected, s.c_str(), N-1) == 0; }, func, args...);
 
 }

--- a/libraries/native/tester.hpp
+++ b/libraries/native/tester.hpp
@@ -67,7 +67,7 @@ inline bool expect_print(bool check, const std::string& li, Pred&& pred, F&& fun
    if (!check)
       eosio_assert(passed, std::string("error : wrong print message {"+li+"}").c_str());
    if (!passed)
-      eosio::print("error : wrong print message9 {"+li+"}\n");
+      eosio::print("error : wrong print message {"+li+"}\n");
    silence_output(disable_out);
    return passed;
 }
@@ -76,7 +76,7 @@ template <size_t N, typename F, typename... Args>
 inline bool expect_print(bool check, const std::string& li, const char (&expected)[N], F&& func, Args... args) {
    return expect_print(check, li, 
          [&](const std::string& s) { 
-            return std_out.index == N-1 &&
+            return std_out.index == N &&
             memcmp(expected, s.c_str(), N-1) == 0; }, func, args...);
 
 }


### PR DESCRIPTION

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
A bug in the CHECK_PRINT macro of the tester API: it returns error conditions always.

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
### First change
In files:
libraries\native\native\eosio\tester.hpp, line 77
and
libraries\native\tester.hpp, line 79

The condition std_out.index == N-1 is always false what causes misleading error messages like this --
```
error : wrong print message9 {hello_test.cpp:hello_test:52}
```
-- even if the print mesage is OK.
```
 inline bool expect_print(bool check, const std::string& li, const char (&expected)[N], F&& func, Args... args) {
   return expect_print(check, li, 
         [&](const std::string& s) { 
-           return std_out.index == N-1 &&
+           return std_out.index == N &&
            memcmp(expected, s.c_str(), N-1) == 0; }, func, args...);
```

### Second change
In files:
libraries\native\native\eosio\tester.hpp, line 68
and
libraries\native\tester.hpp, line 70

The digit 9 in the message text: it is obscure and thus misleading.
```
   if (!check)
      eosio::check(passed, std::string("error : wrong print message {"+li+"}").c_str());
   if (!passed)
-     eosio::print("error : wrong print message9 {"+li+"}\n");
+     eosio::print("error : wrong print message {"+li+"}\n");
   silence_output(disable_out);
```


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
