### PR TITLE
Add check maximum precision in symbol validation

### DIFF
--- a/libraries/eosiolib/core/eosio/symbol.hpp
+++ b/libraries/eosiolib/core/eosio/symbol.hpp
@@ -243,6 +243,11 @@ namespace eosio {
    class symbol {
    public:
       /**
+       * Maximum number of decimal places used for the symbol
+       */
+      static constexpr uint8_t max_precision = 18;
+
+      /**
        * Construct a new symbol object defaulting to a value of 0
        */
       constexpr symbol() : value(0) {}
@@ -277,7 +282,7 @@ namespace eosio {
       /**
        * Is this symbol valid
        */
-      constexpr bool is_valid()const                 { return code().is_valid(); }
+      constexpr bool is_valid()const                 { return precision() <= max_precision && code().is_valid(); }
 
       /**
        * This symbol's precision


### PR DESCRIPTION
## Change Description
Unlike `eosio::chain::symbol`, `eosio::symbol` in contract header doesn't check max precision in validation check. This PR adds max precision check to `eosio::symbol::is_valid` to keep consistency.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
