### PR TITLE
[develop] Community PR tweaks.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,19 +2,10 @@ name: Pull Request
 on: [pull_request]
 
 jobs:
-  start-job:
-    name: Start Job
-    runs-on: ubuntu-latest
-    steps:
-      - name: Start Job.
-        run: echo "PR created. Builds will be triggered here for forked PRs or Buildkite for internal PRs."
-
-
   submodule_regression_check:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Submodule Regression Check
     runs-on: ubuntu-latest
-    needs: start-job
     steps:
       - name: Checkout
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -28,7 +19,6 @@ jobs:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Amazon_Linux 2 | Build
     runs-on: ubuntu-latest
-    needs: start-job
     steps:
       - name: Checkout
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -89,7 +79,6 @@ jobs:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: CentOS 7.7 | Build
     runs-on: ubuntu-latest
-    needs: start-job
     steps:
       - name: Checkout
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -150,7 +139,6 @@ jobs:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id  
     name: Ubuntu 16.04 | Build
     runs-on: ubuntu-latest
-    needs: start-job
     steps:
       - name: Checkout
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -211,7 +199,6 @@ jobs:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Ubuntu 18.04 | Build
     runs-on: ubuntu-latest
-    needs: start-job
     steps:
       - name: Checkout
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
@@ -272,7 +259,6 @@ jobs:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: MacOS 10.15 | Build
     runs-on: macos-latest
-    needs: start-job
     steps:
       - name: Checkout
         uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This is a quick change to Actions runs when community PRs are submitted:
- Remove now unnecessary job that executed before build/test steps occurred in Github Actions.
  - This step was required due to a bug in Actions where if all workflow steps were skipped, such as when org based PRs are executed, the build would be marked as failed.
  - The behavior now shows status as expected, where the steps based in the org do now show up at all.

See:
[Actions](https://github.com/EOSIO/eosio.cdt/actions/runs/44511834) | Actions run from #822 showing the same functionality as before.
[Actions](https://github.com/EOSIO/eosio.cdt/actions/runs/44382260) | Actions run created from this PR where all steps are skipped as expected. No checks from Actions show as failed in this PR.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
