### PR TITLE
Revert "Fix compilation of contracts without actions"

### DIFF
--- a/tools/cc/eosio-cpp.cpp.in
+++ b/tools/cc/eosio-cpp.cpp.in
@@ -160,13 +160,11 @@ void generate(const std::vector<std::string>& base_options, std::string input, s
    if (tool_run != 0) {
       throw std::runtime_error("abigen error");
    }
-
-   if (!get_abigen_ref().is_empty()) {
-      std::string abi_s;
-      get_abigen_ref().to_json().dump(abi_s);
-      codegen::get().set_abi(abi_s);
-   }
-
+   std::string abi_s;
+   if (get_abigen_ref().is_empty())
+      return;
+   get_abigen_ref().to_json().dump(abi_s);
+   codegen::get().set_abi(abi_s);
    tool_run = ctool.run(newFrontendActionFactory<eosio_codegen_frontend_action>().get());
    if (tool_run != 0) {
       throw std::runtime_error("codegen error");


### PR DESCRIPTION
Reverts EOSIO/eosio.cdt#469

The introduction of this change caused the build to fail. This can be seen by comparing build [408](https://buildkite.com/EOSIO/eosio-dot-cdt/builds/408) (when this commit was merged) to build [456](https://buildkite.com/EOSIO/eosio-dot-cdt/builds/456) (this commit reverted).