### PR TITLE
Fix recover key wrappers in light of variable-sized keys and sigs

### DIFF
--- a/libraries/eosiolib/crypto.cpp
+++ b/libraries/eosiolib/crypto.cpp
@@ -92,37 +92,37 @@ namespace eosio {
    eosio::public_key recover_key( const eosio::checksum256& digest, const eosio::signature& sig ) {
       auto digest_data = digest.extract_as_byte_array();
 
-      char sig_data[70];
-      eosio::datastream<char*> sig_ds( sig_data, sizeof(sig_data) );
-      auto sig_begin = sig_ds.pos();
-      sig_ds << sig;
+      auto sig_data = eosio::pack(sig);
 
-      char pubkey_data[38];
+      char optimistic_pubkey_data[256];
       size_t pubkey_size = ::recover_key( reinterpret_cast<const capi_checksum256*>(digest_data.data()),
-                                          sig_begin, (sig_ds.pos() - sig_begin),
-                                          pubkey_data, sizeof(pubkey_data) );
-      eosio::datastream<char*> pubkey_ds( pubkey_data, pubkey_size );
+                                          sig_data.data(), sig_data.size(),
+                                          optimistic_pubkey_data, sizeof(optimistic_pubkey_data) );
+
       eosio::public_key pubkey;
-      pubkey_ds >> pubkey;
+      if ( pubkey_size <= sizeof(optimistic_pubkey_data) ) {
+         eosio::datastream<char*> pubkey_ds( optimistic_pubkey_data, pubkey_size );
+         pubkey_ds >> pubkey;
+      } else {
+         char pubkey_data[pubkey_size];
+         ::recover_key( reinterpret_cast<const capi_checksum256*>(digest_data.data()),
+                        sig_data.data(), sig_data.size(),
+                        pubkey_data, pubkey_size );
+         eosio::datastream<char*> pubkey_ds( pubkey_data, pubkey_size );
+         pubkey_ds >> pubkey;
+      }
       return pubkey;
    }
 
    void assert_recover_key( const eosio::checksum256& digest, const eosio::signature& sig, const eosio::public_key& pubkey ) {
       auto digest_data = digest.extract_as_byte_array();
 
-      char sig_data[70];
-      eosio::datastream<char*> sig_ds( sig_data, sizeof(sig_data) );
-      auto sig_begin = sig_ds.pos();
-      sig_ds << sig;
-
-      char pubkey_data[38];
-      eosio::datastream<char*> pubkey_ds( pubkey_data, sizeof(pubkey_data) );
-      auto pubkey_begin = pubkey_ds.pos();
-      pubkey_ds << pubkey;
+      auto sig_data = eosio::pack(sig);
+      auto pubkey_data = eosio::pack(pubkey);
 
       ::assert_recover_key( reinterpret_cast<const capi_checksum256*>(digest_data.data()),
-                            sig_begin, (sig_ds.pos() - sig_begin),
-                            pubkey_begin, (pubkey_ds.pos() - pubkey_begin) );
+                            sig_data.data(), sig_data.size(),
+                            pubkey_data.data(), pubkey_data.size() );
    }
 
 }


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description

The *_recover_key wrapper functions presumed a fixed size serialization buffer which no longer holds now that sigs and pubkeys can be variable sized

related to #659 

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
