### PR TITLE
[develop] Actions rerun fixes.

### DIFF
--- a/.cicd/submodule-regression-checker.sh
+++ b/.cicd/submodule-regression-checker.sh
@@ -10,7 +10,7 @@ if [[ $BUILDKITE == true ]]; then
 else
     [[ -z $GITHUB_BASE_REF ]] && echo "Cannot find \$GITHUB_BASE_REF, so we have nothing to compare submodules to. Skipping submodule regression check." && exit 0
     BASE_BRANCH=$GITHUB_BASE_REF
-    CURRENT_BRANCH=$GITHUB_SHA
+    CURRENT_BRANCH="refs/remotes/pull/$PR_NUMBER/merge"
 fi
 
 echo "getting submodule info for $CURRENT_BRANCH"
@@ -24,12 +24,6 @@ git submodule update --init 1> /dev/null
 while read -r a b; do
     BASE_MAP[$a]=$b
 done < <(git submodule --quiet foreach --recursive 'echo $path `git log -1 --format=%ct`')
-
-# We need to switch back to the PR ref/head so we can git log properly
-if [[ $BUILDKITE != true ]]; then
-    echo "git fetch origin +$GITHUB_REF:"
-    git fetch origin +${GITHUB_REF}: 1> /dev/null
-fi
 
 echo "switching back to $CURRENT_BRANCH..."
 echo "git checkout -qf $CURRENT_BRANCH"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,15 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-        with:
-          fetch-depth: 0
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Submodule Regression Check
         run: ./.cicd/submodule-regression-checker.sh
 
@@ -27,13 +26,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -51,13 +51,14 @@ jobs:
     needs: amazon_linux-2-build
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -74,13 +75,14 @@ jobs:
     needs: amazon_linux-2-build
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -99,13 +101,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -123,13 +126,14 @@ jobs:
     needs: centos-77-build
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -146,13 +150,14 @@ jobs:
     needs: centos-77-build
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -171,13 +176,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -195,13 +201,14 @@ jobs:
     needs: ubuntu-1604-build
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -218,13 +225,14 @@ jobs:
     needs: ubuntu-1604-build
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -243,13 +251,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -267,13 +276,14 @@ jobs:
     needs: ubuntu-1804-build
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -290,13 +300,14 @@ jobs:
     needs: ubuntu-1804-build
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -315,13 +326,14 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Build
         run: | 
           brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3
@@ -338,13 +350,14 @@ jobs:
     needs: macos-1015-build
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -360,13 +373,14 @@ jobs:
     needs: macos-1015-build
     steps:
       - name: Checkout
-        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
-      - name: Submodules
-        shell: bash
         run: |
-          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git submodule update --init --force --recursive
+        env:
+          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
         run: |
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
-          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive
       - name: Submodule Regression Check
         run: ./.cicd/submodule-regression-checker.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,9 @@
 name: Pull Request
 on: [pull_request]
 
+env:
+  PR_NUMBER: ${{ toJson(github.event.number) }}
+
 jobs:
   submodule_regression_check:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
@@ -14,8 +17,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Submodule Regression Check
         run: ./.cicd/submodule-regression-checker.sh
 
@@ -32,8 +33,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -57,8 +56,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -81,8 +78,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -107,8 +102,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -132,8 +125,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -156,8 +147,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -182,8 +171,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -207,8 +194,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -231,8 +216,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -257,8 +240,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -282,8 +263,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -306,8 +285,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -332,8 +309,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Build
         run: | 
           brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3
@@ -356,8 +331,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -379,8 +352,6 @@ jobs:
           git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
           git submodule sync --recursive
           git submodule update --init --force --recursive
-        env:
-          PR_NUMBER: ${{ toJson(github.event.number) }}
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: Pull Request
-on: [push]
+on: [pull_request]
 
 jobs:
   submodule_regression_check:
-    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Submodule Regression Check
     runs-on: ubuntu-latest
     steps:
@@ -20,7 +20,7 @@ jobs:
 
 
   amazon_linux-2-build:
-    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Amazon_Linux 2 | Build
     runs-on: ubuntu-latest
     steps:
@@ -92,7 +92,7 @@ jobs:
 
 
   centos-77-build:
-    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: CentOS 7.7 | Build
     runs-on: ubuntu-latest
     steps:
