### PR TITLE
Reimplement asset::to_string() and related functions - 1.6.x

### DIFF
--- a/libraries/eosiolib/asset.hpp
+++ b/libraries/eosiolib/asset.hpp
@@ -10,12 +10,15 @@
 #warning "<eosiolib/asset.hpp> is deprecated use <eosio/asset.hpp>"
 
 namespace eosio {
-  /**
-   *  Defines C++ API for managing assets
-   *  @addtogroup asset Asset C++ API
-   *  @ingroup core
-   *  @{
-   */
+
+   char* write_decimal( char* begin, char* end, bool dry_run, uint64_t number, uint8_t num_decimal_places, bool negative );
+
+   /**
+    *  Defines C++ API for managing assets
+    *  @addtogroup asset Asset C++ API
+    *  @ingroup core
+    *  @{
+    */
 
    /**
     * @struct Stores information for owner of asset
@@ -315,42 +318,49 @@ namespace eosio {
       }
 
       /**
+       *  Writes the asset as a string to the provided char buffer
+       *
+       *  @brief Writes the asset as a string to the provided char buffer
+       *  @pre is_valid() == true
+       *  @pre The range [begin, end) must be a valid range of memory to write to.
+       *  @param begin - The start of the char buffer
+       *  @param end - Just past the end of the char buffer
+       *  @param dry_run - If true, do not actually write anything into the range.
+       *  @return char* - Just past the end of the last character that would be written assuming dry_run == false and end was large enough to provide sufficient space. (Meaning only applies if returned pointer >= begin.)
+       *  @post If the output string fits within the range [begin, end) and dry_run == false, the range [begin, returned pointer) contains the string representation of the asset. Nothing is written if dry_run == true or returned pointer > end (insufficient space) or if returned pointer < begin (overflow in calculating desired end).
+       */
+      char* write_as_string( char* begin, char* end, bool dry_run = false )const {
+         bool negative = (amount < 0);
+         uint64_t abs_amount = static_cast<uint64_t>(negative ? -amount : amount);
+         // 0 <= abs_amount <= std::numeric_limits<int64_t>::max() < 10^19 < std::numeric_limits<uint64_t>::max()
+
+         uint8_t precision = symbol.precision();
+
+         int sufficient_size = std::max(static_cast<int>(precision), 19) + 11;
+         if( dry_run || (begin + sufficient_size < begin) || (begin + sufficient_size > end) ) {
+            char* start_of_symbol = write_decimal( begin, end, true, abs_amount, precision, negative ) + 1;
+            char* actual_end = symbol.code().write_as_string( start_of_symbol, end, true );
+            if( dry_run || (actual_end < begin) || (actual_end > end) ) return actual_end;
+         }
+
+         char* end_of_number = write_decimal( begin, end, false, abs_amount, precision, negative );
+         *(end_of_number) = ' ';;
+
+         return symbol.code().write_as_string( end_of_number + 1, end );
+      }
+
+      /**
        * %asset to std::string
        *
        * @brief %asset to std::string
        */
       std::string to_string()const {
-         int64_t p = (int64_t)symbol.precision();
-         int64_t p10 = 1;
-         bool negative = false;
-         int64_t invert = 1;
+         int buffer_size = std::max(static_cast<int>(symbol.precision()), 19) + 11;
+         char buffer[buffer_size];
+         char* end = write_as_string( buffer, buffer + buffer_size );
+         check( end <= buffer + buffer_size, "insufficient space in buffer" ); // should never fail
 
-         while( p > 0  ) {
-            p10 *= 10; --p;
-         }
-         p = (int64_t)symbol.precision();
-
-         char fraction[p+1];
-         fraction[p] = '\0';
-
-         if (amount < 0) {
-            invert = -1;
-            negative = true;
-         }
-
-         auto change = (amount % p10) * invert;
-
-         for( int64_t i = p -1; i >= 0; --i ) {
-            fraction[i] = (change % 10) + '0';
-            change /= 10;
-         }
-         char str[p+32];
-         snprintf(str, sizeof(str), "%lld%s%s %s",
-            (int64_t)(amount/p10),
-            (fraction[0]) ? "." : "",
-            fraction,
-            symbol.code().to_string().c_str());
-         return {str};
+         return {buffer, end};
       }
 
       /**
@@ -359,7 +369,13 @@ namespace eosio {
        * @brief %Print the asset
        */
       void print()const {
-         eosio::print(to_string());
+         int buffer_size = std::max(static_cast<int>(symbol.precision()), 19) + 11;
+         char buffer[buffer_size];
+         char* end = write_as_string( buffer, buffer + buffer_size );
+         check( end <= buffer + buffer_size, "insufficient space in buffer" ); // should never fail
+
+         if( buffer < end )
+            printl( buffer, (end-buffer) );
       }
 
       EOSLIB_SERIALIZE( asset, (amount)(symbol) )

--- a/libraries/eosiolib/asset.hpp
+++ b/libraries/eosiolib/asset.hpp
@@ -344,7 +344,7 @@ namespace eosio {
          }
 
          char* end_of_number = write_decimal( begin, end, false, abs_amount, precision, negative );
-         *(end_of_number) = ' ';;
+         *(end_of_number) = ' ';
 
          return symbol.code().write_as_string( end_of_number + 1, end );
       }

