### PR TITLE
Fix segfault when using nested typedef

### DIFF
--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -569,12 +569,16 @@ struct generation_utils {
    inline std::string get_type_alias_string( const clang::QualType& t ) {
       if (auto dt = llvm::dyn_cast<clang::TypedefType>(t.getTypePtr()))
          return get_type(dt->desugar());
+      else if (auto dt = llvm::dyn_cast<clang::ElaboratedType>(t.getTypePtr()))
+         return get_type_alias_string(dt->desugar());
       return get_type(t);
    }
 
    inline std::vector<clang::QualType> get_type_alias( const clang::QualType& t ) {
       if (auto dt = llvm::dyn_cast<clang::TypedefType>(t.getTypePtr()))
          return {dt->desugar()};
+      else if (auto dt = llvm::dyn_cast<clang::ElaboratedType>(t.getTypePtr()))
+         return get_type_alias(dt->desugar());
       return {};
    }
 


### PR DESCRIPTION
## Change Description

Fix #600.

When typedef is nested in other namespace, `clang::ElaboratedType` is passed to `get_type_alias` instead of `clang::TypedefType`. When dynamic cast to clang::TypedefType fails, try casting to
ElaboratedType once mroe to avoid build fail by segfault.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