@@ -164,7 +164,7 @@ jobs:
 
 
   ubuntu-1604-build:
-    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id  
+    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id  
     name: Ubuntu 16.04 | Build
     runs-on: ubuntu-latest
     steps:
@@ -236,7 +236,7 @@ jobs:
 
 
   ubuntu-1804-build:
-    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Ubuntu 18.04 | Build
     runs-on: ubuntu-latest
     steps:
@@ -308,7 +308,7 @@ jobs:
 
 
   macos-1015-build:
-    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: MacOS 10.15 | Build
     runs-on: macos-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+        with:
+          fetch-depth: 0
       - name: Submodules
         shell: bash
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,29 +1,37 @@
 name: Pull Request
-on: [pull_request]
+on: [push]
 
 jobs:
   submodule_regression_check:
-    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Submodule Regression Check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Submodule Regression Check
         run: ./.cicd/submodule-regression-checker.sh
 
 
   amazon_linux-2-build:
-    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Amazon_Linux 2 | Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -41,9 +49,13 @@ jobs:
     needs: amazon_linux-2-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -60,9 +72,13 @@ jobs:
     needs: amazon_linux-2-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -76,14 +92,18 @@ jobs:
 
 
   centos-77-build:
-    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: CentOS 7.7 | Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -101,9 +121,13 @@ jobs:
     needs: centos-77-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -120,9 +144,13 @@ jobs:
     needs: centos-77-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -136,14 +164,18 @@ jobs:
 
 
   ubuntu-1604-build:
-    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id  
+    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id  
     name: Ubuntu 16.04 | Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -161,9 +193,13 @@ jobs:
     needs: ubuntu-1604-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -180,9 +216,13 @@ jobs:
     needs: ubuntu-1604-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -196,14 +236,18 @@ jobs:
 
 
   ubuntu-1804-build:
-    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Ubuntu 18.04 | Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Build
         run: | 
           ./.cicd/build.sh
@@ -221,9 +265,13 @@ jobs:
     needs: ubuntu-1804-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -240,9 +288,13 @@ jobs:
     needs: ubuntu-1804-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -256,14 +308,18 @@ jobs:
 
 
   macos-1015-build:
-    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
+    # if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: MacOS 10.15 | Build
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Build
         run: | 
           brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3
@@ -280,9 +336,13 @@ jobs:
     needs: macos-1015-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:
@@ -298,9 +358,13 @@ jobs:
     needs: macos-1015-build
     steps:
       - name: Checkout
-        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e
-        with:
-          submodules: recursive
+        uses: actions/checkout@f90c7b395dac7c5a277c1a6d93d5057c1cddb74e
+      - name: Submodules
+        shell: bash
+        run: |
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive --depth=1
       - name: Download Build Artifact
         uses: actions/download-artifact@v1
         with:


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Fixed an issue regarding checkouts when rerunning a failed forked PR:
- Removed use of Actions checkout plugin for several reasons:
  - Version 1 of the plugin does not handle the race condition between the "merge commit" being created in Github and trying to checkout this commit.
  - Version 2 of the plugin addressed the above issue... but does not allow submodules to be checked out automatically.
  - We can use v2 of the plugin and manually checkout submodules... but v2 of the plugin does not checkout the full history of the repo, required for the submodule regression check.
  - Actions-based environment variables are set incorrectly on PR reruns of forked repositories...
- Replaced Actions plugin with our own checkout steps:
  - Clone the full repo.
  - Checkout the specific ref tied to the pull request number. We can do this because the workflow only runs on pull request events and reruns trigger a pull request event. Both cases contain the PR number.
  - Perform our own submodule checkout steps to grab the entire repository.
- Update submodule regression checker.
  - Checkout the specific ref tied to the pull request number when called from Actions.

See:
[Actions](https://github.com/EOSIO/eosio.cdt/actions/runs/45722620) | This Actions run that builds a forked PR could be retried and checked out the codebase correctly. Note that this run was hardcoded to fail after completion of the submodule regression check.
[Actions](https://github.com/EOSIO/eosio.cdt/actions/runs/45739808) | This Actions run is configured to run as expected from a forked PR.
[CDT Build 1030](https://buildkite.com/EOSIO/eosio-dot-cdt/builds/1030#1be3fe28-956c-4ce3-871a-9c446234026a) | Buildkite run showing expected behavior with submodule regression check.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
