### PR TITLE
[release/1.7.x] Fix callouts in docs

### DIFF
--- a/docs/06_how-to-guides/02_multi-index/how-to-define-a-primary-index.md
+++ b/docs/06_how-to-guides/02_multi-index/how-to-define-a-primary-index.md
@@ -37,7 +37,7 @@ using namespace eosio;
   };
 ```
 
-[[Info | Secondary indexes information]]
+[[info | Secondary indexes information]]
 | Other, secondary, indexes if they will be defined can have duplicates. You can have up to 16 additional indexes and the field types can be uint64_t, uint128_t, uint256_t, double or long double.
 
 5. For ease of use, define a type alias `test_tables` based on the `eosio::multi_index` template type, parametarized with a random name `"testtaba"` and the `test_table` data structure defined above
@@ -73,5 +73,5 @@ Declare the multi index table as a data member of type `test_tables`, as defined
 
 Now you have instantiated the `testtab` as a multi index table which has a primary index defined for its `test_primary` data member.
 
-[[Info | Full example location]]
+[[info | Full example location]]
 | A full example project demonstrating the instantiation and usage of multi index table can be found [here](https://github.com/EOSIO/eosio.cdt/tree/master/examples/multi_index_example).

--- a/docs/06_how-to-guides/02_multi-index/how-to-define-a-secondary-index.md
+++ b/docs/06_how-to-guides/02_multi-index/how-to-define-a-secondary-index.md
@@ -88,5 +88,5 @@ class [[eosio::contract]] multi_index_example : public contract {
 };
 ```
 
