### PR TITLE
Fix upper_bound documentation - develop

### DIFF
--- a/libraries/eosiolib/contracts/eosio/multi_index.hpp
+++ b/libraries/eosiolib/contracts/eosio/multi_index.hpp
@@ -1246,7 +1246,7 @@ class multi_index
       }
 
       /**
-       *  Searches for the `object_type` with the highest primary key that is less than or equal to a given primary key.
+       *  Searches for the `object_type` with the lowest primary key that is greater than a given primary key.
        *  @ingroup multiindex
        *
        *  @param primary - Primary key that establishes the target value for the upper bound search


### PR DESCRIPTION
## Change Description

Fixes inaccurate documentation of `multi_index::upper_bound`. Applies fixes of #580 to the other copy of `multi_index.hpp` in eosiolib. 

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
