### PR TITLE
Fix (eosio::string): Add inline specifier to friend functions

### DIFF
--- a/libraries/eosiolib/core/eosio/string.hpp
+++ b/libraries/eosiolib/core/eosio/string.hpp
@@ -424,7 +424,7 @@ namespace eosio {
       }
    };
 
-   bool operator< (const string& lhs, const string& rhs) {
+   inline bool operator< (const string& lhs, const string& rhs) {
       const char* beg_lhs{lhs.cbegin()}; const char* end_lhs{lhs.cend()};
       const char* beg_rhs{rhs.cbegin()}; const char* end_rhs{rhs.cend()};
 
@@ -438,27 +438,27 @@ namespace eosio {
       return beg_lhs == end_lhs && beg_rhs != end_rhs;
    }
 
-   bool operator> (const string& lhs, const string& rhs) {
+   inline bool operator> (const string& lhs, const string& rhs) {
       return (rhs < lhs);
    }
 
-   bool operator<=(const string& lhs, const string& rhs) {
+   inline bool operator<=(const string& lhs, const string& rhs) {
       return !(rhs < lhs);
    }
 
-   bool operator>=(const string& lhs, const string& rhs) {
+   inline bool operator>=(const string& lhs, const string& rhs) {
       return !(lhs < rhs);
    }
 
-   bool operator==(const string& lhs, const string& rhs) {
+   inline bool operator==(const string& lhs, const string& rhs) {
       return !(lhs < rhs) && !(rhs < lhs);
    }
 
-   bool operator!=(const string& lhs, const string& rhs) {
+   inline bool operator!=(const string& lhs, const string& rhs) {
       return !(lhs == rhs);
    }
 
-   string operator+(const string& lhs, const string& rhs) {
+   inline string operator+(const string& lhs, const string& rhs) {
       string res{lhs};
       res += rhs;
       return res;


### PR DESCRIPTION
## Change Description
This PR fixes the duplicated symbol linker error when including `eosio::string` in more then 1 source file.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
