### PR TITLE
Fix stack overflow caused by recursive add_type 

### DIFF
--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -249,6 +249,9 @@ namespace eosio { namespace cdt {
       }
 
       void add_type( const clang::QualType& t ) {
+         if (evaluated.count(t.getTypePtr()))
+            return;
+         evaluated.insert(t.getTypePtr());
          auto type = get_ignored_type(t);
          if (!is_builtin_type(translate_type(type))) {
             if (is_aliasing(type))
@@ -470,5 +473,6 @@ namespace eosio { namespace cdt {
          std::set<const clang::CXXRecordDecl*> tables;
          std::set<abi_table>                   ctables;
          std::map<std::string, std::string>    rcs;
+         std::set<const clang::Type*>          evaluated;
    };
 }} // ns eosio::cdt


### PR DESCRIPTION
## Change Description

Fix #527. 

`add_type` calls itself recursively to add all types it refers to. If user-defined types refer to each other or themselves, it causes stack overflow by cycle.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
