### PR TITLE
Fix missing ABI when struct base is typedef'ed

### DIFF
--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -159,7 +159,7 @@ namespace eosio { namespace cdt {
          abi_struct ret;
          if ( decl->getNumBases() == 1 ) {
             ret.base = get_type(decl->bases_begin()->getType());
-            add_struct(decl->bases_begin()->getType().getTypePtr()->getAsCXXRecordDecl());
+            add_type(decl->bases_begin()->getType());
          }
          std::string sub_name = "";
          for ( auto field : decl->fields() ) {

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -161,7 +161,6 @@ namespace eosio { namespace cdt {
             ret.base = get_type(decl->bases_begin()->getType());
             add_type(decl->bases_begin()->getType());
          }
-         std::string sub_name = "";
          for ( auto field : decl->fields() ) {
             if ( field->getName() == "transaction_extensions") {
                abi_struct ext;
@@ -173,7 +172,6 @@ namespace eosio { namespace cdt {
             }
             else {
                ret.fields.push_back({field->getName().str(), get_type(field->getType())});
-               sub_name += "_" + get_type(field->getType());
                add_type(field->getType());
             }
          }


### PR DESCRIPTION
## Change Description

Fix #601.

abigen removes unused defs from abi json, but when struct base type is aliased type (typedef, using), its type is excluded from json generation unexpectedly.

To avoid merge conflict, changes by #604 are included. If this PR is merged, #604 isn't necessary.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
