### PR TITLE
Fix get_active_producers

### DIFF
--- a/libraries/eosiolib/eosiolib.cpp
+++ b/libraries/eosiolib/eosiolib.cpp
@@ -52,10 +52,11 @@ namespace eosio {
    }
 
    std::vector<name> get_active_producers() {
-      auto prod_cnt = get_active_producers(nullptr, 0)/8;
-     std::vector<name> active_prods(prod_cnt);
-     get_active_producers((uint64_t*)active_prods.data(), active_prods.size());
-     return active_prods;
+      const auto buffer_size = get_active_producers(nullptr, 0);
+      const auto prod_cnt = buffer_size / sizeof(name);
+      std::vector<name> active_prods(prod_cnt);
+      get_active_producers((uint64_t*)active_prods.data(), buffer_size);
+      return active_prods;
    }
 
 } // namespace eosio


### PR DESCRIPTION

get_active_producers from wasm_interface treats the second argument as size of buffer in bytes, but get_active_producers from eosio.cdt puts active_prods.size() as a second argument.

This leads to corrupted active_prods where only 21 bytes of 8*21 are filled.