### PR TITLE
[1.7.x] Test metrics fix

### DIFF
--- a/.cicd/tests.sh
+++ b/.cicd/tests.sh
@@ -12,8 +12,11 @@ if [[ $(uname) == 'Darwin' ]]; then
 
     # You can't use chained commands in execute
     cd $BUILD_DIR
+    set +e
     bash -c "$TEST"
-    
+    EXIT_STATUS=$?
+    cd $ROOT_DIR
+
 else # Linux
 
     ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}
@@ -29,7 +32,29 @@ else # Linux
             evars="$evars --env ${var%%=*}"
         done < "$BUILDKITE_ENV_FILE"
     fi
-
+    set +e
     eval docker run $ARGS $evars $FULL_TAG bash -c \"$COMMANDS\"
-
+    EXIT_STATUS=$?
+fi
+# buildkite
+if [[ "$BUILDKITE" == 'true' ]]; then
+    cd build
+    # upload artifacts
+    echo '+++ :arrow_up: Uploading Artifacts'
+    echo 'Compressing core dumps...'
+    [[ $((`ls -1 core.* 2>/dev/null | wc -l`)) != 0 ]] && tar czf core.tar.gz core.* || : # collect core dumps
+    echo 'Exporting xUnit XML'
+    mv -f ./Testing/$(ls ./Testing/ | grep '2' | tail -n 1)/Test.xml test-results.xml
+    echo 'Uploading artifacts'
+    [[ -f config.ini ]] && buildkite-agent artifact upload config.ini
+    [[ -f core.tar.gz ]] && buildkite-agent artifact upload core.tar.gz
+    [[ -f genesis.json ]] && buildkite-agent artifact upload genesis.json
+    [[ -f mongod.log ]] && buildkite-agent artifact upload mongod.log
+    buildkite-agent artifact upload test-results.xml
+    echo 'Done uploading artifacts.'
+fi
+# re-throw
+if [[ "$EXIT_STATUS" != 0 ]]; then
+    echo "Failing due to non-zero exit status from ctest: $EXIT_STATUS"
+    exit $EXIT_STATUS
 fi

--- a/.cicd/tests.sh
+++ b/.cicd/tests.sh
@@ -41,15 +41,9 @@ if [[ "$BUILDKITE" == 'true' ]]; then
     cd build
     # upload artifacts
     echo '+++ :arrow_up: Uploading Artifacts'
-    echo 'Compressing core dumps...'
-    [[ $((`ls -1 core.* 2>/dev/null | wc -l`)) != 0 ]] && tar czf core.tar.gz core.* || : # collect core dumps
     echo 'Exporting xUnit XML'
     mv -f ./Testing/$(ls ./Testing/ | grep '2' | tail -n 1)/Test.xml test-results.xml
     echo 'Uploading artifacts'
-    [[ -f config.ini ]] && buildkite-agent artifact upload config.ini
-    [[ -f core.tar.gz ]] && buildkite-agent artifact upload core.tar.gz
-    [[ -f genesis.json ]] && buildkite-agent artifact upload genesis.json
-    [[ -f mongod.log ]] && buildkite-agent artifact upload mongod.log
     buildkite-agent artifact upload test-results.xml
     echo 'Done uploading artifacts.'
 fi


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Reviewing PR#713 in eosio.cdt revealed that we are currently not uploading test results in eosio.cdt and eosio.contract test steps. The test metrics step is falling back to parsing the Buildkite log, which is not ideal.

Fixed issue where test steps did not upload artifacts correctly.
- Test metric step now refers to test-results.xml as generated by ctest instead of defaulting to parsing log output.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
