### PR TITLE
Add is_valid member function to block_signing_authority_v0

### DIFF
--- a/libraries/eosiolib/contracts/eosio/producer_schedule.hpp
+++ b/libraries/eosiolib/contracts/eosio/producer_schedule.hpp
@@ -121,6 +121,8 @@ namespace eosio {
        */
       std::vector<key_weight>     keys;
 
+      bool is_valid()const;
+
       EOSLIB_SERIALIZE( block_signing_authority_v0, (threshold)(keys) )
    };
 

--- a/libraries/eosiolib/eosiolib.cpp
+++ b/libraries/eosiolib/eosiolib.cpp
@@ -19,6 +19,33 @@ namespace eosio {
      uint32_t get_active_producers(uint64_t*, uint32_t);
    }
 
+   // producer_schedule.hpp
+   bool block_signing_authority_v0::is_valid()const {
+      uint32_t sum_weights = 0;
+      std::set<eosio::public_key> unique_keys;
+
+      for (const auto& kw: keys ) {
+         if( std::numeric_limits<uint32_t>::max() - sum_weights <= kw.weight ) {
+            sum_weights = std::numeric_limits<uint32_t>::max();
+         } else {
+            sum_weights += kw.weight;
+         }
+
+         unique_keys.insert(kw.key);
+      }
+
+      if( keys.size() != unique_keys.size() )
+         return false; // producer authority includes a duplicated key
+
+      if( threshold == 0 )
+         return false; // producer authority has a threshold of 0
+
+      if( sum_weights < threshold )
+         return false; // producer authority is unsatisfiable
+
+      return true;
+   }
+
    // privileged.hpp
    void set_blockchain_parameters(const eosio::blockchain_parameters& params) {
       char buf[sizeof(eosio::blockchain_parameters)];


### PR DESCRIPTION
## Change Description

Add `is_valid` member function to `block_signing_authority_v0` which allows the caller to determine whether the block signing authority is valid, or:

- does not have repeating keys;
- the sum of the weights is at least equal to the threshold;
- and, the threshold is not 0.

It does not validate whether the keys are valid.

These are the same validations that are done on the EOSIO native side for each of the block signing authorities submitted via `set_proposed_producers_ex` when using the new format (at least after EOSIO/eos#8021 has been merged in).

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
