### PR TITLE
Fix to invalid symbol print

### DIFF
--- a/libraries/eosiolib/core/eosio/symbol.hpp
+++ b/libraries/eosiolib/core/eosio/symbol.hpp
@@ -302,7 +302,7 @@ namespace eosio {
          char buffer[7];
          auto end = code().write_as_string( buffer, buffer + sizeof(buffer) );
          if( buffer < end )
-            ::eosio::print( buffer, (end-buffer) );
+            printl( buffer, (end-buffer) );
       }
 
       /**


### PR DESCRIPTION
## Change Description
`symbol::print` needs to use `eosio::printl` instead of `eosio::print`. Because `eosio::print(buffer, (end-buffer))` is translated into `print(buffer); print(end-buffer)`, so redundant string is printed. 

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
