### PR TITLE
 Fix build fail when struct inherits from std types 

### DIFF
--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -159,7 +159,7 @@ namespace eosio { namespace cdt {
          abi_struct ret;
          if ( decl->getNumBases() == 1 ) {
             ret.base = get_type(decl->bases_begin()->getType());
-            add_struct(decl->bases_begin()->getType().getTypePtr()->getAsCXXRecordDecl());
+            add_type(decl->bases_begin()->getType());
          }
          std::string sub_name = "";
          for ( auto field : decl->fields() ) {

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -161,7 +161,6 @@ namespace eosio { namespace cdt {
             ret.base = get_type(decl->bases_begin()->getType());
             add_type(decl->bases_begin()->getType());
          }
-         std::string sub_name = "";
          for ( auto field : decl->fields() ) {
             if ( field->getName() == "transaction_extensions") {
                abi_struct ext;
@@ -173,7 +172,6 @@ namespace eosio { namespace cdt {
             }
             else {
                ret.fields.push_back({field->getName().str(), get_type(field->getType())});
-               sub_name += "_" + get_type(field->getType());
                add_type(field->getType());
             }
          }


### PR DESCRIPTION
## Change Description

Fix #541.

`add_struct` enforces parsing its base as struct, and it causes segfault when inheriting from the std types. This patch mitigates this issue by allowing add_struct to call add_type for its base, but generated ABI is still not usable, because chain::abi_serializer requires struct base to be struct type. There is a workaround fix making it work by trick, but ultimately it needs consensus upgrade.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
