### PR TITLE
Fix segfault during ABI generation for tuple

### DIFF
--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -110,7 +110,7 @@ namespace eosio { namespace cdt {
 
       void add_tuple(const clang::QualType& type) {
          auto pt = llvm::dyn_cast<clang::ElaboratedType>(type.getTypePtr());
-         auto tst = llvm::dyn_cast<clang::TemplateSpecializationType>(pt->desugar().getTypePtr());
+         auto tst = llvm::dyn_cast<clang::TemplateSpecializationType>((pt) ? pt->desugar().getTypePtr() : type.getTypePtr());
          if (!tst)
             throw abigen_ex;
          abi_struct tup;


### PR DESCRIPTION
## Change Description

Fix #558. 

When passed parameter of clang::QualType is not clang::ElaboratedType, segfault occurs during ABI generation.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
