### PR TITLE
don't use a const vector<> for action return value pack()

### DIFF
--- a/libraries/eosiolib/contracts/eosio/action.hpp
+++ b/libraries/eosiolib/contracts/eosio/action.hpp
@@ -161,7 +161,7 @@ namespace eosio {
     */
    template<typename T>
    inline void set_action_return_value( const T& v ) {
-      const auto packed_value = pack( v );
+      auto packed_value = pack( v );
       internal_use_do_not_use::set_action_return_value( &packed_value[0], packed_value.size() );
    }
 


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
The CAPI for action return value takes a non-const char*, so it's a compile error to pass a const char* from a const vector<> here

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
