### PR TITLE
Do not copy internal headers when building libc,cxx

### DIFF
--- a/libraries/libc++/CMakeLists.txt
+++ b/libraries/libc++/CMakeLists.txt
@@ -18,18 +18,10 @@ add_native_library(native_c++
 
 target_include_directories(c++
                            PUBLIC 
-                           ${CMAKE_SOURCE_DIR}/libc/musl/include
-                           ${CMAKE_SOURCE_DIR}/libc/musl/src/internal
-                           ${CMAKE_SOURCE_DIR}/libc/musl/src/crypt
-                           ${CMAKE_SOURCE_DIR}/libc/musl/arch/eos
                            ${CMAKE_CURRENT_SOURCE_DIR}/libcxx/include)
 
 target_include_directories(native_c++
                            PUBLIC 
-                           ${CMAKE_SOURCE_DIR}/libc/musl/include
-                           ${CMAKE_SOURCE_DIR}/libc/musl/src/internal
-                           ${CMAKE_SOURCE_DIR}/libc/musl/src/crypt
-                           ${CMAKE_SOURCE_DIR}/libc/musl/arch/eos
                            ${CMAKE_CURRENT_SOURCE_DIR}/libcxx/include)
 
 target_link_libraries(c++ c)

--- a/libraries/libc/CMakeLists.txt
+++ b/libraries/libc/CMakeLists.txt
@@ -84,5 +84,3 @@ add_custom_command( TARGET c POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGE
 add_custom_command( TARGET native_c POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:native_c> ${BASE_BINARY_DIR}/lib )
 
 file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/musl/include/ DESTINATION ${BASE_BINARY_DIR}/include/libc/)
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/musl/src/internal/ DESTINATION ${BASE_BINARY_DIR}/include/libc/)
-file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/musl/arch/eos/ DESTINATION ${BASE_BINARY_DIR}/include/libc/)


### PR DESCRIPTION
## Change Description
Install only public headers for libc. This PR excludes internal headers from installation. Moreover, libcxx doesn't need to have explicit include for libc, because `eosio-cpp` will add default include path `whereami() + "/../include/libc"`. 

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