--- a/libraries/eosiolib/core/eosio/asset.hpp
+++ b/libraries/eosiolib/core/eosio/asset.hpp
@@ -347,7 +347,7 @@ namespace eosio {
          }
 
          char* end_of_number = write_decimal( begin, end, false, abs_amount, precision, negative );
-         *(end_of_number) = ' ';;
+         *(end_of_number) = ' ';
 
          return symbol.code().write_as_string( end_of_number + 1, end );
       }

--- a/libraries/eosiolib/core/eosio/asset.hpp
+++ b/libraries/eosiolib/core/eosio/asset.hpp
@@ -9,11 +9,14 @@
 #include <limits>
 
 namespace eosio {
-  /**
-   *  @defgroup asset Asset
-   *  @ingroup core
-   *  @brief Defines C++ API for managing assets
-   */
+
+   char* write_decimal( char* begin, char* end, bool dry_run, uint64_t number, uint8_t num_decimal_places, bool negative );
+
+   /**
+    *  @defgroup asset Asset
+    *  @ingroup core
+    *  @brief Defines C++ API for managing assets
+    */
 
    /**
     *  Stores information for owner of asset
@@ -318,42 +321,49 @@ namespace eosio {
       /// @endcond
 
       /**
+       *  Writes the asset as a string to the provided char buffer
+       *
+       *  @brief Writes the asset as a string to the provided char buffer
+       *  @pre is_valid() == true
+       *  @pre The range [begin, end) must be a valid range of memory to write to.
+       *  @param begin - The start of the char buffer
+       *  @param end - Just past the end of the char buffer
+       *  @param dry_run - If true, do not actually write anything into the range.
+       *  @return char* - Just past the end of the last character that would be written assuming dry_run == false and end was large enough to provide sufficient space. (Meaning only applies if returned pointer >= begin.)
+       *  @post If the output string fits within the range [begin, end) and dry_run == false, the range [begin, returned pointer) contains the string representation of the asset. Nothing is written if dry_run == true or returned pointer > end (insufficient space) or if returned pointer < begin (overflow in calculating desired end).
+       */
+      char* write_as_string( char* begin, char* end, bool dry_run = false )const {
+         bool negative = (amount < 0);
+         uint64_t abs_amount = static_cast<uint64_t>(negative ? -amount : amount);
+         // 0 <= abs_amount <= std::numeric_limits<int64_t>::max() < 10^19 < std::numeric_limits<uint64_t>::max()
+
+         uint8_t precision = symbol.precision();
+
+         int sufficient_size = std::max(static_cast<int>(precision), 19) + 11;
+         if( dry_run || (begin + sufficient_size < begin) || (begin + sufficient_size > end) ) {
+            char* start_of_symbol = write_decimal( begin, end, true, abs_amount, precision, negative ) + 1;
+            char* actual_end = symbol.code().write_as_string( start_of_symbol, end, true );
+            if( dry_run || (actual_end < begin) || (actual_end > end) ) return actual_end;
+         }
+
+         char* end_of_number = write_decimal( begin, end, false, abs_amount, precision, negative );
+         *(end_of_number) = ' ';;
+
+         return symbol.code().write_as_string( end_of_number + 1, end );
+      }
+
+      /**
        * %asset to std::string
        *
        * @brief %asset to std::string
        */
       std::string to_string()const {
-         int64_t p = (int64_t)symbol.precision();
-         int64_t p10 = 1;
-         bool negative = false;
-         int64_t invert = 1;
+         int buffer_size = std::max(static_cast<int>(symbol.precision()), 19) + 11;
+         char buffer[buffer_size];
+         char* end = write_as_string( buffer, buffer + buffer_size );
+         check( end <= buffer + buffer_size, "insufficient space in buffer" ); // should never fail
 
-         while( p > 0  ) {
-            p10 *= 10; --p;
-         }
-         p = (int64_t)symbol.precision();
-
-         char fraction[p+1];
-         fraction[p] = '\0';
-
-         if (amount < 0) {
-            invert = -1;
-            negative = true;
-         }
-
-         auto change = (amount % p10) * invert;
-
-         for( int64_t i = p -1; i >= 0; --i ) {
-            fraction[i] = (change % 10) + '0';
-            change /= 10;
-         }
-         char str[p+32];
-         snprintf(str, sizeof(str), "%lld%s%s %s",
-            (int64_t)(amount/p10),
-            (fraction[0]) ? "." : "",
-            fraction,
-            symbol.code().to_string().c_str());
-         return {str};
+         return {buffer, end};
       }
 
       /**
@@ -362,7 +372,13 @@ namespace eosio {
        * @brief %Print the asset
        */
       void print()const {
-         ::eosio::print(to_string());
+         int buffer_size = std::max(static_cast<int>(symbol.precision()), 19) + 11;
+         char buffer[buffer_size];
+         char* end = write_as_string( buffer, buffer + buffer_size );
+         check( end <= buffer + buffer_size, "insufficient space in buffer" ); // should never fail
+
+         if( buffer < end )
+            printl( buffer, (end-buffer) );
       }
 
       EOSLIB_SERIALIZE( asset, (amount)(symbol) )

--- a/libraries/eosiolib/core/eosio/name.hpp
+++ b/libraries/eosiolib/core/eosio/name.hpp
@@ -187,21 +187,24 @@ namespace eosio {
       /**
        *  Writes the %name as a string to the provided char buffer
        *
-       *  @pre Appropriate Size Precondition: (begin + 13) <= end and (begin + 13) does not overflow
-       *  @pre Valid Memory Region Precondition: The range [begin, end) must be a valid range of memory to write to.
+       *  @pre The range [begin, end) must be a valid range of memory to write to.
        *  @param begin - The start of the char buffer
        *  @param end - Just past the end of the char buffer
-       *  @return char* - Just past the end of the last character written (returns begin if the Appropriate Size Precondition is not satisfied)
-       *  @post If the Appropriate Size Precondition is satisfied, the range [begin, returned pointer) contains the string representation of the %name.
+       *  @param dry_run - If true, do not actually write anything into the range.
+       *  @return char* - Just past the end of the last character that would be written assuming dry_run == false and end was large enough to provide sufficient space. (Meaning only applies if returned pointer >= begin.)
+       *  @post If the output string fits within the range [begin, end) and dry_run == false, the range [begin, returned pointer) contains the string representation of the %name. Nothing is written if dry_run == true or returned pointer > end (insufficient space) or if returned pointer < begin (overflow in calculating desired end).
        */
-      char* write_as_string( char* begin, char* end )const {
+      char* write_as_string( char* begin, char* end, bool dry_run = false )const {
          static const char* charmap = ".12345abcdefghijklmnopqrstuvwxyz";
          constexpr uint64_t mask = 0xF800000000000000ull;
 
-         if( (begin + 13) < begin || (begin + 13) > end ) return begin;
+         if( dry_run || (begin + 13 < begin) || (begin + 13 > end) ) {
+            char* actual_end = begin + length();
+            if( dry_run || (actual_end < begin) || (actual_end > end) ) return actual_end;
+         }
 
          auto v = value;
-         for( auto i = 0;   i < 13; ++i, v <<= 5 ) {
+         for( auto i = 0; i < 13; ++i, v <<= 5 ) {
             if( v == 0 ) return begin;
 
             auto indx = (v & mask) >> (i == 12 ? 60 : 59);

--- a/libraries/eosiolib/core/eosio/powers.hpp
+++ b/libraries/eosiolib/core/eosio/powers.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "check.hpp"
+
+#include <type_traits>
+#include <utility>
+#include <array>
+
+namespace eosio {
+
+   namespace detail {
+
+      template<typename Generator, std::size_t... Is>
+      constexpr auto generate_array_helper( Generator&& g, std::index_sequence<Is...> )
+      -> std::array<decltype(g(std::size_t{}, sizeof...(Is))), sizeof...(Is)>
+      {
+          return {{g(Is, sizeof...(Is))...}};
+      }
+
+      template<std::size_t N, typename Generator>
+      constexpr auto generate_array( Generator&& g ) {
+          return generate_array_helper( std::forward<Generator>(g), std::make_index_sequence<N>{} );
+      }
+
+      template<typename T, T Base, uint8_t Exponent, uint64_t Value, bool Overflow = (Value * Base < Value)>
+      struct largest_power_helper {
+      private:
+         static_assert( std::is_integral_v<T> && std::is_unsigned_v<T> &&!std::is_same_v<T, bool> );
+         static_assert( Base > 1 );
+         constexpr static T next_value = Value * Base;
+         using next = largest_power_helper<T, Base, Exponent+1, next_value>;
+      public:
+         constexpr static T       value    = next::value;
+         constexpr static uint8_t exponent = next::exponent;
+      };
+
+      template<typename T, T Base, uint8_t Exponent, uint64_t Value>
+      struct largest_power_helper<T, Base, Exponent, Value, true> {
+      private:
+         static_assert( std::is_integral_v<T> && std::is_unsigned_v<T> &&!std::is_same_v<T, bool> );
+         static_assert( Base > 1 );
+         static_assert( Exponent < 255 );
+      public:
+         constexpr static T       value    = Value;
+         constexpr static uint8_t exponent = Exponent;
+      };
+
+      template<typename T, T Base>
+      struct largest_power {
+      private:
+         using helper = largest_power_helper<T, Base, 0, 1>;
+      public:
+         constexpr static T       value    = helper::value;
+         constexpr static uint8_t exponent = helper::exponent;
+      };
+
+      template<typename T>
+      constexpr T pow( T base, uint8_t exponent ) {
+         if( base <= 1 ) check( false, "base must be at least 2" );
+         T prior  = 1;
+         T result = prior;
+         for( uint8_t i = 0; i < exponent; ++i, prior = result ) {
+            result = prior * base;
+            if( result <= prior ) check( false, "overflow" );
+         }
+         return result;
+      }
+
+      template<typename T, T Base>
+      constexpr T pow_generator( std::size_t i, std::size_t ) {
+         return pow( Base, static_cast<uint8_t>(i) );
+      }
+
+   }
+
+   template<uint8_t Base, typename T = uint64_t>
+   inline constexpr auto powers_of_base = detail::generate_array<detail::largest_power<T, Base>::exponent + 1>( detail::pow_generator<T, Base> );
+
+   /** @returns Base^exponent */
+   template<uint8_t Base, typename T = uint64_t>
+   constexpr T pow( uint8_t exponent ) {
+      const auto& lookup_table = powers_of_base<Base, T>;
+      if( exponent >= lookup_table.size() ) check( false, "overflow" );
+
+      return lookup_table[exponent];
+   }
+
+}

--- a/libraries/eosiolib/core/eosio/symbol.hpp
+++ b/libraries/eosiolib/core/eosio/symbol.hpp
@@ -125,17 +125,21 @@ namespace eosio {
        *
        *
        *  @brief Writes the symbol_code as a string to the provided char buffer
-       *  @pre Appropriate Size Precondition: (begin + 7) <= end and (begin + 7) does not overflow
-       *  @pre Valid Memory Region Precondition: The range [begin, end) must be a valid range of memory to write to.
+       *  @pre is_valid() == true
+       *  @pre The range [begin, end) must be a valid range of memory to write to.
        *  @param begin - The start of the char buffer
        *  @param end - Just past the end of the char buffer
-       *  @return char* - Just past the end of the last character written (returns begin if the Appropriate Size Precondition is not satisfied)
-       *  @post If the Appropriate Size Precondition is satisfied, the range [begin, returned pointer) contains the string representation of the symbol_code.
+       *  @param dry_run - If true, do not actually write anything into the range.
+       *  @return char* - Just past the end of the last character that would be written assuming dry_run == false and end was large enough to provide sufficient space. (Meaning only applies if returned pointer >= begin.)
+       *  @post If the output string fits within the range [begin, end) and dry_run == false, the range [begin, returned pointer) contains the string representation of the symbol_code. Nothing is written if dry_run == true or returned pointer > end (insufficient space) or if returned pointer < begin (overflow in calculating desired end).
        */
-      char* write_as_string( char* begin, char* end )const {
+      char* write_as_string( char* begin, char* end, bool dry_run = false )const {
          constexpr uint64_t mask = 0xFFull;
 
-         if( (begin + 7) < begin || (begin + 7) > end ) return begin;
+         if( dry_run || (begin + 7 < begin) || (begin + 7 > end) ) {
+            char* actual_end = begin + length();
+            if( dry_run || (actual_end < begin) || (actual_end > end) ) return actual_end;
+         }
 
          auto v = value;
          for( auto i = 0; i < 7; ++i, v >>= 8 ) {

--- a/libraries/eosiolib/eosiolib.cpp
+++ b/libraries/eosiolib/eosiolib.cpp
@@ -1,6 +1,9 @@
 #include "core/eosio/datastream.hpp"
+#include "core/eosio/powers.hpp"
 #include "contracts/eosio/system.hpp"
 #include "contracts/eosio/privileged.hpp"
+
+#include <algorithm>
 
 namespace eosio {
    extern "C" {
@@ -56,6 +59,72 @@ namespace eosio {
      std::vector<name> active_prods(prod_cnt);
      get_active_producers((uint64_t*)active_prods.data(), active_prods.size());
      return active_prods;
+   }
+
+   // powers.hpp
+   template const std::array<uint64_t, 20>  powers_of_base<10, uint64_t>;
+
+   /**
+    *  Writes a number as a string to the provided char buffer
+    *
+    *  @brief Writes number x 10^(-num_decimal_places) (optionally negative) as a string to the provided char buffer
+    *  @pre The range [begin, end) must be a valid range of memory to write to.
+    *  @param begin - The start of the char buffer
+    *  @param end - Just past the end of the char buffer
+    *  @param dry_run - If true, do not actually write anything into the range.
+    *  @param number - The number to print before shifting the decimal point to the left by num_decimal_places.
+    *  @param num_decimal_places - The number of decimal places to shift the decimal point.
+    *  @param negative - Whether to print a minus sign in the front.
+    *  @return char* - Just past the end of the last character that would be written assuming dry_run == false and end was large enough to provide sufficient space. (Meaning only applies if returned pointer >= begin.)
+    *  @post If the output string fits within the range [begin, end), the range [begin, returned pointer) contains the string representation of the number. Nothing is written if dry_run == true or returned pointer > end (insufficient space) or if returned pointer < begin (overflow in calculating desired end).
+    */
+   char* write_decimal( char* begin, char* end, bool dry_run, uint64_t number, uint8_t num_decimal_places, bool negative ) {
+      constexpr static uint8_t log10_max_uint64 = powers_of_base<10, uint64_t>.size() - 1; // 19
+      const auto& powers_of_ten = powers_of_base<10, uint64_t>;
+
+      uint8_t num_digits = (std::upper_bound( powers_of_ten.begin(), powers_of_ten.end(), number ) - powers_of_ten.begin()); // num_digits == 0 iff number == 0
+      // 0 <= num_digits <= 20
+
+      uint16_t characters_needed = std::max( num_digits, num_decimal_places );
+      uint16_t decimal_point_pos = num_digits;
+      if( num_decimal_places >= num_digits ) {
+         ++characters_needed; // space needing for additional leading zero digit
+         decimal_point_pos = 1;
+      } else {
+         decimal_point_pos -= num_decimal_places;
+      }
+      if( num_decimal_places > 0 ) ++characters_needed; // space for decimal point
+      uint16_t after_minus_pos = 0;
+      if( negative ) {
+         ++characters_needed; // space for minus sign
+         ++after_minus_pos;
+         ++decimal_point_pos;
+      }
+      // 1 <= characters_needed <= 258
+      // 1 <= decimal_point_pos <= num_digits + 1 <= 21
+
+      char* actual_end = begin + characters_needed;
+      if( dry_run || (actual_end < begin) || (actual_end > end) ) return actual_end;
+
+      int i = characters_needed - 1;
+      for( ; number > 0 && i > decimal_point_pos; --i ) {
+         *(begin + i) = (number % 10) + '0';
+         number /= 10;
+      }
+      for( ; i > decimal_point_pos; --i ) {
+         *(begin + i) = '0';
+      }
+      if( i == decimal_point_pos ) {
+         *(begin + i) = '.';
+         --i;
+      }
+      for( ; i >= after_minus_pos; --i ) {
+         *(begin + i) = (number % 10) + '0';
+         number /= 10;
+      }
+      if( i == 0 ) *(begin + i) = '-';
+
+      return actual_end;
    }
 
 } // namespace eosio

--- a/libraries/eosiolib/symbol.hpp
+++ b/libraries/eosiolib/symbol.hpp
@@ -126,17 +126,21 @@ namespace eosio {
        *
        *
        *  @brief Writes the symbol_code as a string to the provided char buffer
-       *  @pre Appropriate Size Precondition: (begin + 7) <= end and (begin + 7) does not overflow
-       *  @pre Valid Memory Region Precondition: The range [begin, end) must be a valid range of memory to write to.
+       *  @pre is_valid() == true
+       *  @pre The range [begin, end) must be a valid range of memory to write to.
        *  @param begin - The start of the char buffer
        *  @param end - Just past the end of the char buffer
-       *  @return char* - Just past the end of the last character written (returns begin if the Appropriate Size Precondition is not satisfied)
-       *  @post If the Appropriate Size Precondition is satisfied, the range [begin, returned pointer) contains the string representation of the symbol_code.
+       *  @param dry_run - If true, do not actually write anything into the range.
+       *  @return char* - Just past the end of the last character that would be written assuming dry_run == false and end was large enough to provide sufficient space. (Meaning only applies if returned pointer >= begin.)
+       *  @post If the output string fits within the range [begin, end) and dry_run == false, the range [begin, returned pointer) contains the string representation of the symbol_code. Nothing is written if dry_run == true or returned pointer > end (insufficient space) or if returned pointer < begin (overflow in calculating desired end).
        */
-      char* write_as_string( char* begin, char* end )const {
+      char* write_as_string( char* begin, char* end, bool dry_run = false )const {
          constexpr uint64_t mask = 0xFFull;
 
-         if( (begin + 7) < begin || (begin + 7) > end ) return begin;
+         if( dry_run || (begin + 7 < begin) || (begin + 7 > end) ) {
+            char* actual_end = begin + length();
+            if( dry_run || (actual_end < begin) || (actual_end > end) ) return actual_end;
+         }
 
          auto v = value;
          for( auto i = 0; i < 7; ++i, v >>= 8 ) {

--- a/tests/unit/asset_tests.cpp
+++ b/tests/unit/asset_tests.cpp
@@ -122,15 +122,29 @@ EOSIO_TEST_BEGIN(asset_type_test)
 
    CHECK_EQUAL( (asset{ 1LL, sym_no_prec}.to_string()),  "1 SYMBOLL" )
    CHECK_EQUAL( (asset{-1LL, sym_no_prec}.to_string()), "-1 SYMBOLL" )
+   CHECK_EQUAL( (asset{-1LL, symbol{"SYMBOLL", 1}}.to_string()), "-0.1 SYMBOLL" )
+   CHECK_EQUAL( (asset{ 1LL, symbol{"SYMBOLL", 1}}.to_string()),  "0.1 SYMBOLL" )
+   CHECK_EQUAL( (asset{-12LL, sym_no_prec}.to_string()), "-12 SYMBOLL" )
+   CHECK_EQUAL( (asset{ 12LL, sym_no_prec}.to_string()),  "12 SYMBOLL" )
+   CHECK_EQUAL( (asset{-123LL, sym_no_prec}.to_string()), "-123 SYMBOLL" )
+   CHECK_EQUAL( (asset{ 123LL, sym_no_prec}.to_string()),  "123 SYMBOLL" )
+   CHECK_EQUAL( (asset{-12LL, symbol{"SYMBOLL", 2}}.to_string()), "-0.12 SYMBOLL" )
+   CHECK_EQUAL( (asset{ 12LL, symbol{"SYMBOLL", 2}}.to_string()),  "0.12 SYMBOLL" )
+   CHECK_EQUAL( (asset{-12LL, symbol{"SYMBOLL", 1}}.to_string()), "-1.2 SYMBOLL" )
+   CHECK_EQUAL( (asset{ 12LL, symbol{"SYMBOLL", 1}}.to_string()),  "1.2 SYMBOLL" )
+   CHECK_EQUAL( (asset{-123LL, symbol{"SYMBOLL", 2}}.to_string()), "-1.23 SYMBOLL" )
+   CHECK_EQUAL( (asset{ 123LL, symbol{"SYMBOLL", 2}}.to_string()),  "1.23 SYMBOLL" )
    CHECK_EQUAL( (asset{ 1LL, sym_prec}.to_string()),
                 "0.000000000000000000000000000000000000000000000000000000000000001 SYMBOLL" )
    CHECK_EQUAL( (asset{-1LL, sym_prec}.to_string()),
-                "0.000000000000000000000000000000000000000000000000000000000000001 SYMBOLL" )
+                "-0.000000000000000000000000000000000000000000000000000000000000001 SYMBOLL" )
 
    CHECK_EQUAL( (asset{asset_min, sym_no_prec}.to_string()), "-4611686018427387903 SYMBOLL" )
    CHECK_EQUAL( (asset{asset_max, sym_no_prec}.to_string()),  "4611686018427387903 SYMBOLL" )
+   CHECK_EQUAL( (asset{asset_min, symbol{"SYMBOLL", 2}}.to_string()), "-46116860184273879.03 SYMBOLL" )
+   CHECK_EQUAL( (asset{asset_max, symbol{"SYMBOLL", 2}}.to_string()),  "46116860184273879.03 SYMBOLL" )
    CHECK_EQUAL( (asset{asset_min, sym_prec}.to_string()),
-                "0.000000000000000000000000000000000000000000004611686018427387903 SYMBOLL" )
+                "-0.000000000000000000000000000000000000000000004611686018427387903 SYMBOLL" )
    CHECK_EQUAL( (asset{asset_max, sym_prec}.to_string()),
                 "0.000000000000000000000000000000000000000000004611686018427387903 SYMBOLL" )
 
@@ -156,7 +170,7 @@ EOSIO_TEST_BEGIN(asset_type_test)
           asset{1LL, sym_prec}.print();
        })
     )
-    CHECK_PRINT( "0.000000000000000000000000000000000000000000000000000000000000001 SYMBOLL", (
+    CHECK_PRINT( "-0.000000000000000000000000000000000000000000000000000000000000001 SYMBOLL", (
        [&]() {
           asset{-1LL, sym_prec}.print();
        })
@@ -164,7 +178,7 @@ EOSIO_TEST_BEGIN(asset_type_test)
 
     CHECK_PRINT( "-4611686018427387903 SYMBOLL", [&](){asset{asset_min, sym_no_prec}.print();} );
     CHECK_PRINT(  "4611686018427387903 SYMBOLL", [&](){asset{asset_max, sym_no_prec}.print();} );
-    CHECK_PRINT(  "0.000000000000000000000000000000000000000000004611686018427387903 SYMBOLL", (
+    CHECK_PRINT(  "-0.000000000000000000000000000000000000000000004611686018427387903 SYMBOLL", (
        [&]() {
           asset{asset_min, sym_prec}.print();
        })


### PR DESCRIPTION
## Change Description

Changes in this PR:
- Added `asset::write_as_string` member function which allows for efficiently writing out the asset into a character buffer. (`asset::to_string` and `asset::print` have been reimplemented to now use this new `asset::write_as_string` function.)
- Modifed all `write_as_string` member functions (in `name`, `symbol_code`, and `asset`) to take an optional `dry_run` parameter and to be less strict with their preconditions. 
-  Fixed the few test cases in `asset_tests` that were comparing the string representation of specific assets with negative quantities to incorrect expected values. (Similar to #557).
- Added additional test cases to `asset_tests`.

This PR acts as an alternative to #650.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions

