### PR TITLE
More fixes to native tester macros - 1.6.x

### DIFF
--- a/libraries/eosiolib/core/eosio/symbol.hpp
+++ b/libraries/eosiolib/core/eosio/symbol.hpp
@@ -302,7 +302,7 @@ namespace eosio {
          char buffer[7];
          auto end = code().write_as_string( buffer, buffer + sizeof(buffer) );
          if( buffer < end )
-            ::eosio::print( buffer, (end-buffer) );
+            printl( buffer, (end-buffer) );
       }
 
       /**

--- a/libraries/native/native/eosio/tester.hpp
+++ b/libraries/native/native/eosio/tester.hpp
@@ -66,7 +66,7 @@ inline bool expect_print(bool check, const std::string& li, Pred&& pred, F&& fun
    if (!check)
       eosio::check(passed, std::string("error : wrong print message {"+li+"}").c_str());
    if (!passed)
-      eosio::print("error : wrong print message9 {"+li+"}\n");
+      eosio::print("error : wrong print message {"+li+"}\n");
    silence_output(disable_out);
    return passed;
 }
@@ -81,13 +81,13 @@ inline bool expect_print(bool check, const std::string& li, const char (&expecte
 }
 
 #define CHECK_ASSERT(...) \
-   ___has_failed &= expect_assert(true, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)), __VA_ARGS__);
+   ___has_failed |= !expect_assert(true, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)), __VA_ARGS__);
 
 #define REQUIRE_ASSERT(...) \
    expect_assert(false, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)),  __VA_ARGS__);
 
 #define CHECK_PRINT(...) \
-   ___has_failed &= expect_print(true, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)), __VA_ARGS__);
+   ___has_failed |= !expect_print(true, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)), __VA_ARGS__);
 
 #define REQUIRE_PRINT(...) \
    expect_print(false, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)),  __VA_ARGS__);

--- a/libraries/native/tester.hpp
+++ b/libraries/native/tester.hpp
@@ -68,7 +68,7 @@ inline bool expect_print(bool check, const std::string& li, Pred&& pred, F&& fun
    if (!check)
       eosio_assert(passed, std::string("error : wrong print message {"+li+"}").c_str());
    if (!passed)
-      eosio::print("error : wrong print message9 {"+li+"}\n");
+      eosio::print("error : wrong print message {"+li+"}\n");
    silence_output(disable_out);
    return passed;
 }
@@ -83,13 +83,13 @@ inline bool expect_print(bool check, const std::string& li, const char (&expecte
 }
 
 #define CHECK_ASSERT(...) \
-   ___has_failed &= expect_assert(true, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)), __VA_ARGS__);
+   ___has_failed |= !expect_assert(true, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)), __VA_ARGS__);
 
 #define REQUIRE_ASSERT(...) \
    expect_assert(false, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)),  __VA_ARGS__);
 
 #define CHECK_PRINT(...) \
-   ___has_failed &= expect_print(true, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)), __VA_ARGS__);
+   ___has_failed |= !expect_print(true, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)), __VA_ARGS__);
 
 #define REQUIRE_PRINT(...) \
    expect_print(false, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)),  __VA_ARGS__);

--- a/tests/unit/symbol_tests.cpp
+++ b/tests/unit/symbol_tests.cpp
@@ -192,12 +192,10 @@ EOSIO_TEST_BEGIN(symbol_type_test)
 
    // ---------------------
    // void print(bool)const
-   // Note:
-   // This function prints the length of the symbol at the very end
-   CHECK_PRINT( "0,A1", [&](){symbol{"A", 0}.print(true);} );
-   CHECK_PRINT( "0,Z1", [&](){symbol{"Z", 0}.print(true);} );
-   CHECK_PRINT( "255,AAAAAAA7", [&](){symbol{"AAAAAAA", 255}.print(true);} );
-   CHECK_PRINT( "255,ZZZZZZZ7", [&](){symbol{"ZZZZZZZ", 255}.print(true);} );
+   CHECK_PRINT( "0,A", [&](){symbol{"A", 0}.print(true);} );
+   CHECK_PRINT( "0,Z", [&](){symbol{"Z", 0}.print(true);} );
+   CHECK_PRINT( "255,AAAAAAA", [&](){symbol{"AAAAAAA", 255}.print(true);} );
+   CHECK_PRINT( "255,ZZZZZZZ", [&](){symbol{"ZZZZZZZ", 255}.print(true);} );
 
    // --------------------------------------------------------------
    // friend constexpr bool operator==(const symbol&, const symbol&)


### PR DESCRIPTION
## Change Description

- Fixed bug in `CHECK_ASSERT` and `CHECK_PRINT` macros which could undo a prior recording of a failure.
- Fixed bug in `symbol::print` which used the wrong function to print the symbol code. (This bug was exposed from a test failure in `symbol_tests` after the `CHECK_PRINT` function was fixed.)
- Corrected the `symbol_tests` unit test to use the proper expected print messages.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
