### PR TITLE
release/1.6.x `binary_extension` and explicit default constructors fix

### DIFF
--- a/libraries/eosiolib/binary_extension.hpp
+++ b/libraries/eosiolib/binary_extension.hpp
@@ -112,12 +112,12 @@
          }
          constexpr T value_or()& {
             if (!_has_value)
-               return {};
+               return T{};
             return _get();
          }
          constexpr T value_or()const& {
             if (!_has_value)
-               return {};
+               return T{};
             return _get();
          }
 

--- a/libraries/eosiolib/binary_extension.hpp
+++ b/libraries/eosiolib/binary_extension.hpp
@@ -112,12 +112,12 @@
          }
          constexpr T value_or()& {
             if (!_has_value)
-               return T{};
+               return T();
             return _get();
          }
          constexpr T value_or()const& {
             if (!_has_value)
-               return T{};
+               return T();
             return _get();
          }
 

--- a/libraries/eosiolib/core/eosio/binary_extension.hpp
+++ b/libraries/eosiolib/core/eosio/binary_extension.hpp
@@ -103,12 +103,12 @@ namespace eosio {
          }
          constexpr T value_or()& {
             if (!_has_value)
-               return {};
+               return T{};
             return _get();
          }
          constexpr T value_or()const& {
             if (!_has_value)
-               return {};
+               return T{};
             return _get();
          }
 

--- a/libraries/eosiolib/core/eosio/binary_extension.hpp
+++ b/libraries/eosiolib/core/eosio/binary_extension.hpp
@@ -103,12 +103,12 @@ namespace eosio {
          }
          constexpr T value_or()& {
             if (!_has_value)
-               return T{};
+               return T();
             return _get();
          }
          constexpr T value_or()const& {
             if (!_has_value)
-               return T{};
+               return T();
             return _get();
          }
 


### PR DESCRIPTION
Allow for the type `binary_extension` to build if the given parameterized type only has an explicit default constructor.