### PR TITLE
More native tester macro fixes develop

### DIFF
--- a/libraries/eosiolib/core/eosio/string.hpp
+++ b/libraries/eosiolib/core/eosio/string.hpp
@@ -22,10 +22,12 @@ namespace eosio {
 
       template <size_t N>
       constexpr string(const char (&str)[N]) : _size{N-1}, _capacity{_size}, _begin{str}
-      { }
+      {
+      }
 
       constexpr string() : _size{0}, _capacity{0}, _begin{""}
-      { }
+      {
+      }
 
       constexpr string(const char* str, const size_t n) : _size{n}, _capacity{_size*2} {
          char* begin{new char[_capacity]};
@@ -255,7 +257,7 @@ namespace eosio {
       void pop_back() {
          if (_size == 0)
             return;
-         --_size;
+         resize(--_size);
       }
 
       string substr(size_t pos = 0, size_t len = npos) const {
@@ -319,6 +321,7 @@ namespace eosio {
          if (is_literal())
             clone(_size, _capacity, std::get<const char*>(_begin));
          memmove(std::get<uptr>(_begin).get()+pos+len, std::get<uptr>(_begin).get(), len);
+         resize(_size);
 
          return *this;
       }

--- a/libraries/eosiolib/core/eosio/string.hpp
+++ b/libraries/eosiolib/core/eosio/string.hpp
@@ -21,27 +21,42 @@ namespace eosio {
       static constexpr size_t npos = -1;
 
       template <size_t N>
-      constexpr string(const char (&str)[N]) : _size{N-1}, _capacity{_size}, _begin{str}
+      constexpr string(const char (&str)[N])
+         : _size{N-1}
+         , _capacity{_size}
+         , _begin{str}
       {
       }
 
-      constexpr string() : _size{0}, _capacity{0}, _begin{""}
+      constexpr string()
+         : _size{0}
+         , _capacity{0}
+         , _begin{""}
       {
       }
 
-      constexpr string(const char* str, const size_t n) : _size{n}, _capacity{_size*2} {
+      constexpr string(const char* str, const size_t n)
+         : _size{n}
+         , _capacity{_size*2}
+      {
          char* begin{new char[_capacity]};
          memcpy(begin, str, _size);
          _begin = begin;
       }
 
-      constexpr string(const size_t n, const char c) : _size{n}, _capacity{_size*2} {
+      constexpr string(const size_t n, const char c)
+         : _size{n}
+         , _capacity{_size*2}
+      {
          char* begin{new char[_capacity]};
          memset(begin, c, _size);
          _begin = begin;
       }
 
-      constexpr string(const string& str, const size_t pos, const size_t n) : _size{n}, _capacity{_size*2} {
+      constexpr string(const string& str, const size_t pos, const size_t n)
+         : _size{n}
+         , _capacity{_size*2}
+      {
          if (n == string::npos || str._size < pos+n) {
             _size     = str._size;
             _capacity = _size*2;
@@ -50,14 +65,20 @@ namespace eosio {
          clone(_size, _capacity, str.data()+pos);
       }
 
-      constexpr string(const string& str) : _size{str._size}, _capacity{str._capacity} {
+      constexpr string(const string& str)
+         : _size{str._size}
+         , _capacity{str._capacity}
+      {
          if (str.is_literal())
             _begin = std::get<const char*>(str._begin);
          else
             clone(str._size, str._capacity, str.data());
       }
 
-      constexpr string(string&& str) : _size{str._size}, _capacity{str._capacity} {
+      constexpr string(string&& str)
+         : _size{str._size}
+         , _capacity{str._capacity}
+      {
          if (str.is_literal())
             _begin = std::get<const char*>(str._begin);
          else

--- a/libraries/eosiolib/core/eosio/symbol.hpp
+++ b/libraries/eosiolib/core/eosio/symbol.hpp
@@ -302,7 +302,7 @@ namespace eosio {
          char buffer[7];
          auto end = code().write_as_string( buffer, buffer + sizeof(buffer) );
          if( buffer < end )
-            ::eosio::print( buffer, (end-buffer) );
+            printl( buffer, (end-buffer) );
       }
 
       /**

--- a/libraries/native/native/eosio/tester.hpp
+++ b/libraries/native/native/eosio/tester.hpp
@@ -66,7 +66,7 @@ inline bool expect_print(bool check, const std::string& li, Pred&& pred, F&& fun
    if (!check)
       eosio::check(passed, std::string("error : wrong print message {"+li+"}").c_str());
    if (!passed)
-      eosio::print("error : wrong print message9 {"+li+"}\n");
+      eosio::print("error : wrong print message {"+li+"}\n");
    silence_output(disable_out);
    return passed;
 }
@@ -81,13 +81,13 @@ inline bool expect_print(bool check, const std::string& li, const char (&expecte
 }
 
 #define CHECK_ASSERT(...) \
-   ___has_failed &= expect_assert(true, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)), __VA_ARGS__);
+   ___has_failed |= !expect_assert(true, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)), __VA_ARGS__);
 
 #define REQUIRE_ASSERT(...) \
    expect_assert(false, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)),  __VA_ARGS__);
 
 #define CHECK_PRINT(...) \
-   ___has_failed &= expect_print(true, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)), __VA_ARGS__);
+   ___has_failed |= !expect_print(true, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)), __VA_ARGS__);
 
 #define REQUIRE_PRINT(...) \
    expect_print(false, std::string(__FILE__)+":"+__func__+":"+(std::to_string(__LINE__)),  __VA_ARGS__);

--- a/tests/unit/string_tests.cpp
+++ b/tests/unit/string_tests.cpp
@@ -15,8 +15,6 @@ using eosio::string;
 
 // Definitions found in `eosio.cdt/libraries/eosiolib/core/eosio/string.hpp`
 EOSIO_TEST_BEGIN(string_test)
-   silence_output(false);
-
    //// template <size_t N>
    //// string(const char (&str)[N])
    {
@@ -1025,7 +1023,7 @@ EOSIO_TEST_BEGIN(string_test)
       CHECK_EQUAL( eostr.size(), 6 )
       CHECK_EQUAL( eostr.capacity(), 12 )
       CHECK_EQUAL( strcmp(eostr.c_str(), "0hello") , 0 )
-         
+
       eostr.insert(0, "h", 1);
       CHECK_EQUAL( eostr.size(), 7 )
       CHECK_EQUAL( eostr.capacity(), 12 )
@@ -1494,11 +1492,15 @@ EOSIO_TEST_BEGIN(string_test)
       ds >> str;
       CHECK_EQUAL( cstr, str )
    }
-
-silence_output(false);
 EOSIO_TEST_END
 
-int main() {
+int main(int argc, char* argv[]) {
+   bool verbose = false;
+   if( argc >= 2 && std::strcmp( argv[1], "-v" ) == 0 ) {
+      verbose = true;
+   }
+   silence_output(!verbose);
+
    EOSIO_TEST(string_test)
    return has_failed();
 }

--- a/tests/unit/string_tests.cpp
+++ b/tests/unit/string_tests.cpp
@@ -354,8 +354,7 @@ EOSIO_TEST_BEGIN(string_test)
       CHECK_EQUAL( eostr.at(0), 'a' )
       CHECK_EQUAL( eostr.at(5), 'f' )
 
-      CHECK_ASSERT( "eosio::string::at", []() {eostr.at(6);} )
-                    
+      CHECK_ASSERT( "eosio::string::at", []() {eostr.at(6);} )                    
    }
 
    //// const char& at(const size_t n) const

--- a/tests/unit/string_tests.cpp
+++ b/tests/unit/string_tests.cpp
@@ -354,7 +354,8 @@ EOSIO_TEST_BEGIN(string_test)
       CHECK_EQUAL( eostr.at(0), 'a' )
       CHECK_EQUAL( eostr.at(5), 'f' )
 
-      CHECK_ASSERT( "eostring::string::at", []() {eostr.at(6);} )
+      CHECK_ASSERT( "eosio::string::at", []() {eostr.at(6);} )
+                    
    }
 
    //// const char& at(const size_t n) const
@@ -363,7 +364,7 @@ EOSIO_TEST_BEGIN(string_test)
       CHECK_EQUAL( eostr.at(0), 'a' )
       CHECK_EQUAL( eostr.at(5), 'f' )
 
-      CHECK_ASSERT( "eostring::string::at const", []() {eostr.at(6);} )
+      CHECK_ASSERT( "eosio::string::at const", []() {eostr.at(6);} )
    }
 
    {
@@ -794,7 +795,7 @@ EOSIO_TEST_BEGIN(string_test)
    {
       static const string eostr{"abcdef"};
       static char str[7]{};
-      CHECK_ASSERT( "eostring::string::copy", []() {eostr.copy(str, 1, eostr.size()+1);} )
+      CHECK_ASSERT( "eosio::string::copy", []() {eostr.copy(str, 1, eostr.size()+1);} )
    }
 
    //// string& insert(const size_t pos, const char* str)
@@ -861,8 +862,8 @@ EOSIO_TEST_BEGIN(string_test)
    {
       static string eostr{"abcdefg"};
       static const char* null_man{nullptr};
-      CHECK_ASSERT( "eostring::string::insert", []() {eostr.insert(0, null_man, 1);} )
-      CHECK_ASSERT( "eostring::string::insert", []() {eostr.insert(-1, "ooo", 1);} )
+      CHECK_ASSERT( "eosio::string::insert", []() {eostr.insert(0, null_man, 1);} )
+      CHECK_ASSERT( "eosio::string::insert", []() {eostr.insert(-1, "ooo", 1);} )
    }
 
    //// string& insert(const size_t pos, const string& str)
@@ -932,7 +933,7 @@ EOSIO_TEST_BEGIN(string_test)
    {
       static string eostr{"abcdefg"};
       static const string str{"ooo"};
-      CHECK_ASSERT( "eostring::string::insert", []() {eostr.insert(-1, str);} )
+      CHECK_ASSERT( "eosio::string::insert", []() {eostr.insert(-1, str);} )
    }
 
    {
@@ -1014,7 +1015,7 @@ EOSIO_TEST_BEGIN(string_test)
    {
       static string eostr{"abcdefg"};
       static string str{"ooo"};
-      CHECK_ASSERT( "eostring::string::insert", []() {eostr.insert(-1, str);} )
+      CHECK_ASSERT( "eosio::string::insert", []() {eostr.insert(-1, str);} )
    }
 
    {  // Bucky's test for bug he caught; PR #459.
@@ -1117,7 +1118,7 @@ EOSIO_TEST_BEGIN(string_test)
 
    {
       static string eostr{"abcdefg"};
-      CHECK_ASSERT( "eostring::string::erase", []() {eostr.erase(-1, 1);} )
+      CHECK_ASSERT( "eosio::string::erase", []() {eostr.erase(-1, 1);} )
    }
 
    {
@@ -1230,7 +1231,7 @@ EOSIO_TEST_BEGIN(string_test)
 
    {
       static string eostr{"abcdefg"};
-      CHECK_ASSERT( "eostring::string::erase", []() {eostr.erase(-1, 1);} )
+      CHECK_ASSERT( "eosio::string::erase", []() {eostr.erase(-1, 1);} )
    }
 
    //// string& append(const char* str)
@@ -1255,7 +1256,7 @@ EOSIO_TEST_BEGIN(string_test)
    {
       static string eostr{"abcdefg"};
       static const char* null_man{nullptr};
-      CHECK_ASSERT( "eostring::string::append", []() {eostr.append(null_man);} )
+      CHECK_ASSERT( "eosio::string::append", []() {eostr.append(null_man);} )
    }
 
    //// string& append(const string& str)

--- a/tests/unit/symbol_tests.cpp
+++ b/tests/unit/symbol_tests.cpp
@@ -192,12 +192,10 @@ EOSIO_TEST_BEGIN(symbol_type_test)
 
    // ---------------------
    // void print(bool)const
-   // Note:
-   // This function prints the length of the symbol at the very end
-   CHECK_PRINT( "0,A1", [&](){symbol{"A", 0}.print(true);} );
-   CHECK_PRINT( "0,Z1", [&](){symbol{"Z", 0}.print(true);} );
-   CHECK_PRINT( "255,AAAAAAA7", [&](){symbol{"AAAAAAA", 255}.print(true);} );
-   CHECK_PRINT( "255,ZZZZZZZ7", [&](){symbol{"ZZZZZZZ", 255}.print(true);} );
+   CHECK_PRINT( "0,A", [&](){symbol{"A", 0}.print(true);} );
+   CHECK_PRINT( "0,Z", [&](){symbol{"Z", 0}.print(true);} );
+   CHECK_PRINT( "255,AAAAAAA", [&](){symbol{"AAAAAAA", 255}.print(true);} );
+   CHECK_PRINT( "255,ZZZZZZZ", [&](){symbol{"ZZZZZZZ", 255}.print(true);} );
 
    // --------------------------------------------------------------
    // friend constexpr bool operator==(const symbol&, const symbol&)


### PR DESCRIPTION
## Change Description

- Fixed bug in `CHECK_ASSERT` and `CHECK_PRINT` macros which could undo a prior recording of a failure.
- Fixed bug in `symbol::print` which used the wrong function to print the symbol code. (This bug was exposed from a test failure in `symbol_tests` after the `CHECK_PRINT` function was fixed.)
- Corrected the `symbol_tests` unit test to use the proper expected print messages.
- Fixed bugs in `eosio::string::pop_back` and `eosio::string::erase`. 
- Corrected wrong expected assert message in `string_tests`.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
