### PR TITLE
Fix the develop build by not adding `eosio_assert_code` to files that…

### DIFF
--- a/tools/include/eosio/codegen.hpp
+++ b/tools/include/eosio/codegen.hpp
@@ -420,6 +420,10 @@ namespace eosio { namespace cdt {
                for (auto nd : visitor->notify_decls)
                   visitor->create_notify_dispatch(nd);
 
+               if (cg.actions.size() < 1 && cg.notify_handlers.size() < 1) {
+                  return;
+               }
+
                int fd;
                llvm::SmallString<128> fn;
                try {


### PR DESCRIPTION
… are not contracts.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

This PR fixes the develop build while retaining the ability to have contracts with no actions.

The addition of the checks on `actions` and `notify_handlers` size are necessary because we compile not only contracts with `eosio-cpp` but also libraries used within the CDT. With the changes originally made in #469, the `HandleTranslationUnit` in `eosio_codegen_consumer` is being called on some of these internal libraries (specifically on libc++). Several of the files in libc++ are not using the std namespace or including `cstdint` so `uint64_t` is undefined when the `eosio_assert_code` function is added to the end of the file. This causes the compilation to fail. 

By checking the `actions` or `notify_handlers` size, we 1. fix the compilation errors and 2. remove the unnecessary `eosio_assert_code` definitions from libc++ because `actions` or `notify_handlers` should only have entries in contract code.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
