### PR TITLE
Add support for ctime

### DIFF
--- a/libraries/libc/CMakeLists.txt
+++ b/libraries/libc/CMakeLists.txt
@@ -11,7 +11,7 @@ file(GLOB SEARCH_SOURCES "musl/src/search/*.c")
 file(GLOB STDIO_SOURCES "musl/src/stdio/*.c")
 file(GLOB STDLIB_SOURCES "musl/src/stdlib/*.c")
 file(GLOB STRING_SOURCES "musl/src/string/*.c")
-#file(GLOB TIME_SOURCES "musl/src/time/*.c")
+file(GLOB TIME_SOURCES "musl/src/time/*.c")
 file(GLOB THREAD_SOURCES "musl/src/thread/*.c") #only for __lock __unlock
 
 set(INTERNAL_SOURCES musl/src/internal/floatscan.c musl/src/internal/intscan.c musl/src/internal/shgetc.c musl/src/internal/libc.c)

--- a/libraries/libc/CMakeLists.txt
+++ b/libraries/libc/CMakeLists.txt
@@ -16,7 +16,7 @@ file(GLOB THREAD_SOURCES "musl/src/thread/*.c") #only for __lock __unlock
 
 set(INTERNAL_SOURCES musl/src/internal/floatscan.c musl/src/internal/intscan.c musl/src/internal/shgetc.c musl/src/internal/libc.c)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-everything -allow-sse")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-everything -allow-sse -D_XOPEN_SOURCE=700")
 
 file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/musl/include/*.h"
                   "${CMAKE_CURRENT_SOURCE_DIR}/musl/src/internal/*.h"


### PR DESCRIPTION
## Change Description
Add support for `ctime`. This PR depends on EOSIO/musl#11 and EOSIO/libcxx#5.
If the PRs on submodules are merged, I'll update this too.

## API Changes
- [x] API Changes
Add types and methods supported by `ctime` like std::time, std::time_t etc.

## Documentation Additions
- [ ] Documentation Additions
Not sure, if the documentation listing what std libraries are supported exists, it needs to be updated. 
