### PR TITLE
WebAuthN Support

### DIFF
--- a/libraries/eosiolib/capi/eosio/types.h
+++ b/libraries/eosiolib/capi/eosio/types.h
@@ -32,14 +32,16 @@ typedef uint64_t capi_name;
 /**
  * EOSIO Public Key. K1 and R1 keys are 34 bytes.  Newer keys can be variable-sized
  */
-struct capi_public_key __attribute__((deprecated("newer public key types cannot be represented as a fixed size structure", "char[]"))) {
+struct __attribute__((deprecated("newer public key types cannot be represented as a fixed size structure", "char[]")))
+capi_public_key {
    char data[34];
 };
 
 /**
  * EOSIO Signature. K1 and R1 signatures are 66 bytes. Newer signatures can be variable-sized
  */
-struct capi_signature __attribute__((deprecated("newer signature types cannot be represented as a fixed size structure", "char[]"))) {
+struct __attribute__((deprecated("newer signature types cannot be represented as a fixed size structure", "char[]")))
+capi_signature {
    uint8_t data[66];
 };
 

--- a/libraries/eosiolib/capi/eosio/types.h
+++ b/libraries/eosiolib/capi/eosio/types.h
@@ -30,16 +30,16 @@
 typedef uint64_t capi_name;
 
 /**
- * EOSIO Public Key. It is 34 bytes.
+ * EOSIO Public Key. K1 and R1 keys are 34 bytes.  Newer keys can be variable-sized
  */
-struct capi_public_key {
+struct capi_public_key __attribute__((deprecated("newer public key types cannot be represented as a fixed size structure", "char[]"))) {
    char data[34];
 };
 
 /**
- * EOSIO Signature. It is 66 bytes.
+ * EOSIO Signature. K1 and R1 signatures are 66 bytes. Newer signatures can be variable-sized
  */
-struct capi_signature {
+struct capi_signature __attribute__((deprecated("newer signature types cannot be represented as a fixed size structure", "char[]"))) {
    uint8_t data[66];
 };
 

--- a/libraries/eosiolib/core/eosio/crypto.hpp
+++ b/libraries/eosiolib/core/eosio/crypto.hpp
@@ -60,6 +60,17 @@ namespace eosio {
        * @see https://w3c.github.io/webauthn/#relying-party-identifier
        */
       std::string        rpid;
+
+      /// @cond OPERATORS
+
+      friend bool operator == ( const webauthn_public_key& a, const webauthn_public_key& b ) {
+         return std::tie(a.key,a.user_presence,a.rpid) == std::tie(b.key,b.user_presence,b.rpid);
+      }
+      friend bool operator != ( const webauthn_public_key& a, const webauthn_public_key& b ) {
+         return std::tie(a.key,a.user_presence,a.rpid) != std::tie(b.key,b.user_presence,b.rpid);
+      }
+
+      /// @cond
    };
 
    /**
@@ -147,6 +158,17 @@ namespace eosio {
        * @see https://w3c.github.io/webauthn/#dictdef-collectedclientdata
        */
       std::string                       client_json;
+
+      /// @cond OPERATORS
+
+      friend bool operator == ( const webauthn_signature& a, const webauthn_signature& b ) {
+         return std::tie(a.compact_signature,a.auth_data,a.client_json) == std::tie(b.compact_signature,b.auth_data,b.client_json);
+      }
+      friend bool operator != ( const webauthn_signature& a, const webauthn_signature& b ) {
+         return std::tie(a.compact_signature,a.auth_data,a.client_json) != std::tie(b.compact_signature,b.auth_data,b.client_json);
+      }
+
+      /// @cond
    };
 
    /**

--- a/libraries/eosiolib/core/eosio/datastream.hpp
+++ b/libraries/eosiolib/core/eosio/datastream.hpp
@@ -340,7 +340,7 @@ void deserialize(datastream<Stream>& ds, std::variant<Ts...>& var, int i) {
       if (i == I) {
          std::variant_alternative_t<I, std::variant<Ts...>> tmp;
          ds >> tmp;
-         var = std::move(tmp);
+         var.template emplace<I>(std::move(tmp));
       } else {
          deserialize<I+1>(ds,var,i);
       }

--- a/libraries/eosiolib/types.h
+++ b/libraries/eosiolib/types.h
@@ -31,14 +31,16 @@ typedef uint64_t capi_name;
 /**
  * EOSIO Public Key. K1 and R1 keys are 34 bytes.  Newer keys can be variable-sized
  */
-struct capi_public_key __attribute__((deprecated("newer public key types cannot be represented as a fixed size structure", "char[]"))) {
+struct __attribute__((deprecated("newer public key types cannot be represented as a fixed size structure", "char[]")))
+capi_public_key {
    char data[34];
 };
 
 /**
  * EOSIO Signature. K1 and R1 signatures are 66 bytes. Newer signatures can be variable-sized
  */
-struct capi_signature __attribute__((deprecated("newer signature types cannot be represented as a fixed size structure", "char[]"))) {
+struct __attribute__((deprecated("newer signature types cannot be represented as a fixed size structure", "char[]")))
+capi_signature {
    uint8_t data[66];
 };
 

--- a/libraries/eosiolib/types.h
+++ b/libraries/eosiolib/types.h
@@ -29,16 +29,16 @@ extern "C" {
 typedef uint64_t capi_name;
 
 /**
- * EOSIO Public Key. It is 34 bytes.
+ * EOSIO Public Key. K1 and R1 keys are 34 bytes.  Newer keys can be variable-sized
  */
-struct capi_public_key {
+struct capi_public_key __attribute__((deprecated("newer public key types cannot be represented as a fixed size structure", "char[]"))) {
    char data[34];
 };
 
 /**
- * EOSIO Signature. It is 66 bytes.
+ * EOSIO Signature. K1 and R1 signatures are 66 bytes. Newer signatures can be variable-sized
  */
-struct capi_signature {
+struct capi_signature __attribute__((deprecated("newer signature types cannot be represented as a fixed size structure", "char[]"))) {
    uint8_t data[66];
 };
 

--- a/tests/unit/crypto_tests.cpp
+++ b/tests/unit/crypto_tests.cpp
@@ -13,26 +13,26 @@ using eosio::signature;
 EOSIO_TEST_BEGIN(public_key_type_test)
    // -----------------------------------------------------
    // bool operator==(const public_key&, const public_key&)
-   CHECK_EQUAL( (public_key{0, std::array<char, 33>{}}  == public_key{0, std::array<char, 33>{}}), true  )
-   CHECK_EQUAL( (public_key{0, std::array<char, 33>{1}} == public_key{0, std::array<char, 33>{}}), false )
+   CHECK_EQUAL( (public_key(std::in_place_index<0>, std::array<char, 33>{})  == public_key(std::in_place_index<0>, std::array<char, 33>{})), true  )
+   CHECK_EQUAL( (public_key(std::in_place_index<0>, std::array<char, 33>{1}) == public_key(std::in_place_index<0>, std::array<char, 33>{})), false )
 
    // -----------------------------------------------------
    // bool operator!=(const public_key&, const public_key&)
-   CHECK_EQUAL( (public_key{0, std::array<char, 33>{}}  != public_key{0, std::array<char, 33>{}}), false )
-   CHECK_EQUAL( (public_key{0, std::array<char, 33>{1}} != public_key{0, std::array<char, 33>{}}), true  )
+   CHECK_EQUAL( (public_key(std::in_place_index<0>, std::array<char, 33>{})  != public_key(std::in_place_index<0>, std::array<char, 33>{})), false )
+   CHECK_EQUAL( (public_key(std::in_place_index<0>, std::array<char, 33>{1}) != public_key(std::in_place_index<0>, std::array<char, 33>{})), true  )
 EOSIO_TEST_END
 
 // Definitions in `eosio.cdt/libraries/eosio/crypto.hpp`
 EOSIO_TEST_BEGIN(signature_type_test)
    // ---------------------------------------------------
    // bool operator==(const signature&, const signature&)
-   CHECK_EQUAL( (signature{0, std::array<char, 65>{}}  == signature{0, std::array<char, 65>{}}), true  )
-   CHECK_EQUAL( (signature{0, std::array<char, 65>{1}} == signature{0, std::array<char, 65>{}}), false )
+   CHECK_EQUAL( (signature(std::in_place_index<0>, std::array<char, 65>{})  == signature(std::in_place_index<0>, std::array<char, 65>{})), true  )
+   CHECK_EQUAL( (signature(std::in_place_index<0>, std::array<char, 65>{1}) == signature(std::in_place_index<0>, std::array<char, 65>{})), false )
 
    // ---------------------------------------------------
    // bool operator!=(const signature&, const signature&)
-   CHECK_EQUAL( (signature{0, std::array<char, 65>{1}} != signature{0, std::array<char, 65>{}}), true  )
-   CHECK_EQUAL( (signature{0, std::array<char, 65>{}}  != signature{0, std::array<char, 65>{}}), false )
+   CHECK_EQUAL( (signature(std::in_place_index<0>, std::array<char, 65>{1}) != signature(std::in_place_index<0>, std::array<char, 65>{})), true  )
+   CHECK_EQUAL( (signature(std::in_place_index<0>, std::array<char, 65>{})  != signature(std::in_place_index<0>, std::array<char, 65>{})), false )
 EOSIO_TEST_END
 
 int main(int argc, char* argv[]) {

--- a/tests/unit/datastream_tests.cpp
+++ b/tests/unit/datastream_tests.cpp
@@ -39,7 +39,9 @@ using eosio::ignore;
 using eosio::ignore_wrapper;
 using eosio::pack;
 using eosio::pack_size;
+using eosio::ecc_public_key;
 using eosio::public_key;
+using eosio::ecc_signature;
 using eosio::signature;
 using eosio::symbol;
 using eosio::symbol_code;
@@ -507,7 +509,7 @@ EOSIO_TEST_BEGIN(datastream_stream_test)
    // eosio::public_key
    ds.seekp(0);
    fill(begin(datastream_buffer), end(datastream_buffer), 0);
-   static const public_key cpubkey{{},'a','b','c','d','e','f','g','h','i'};
+   static const public_key cpubkey(std::in_place_index<0>,ecc_public_key{'a','b','c','d','e','f','g','h','i'});
    public_key pubkey{};
    ds << cpubkey;
    ds.seekp(0);
@@ -518,7 +520,7 @@ EOSIO_TEST_BEGIN(datastream_stream_test)
    // eosio::signature
    ds.seekp(0);
    fill(begin(datastream_buffer), end(datastream_buffer), 0);
-   static const signature csig{{},'a','b','c','d','e','f','g','h','i'};
+   static const signature csig(std::in_place_index<0>,ecc_signature{'a','b','c','d','e','f','g','h','i'});
    signature sig{};
    ds << csig;
    ds.seekp(0);


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Added support for WebAuthN keys and signatures to the c++ wrapper types.  Deprecated the fixed size `capi_` types for both signature and public_key as they are no longer sufficient to represent the potentially variable-sized keys in the future

## API Changes
- [x] API Changes
The c++ types for `eosio::signature` and `eosio::public_key` are different.  Before these were simple structs with public fields for the "which" type of public key and underlying buffer of bytes, these are now variants of either an `std::array<char, 65>` or a `webauthn_signature` and `std::array<char, 33>` or a `webauthn_public_key` respectively.
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->

The c++ types for `eosio::signature` and `eosio::public_key` have become significantly more complex to handle the unexposed details of what those data types really were.  This resulted in shifting the types to `std::variant` and creating (sometimes shared) sub-types to represent the underlying types. Need to review the docs to make sure its reasonably legible. 
