### PR TITLE
Fix missing ABI when aliased type used in variant

### DIFF
--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -424,6 +424,12 @@ namespace eosio { namespace cdt {
                   for ( auto f : as.fields )
                      if ( remove_suffix(f.type) == td.new_type_name )
                         return true;
+            for ( auto v : _abi.variants ) {
+               for ( auto vt : v.types ) {
+                  if ( remove_suffix(vt) == td.new_type_name )
+                     return true;
+               }
+            }
             for ( auto t : _abi.tables )
                if ( t.type == td.new_type_name )
                   return true;


### PR DESCRIPTION
## Change Description

Fix #602.

When aliased type (typedef, using) is used as a template argument of variant, its typedef is excluded from json output unexpectedly.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