-[[Info | Full example location]]
+[[info | Full example location]]
 | A full example project demonstrating the instantiation and usage of multi index table can be found [here](https://github.com/EOSIO/eosio.cdt/tree/master/examples/multi_index_example).

--- a/docs/06_how-to-guides/02_multi-index/how-to-define-a-singleton.md
+++ b/docs/06_how-to-guides/02_multi-index/how-to-define-a-singleton.md
@@ -112,5 +112,5 @@ __singleton_example.cpp__
 ```
 
 
-[[Info | Full example location]]
+[[info | Full example location]]
 | A full example project demonstrating the instantiation and usage of singleton can be found [here](https://github.com/EOSIO/eosio.cdt/tree/master/examples/singleton_example).

--- a/docs/06_how-to-guides/02_multi-index/how-to-delete-data-from-a-multi-index-table.md
+++ b/docs/06_how-to-guides/02_multi-index/how-to-delete-data-from-a-multi-index-table.md
@@ -29,5 +29,5 @@ To delete data from a multi index table follow the steps below:
 }
 ```
 
-[[Info | Full example location]]
+[[info | Full example location]]
 | A full example project demonstrating the instantiation and usage of multi index table can be found [here](https://github.com/EOSIO/eosio.cdt/tree/master/examples/multi_index_example).

--- a/docs/06_how-to-guides/02_multi-index/how-to-insert-data-into-a-multi-index-table.md
+++ b/docs/06_how-to-guides/02_multi-index/how-to-insert-data-into-a-multi-index-table.md
@@ -7,7 +7,7 @@ content_title: How to insert data into a multi index table
 
 To insert data into a multi index table follow the following steps
 
-1. Make use of the multi index table iterator to find out if the data doesn't already exist 
+1. Make use of the multi index table iterator to find out if the data doesn't already exist
 ```cpp
 [[eosio::action]] void multi_index_example::set( name user ) {
   // check if the user already exists
@@ -32,5 +32,5 @@ To insert data into a multi index table follow the following steps
 }
 ```
 
-[[Info | Full example location]]
+[[info | Full example location]]
 | A full example project demonstrating the instantiation and usage of multi index table can be found [here](https://github.com/EOSIO/eosio.cdt/tree/master/examples/multi_index_example).

--- a/docs/06_how-to-guides/02_multi-index/how-to-instantiate-a-multi-index-table.md
+++ b/docs/06_how-to-guides/02_multi-index/how-to-instantiate-a-multi-index-table.md
@@ -35,7 +35,7 @@ using namespace eosio;
   };
 ```
 
-[[Info | Additional indexes information]]
+[[info | Additional indexes information]]
 | Other, secondary, indexes if they will be defined can have duplicates. You can have up to 16 additional indexes and the field types can be uint64_t, uint128_t, uint256_t, double or long double.
 
 5. For ease of use, define a type alias `test_tables` based on the multi_index template type, parametarized with a random name `"testtaba"` and the `test_table` data structure defined above
@@ -129,5 +129,5 @@ class [[eosio::contract]] multi_index_example : public contract {
 };
 ```
 
-[[Info | Full example location]]
+[[info | Full example location]]
 | A full example project demonstrating the instantiation and usage of multi index table can be found [here](https://github.com/EOSIO/eosio.cdt/tree/master/examples/multi_index_example).

--- a/docs/06_how-to-guides/02_multi-index/how-to-iterate-and-retrieve-a-multi_index-table-based-on-secondary-index.md
+++ b/docs/06_how-to-guides/02_multi-index/how-to-iterate-and-retrieve-a-multi_index-table-based-on-secondary-index.md
@@ -171,5 +171,5 @@ __multi_index_example.cpp__
 }
 ```
 
-[[Info | Full example location]]
+[[info | Full example location]]
 | A full example project demonstrating the instantiation and usage of multi index table can be found [here](https://github.com/EOSIO/eosio.cdt/tree/master/examples/multi_index_example).

--- a/docs/06_how-to-guides/02_multi-index/how-to-iterate-and-retrieve-a-multi_index-table.md
+++ b/docs/06_how-to-guides/02_multi-index/how-to-iterate-and-retrieve-a-multi_index-table.md
@@ -153,5 +153,5 @@ __multi_index_example.cpp__
 }
 ```
 
-[[Info | Full example location]]
+[[info | Full example location]]
 | A full example project demonstrating the instantiation and usage of multi index table can be found [here](https://github.com/EOSIO/eosio.cdt/tree/master/examples/multi_index_example).

--- a/docs/06_how-to-guides/02_multi-index/how-to-modify-data-in-a-multi-index-table.md
+++ b/docs/06_how-to-guides/02_multi-index/how-to-modify-data-in-a-multi-index-table.md
@@ -37,5 +37,5 @@ To modify data in the multi index table defined in the above tutorial, you will 
 }
 ```
 
-[[Info | Full example location]
+[[info | Full example location]
 | A full example project demonstrating the instantiation and usage of multi index table can be found [here](https://github.com/EOSIO/eosio.cdt/tree/master/examples/multi_index_example).

--- a/docs/09_tutorials/02_abi-variants.md
+++ b/docs/09_tutorials/02_abi-variants.md
@@ -155,5 +155,5 @@ class [[eosio::contract]] multi_index_example : public contract {
 [[warning | Not recommended warning]]
 | Be aware, it is not recommend to use `eosio::binary_extension` inside variant definition, this can lead to data corruption unless one is very careful in understanding how these two templates work and how to ABI gets generated!
 
-[[Info | Implemenatation location]]
+[[info | Implemenatation location]]
 | The implementation for ABI `variants' section can be found [here](https://github.com/EOSIO/eos/pull/5652).


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
Fixes callouts in the docs in `release/1.7.x`. Was using `Info` as opposed to the required lowercase variant `info`. Was not rendering, as seen below:

![Screen Shot 2019-12-09 at 11 29 02 PM](https://user-images.githubusercontent.com/299465/70478611-b54b6a80-1adb-11ea-9bde-4927ae35af2c.png)

After correction: 

![Screen Shot 2019-12-09 at 11 28 08 PM](https://user-images.githubusercontent.com/299465/70478554-964cd880-1adb-11ea-8793-f299eb4f2c36.png)


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
