### PR TITLE
release/1.7.x `binary_extension` and explicit default constructors fix

### DIFF
--- a/libraries/eosiolib/core/eosio/binary_extension.hpp
+++ b/libraries/eosiolib/core/eosio/binary_extension.hpp
@@ -103,12 +103,12 @@ namespace eosio {
          }
          constexpr T value_or()& {
             if (!_has_value)
-               return {};
+               return T{};
             return _get();
          }
          constexpr T value_or()const& {
             if (!_has_value)
-               return {};
+               return T{};
             return _get();
          }
 

--- a/libraries/eosiolib/core/eosio/binary_extension.hpp
+++ b/libraries/eosiolib/core/eosio/binary_extension.hpp
@@ -13,6 +13,7 @@ namespace eosio {
     /**
     *  Container to hold a binary payload for an extension
     *
+    *  @ingroup binary_extension
     *  @tparam T - Contained typed
     */
    template <typename T>

--- a/libraries/eosiolib/core/eosio/binary_extension.hpp
+++ b/libraries/eosiolib/core/eosio/binary_extension.hpp
@@ -13,7 +13,6 @@ namespace eosio {
     /**
     *  Container to hold a binary payload for an extension
     *
-    *  @ingroup binary_extension
     *  @tparam T - Contained typed
     */
    template <typename T>
@@ -103,12 +102,12 @@ namespace eosio {
          }
          constexpr T value_or()& {
             if (!_has_value)
-               return T{};
+               return T();
             return _get();
          }
          constexpr T value_or()const& {
             if (!_has_value)
-               return T{};
+               return T();
             return _get();
          }
 


### PR DESCRIPTION
Allow for the type `binary_extension` to build if the given parameterized type only has an explicit default constructor.