### PR TITLE
Add new intrinsic set_action_return_value

### DIFF
--- a/libraries/eosiolib/capi/eosio/action.h
+++ b/libraries/eosiolib/capi/eosio/action.h
@@ -168,6 +168,16 @@ uint64_t  publication_time( void );
 __attribute__((eosio_wasm_import))
 capi_name current_receiver( void );
 
+/**
+ * Set the action return value which will be included in the action_receipt
+ * @brief Set the action return value
+ * @param return_value - serialized return value
+ * @param size - size of serialized return value in bytes
+ * @pre `return_value` is a valid pointer to an array at least `size` bytes long
+ */
+__attribute__((eosio_wasm_import))
+void set_action_return_value(char *return_value, size_t size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/eosiolib/contracts/eosio/action.hpp
+++ b/libraries/eosiolib/contracts/eosio/action.hpp
@@ -52,6 +52,9 @@ namespace eosio {
 
          __attribute__((eosio_wasm_import))
          uint64_t current_receiver();
+
+         __attribute__((eosio_wasm_import))
+         void set_action_return_value(char *return_value, size_t size);
       }
    };
 
@@ -148,6 +151,18 @@ namespace eosio {
    */
    inline name current_receiver() {
      return name{internal_use_do_not_use::current_receiver()};
+   }
+
+   /**
+    * Set the action return value which will be included in action_receipt
+    * @ingroup action
+    * @tparam T type of return value
+    * @param v the return value to set
+    */
+   template<typename T>
+   inline void set_action_return_value( const T& v ) {
+      const auto packed_value = pack( v );
+      internal_use_do_not_use::set_action_return_value( &packed_value[0], packed_value.size() );
    }
 
    /**

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -292,6 +292,9 @@ extern "C" {
    capi_name current_receiver() {
       return intrinsics::get().call<intrinsics::current_receiver>();
    }
+   void set_action_return_value( char* rv, size_t len ) {
+      intrinsics::get().call<intrinsics::set_action_return_value>(rv, len);
+   }
    void require_recipient( capi_name name ) {
       return intrinsics::get().call<intrinsics::require_recipient>(name);
    }

--- a/libraries/native/native/eosio/intrinsics_def.hpp
+++ b/libraries/native/native/eosio/intrinsics_def.hpp
@@ -157,7 +157,8 @@ intrinsic_macro(send_context_free_inline) \
 intrinsic_macro(send_deferred) \
 intrinsic_macro(cancel_deferred) \
 intrinsic_macro(get_context_free_data) \
-intrinsic_macro(get_sender) 
+intrinsic_macro(get_sender) \
+intrinsic_macro(set_action_return_value)
 
 #define CREATE_ENUM(name) \
    name,

--- a/tests/unit/test_contracts/capi/action.c
+++ b/tests/unit/test_contracts/capi/action.c
@@ -13,4 +13,5 @@ void test_action( void ) {
    send_context_free_inline(NULL, 0);
    publication_time();
    current_receiver();
+   set_action_return_value(NULL, 0);
 }


### PR DESCRIPTION
## Change Description

- Adds new intrinsic `set_action_return_value` enabled by https://github.com/EOSIO/eos/pull/8327

## API Changes
- [x] API Changes

```
/**
 * Set the action return value which will be included in the action_receipt
 * @brief Set the action return value
 * @param return_value - serialized return value
 * @param size - size of serialized return value in bytes
 * @pre `return_value` is a valid pointer to an array at least `size` bytes long
 */
```

## Documentation Additions
- [x] Documentation Additions
