### PR TITLE
[docs] fixes typos "and and" -> "and"

### DIFF
--- a/docs/06_how-to-guides/02_multi-index/how-to-instantiate-a-multi-index-table.md
+++ b/docs/06_how-to-guides/02_multi-index/how-to-instantiate-a-multi-index-table.md
@@ -22,7 +22,7 @@ using namespace eosio;
 +    uint64_t datum;
   };
 ```
-4. Add definition of the primary index for the multi index table. The primary index type must be uint64_t, it must be unique and and it must be named `primary_key()`, if you don't have this the compiler (eosio-cpp) will generate an error saying it can't find the field to use as the primary key:
+4. Add definition of the primary index for the multi index table. The primary index type must be uint64_t, it must be unique and it must be named `primary_key()`, if you don't have this the compiler (eosio-cpp) will generate an error saying it can't find the field to use as the primary key:
 ```diff
   // the data structure which defines each row of the table
   struct [[eosio::table]] test_table {

--- a/libraries/boost/include/boost/hana/fwd/type.hpp
+++ b/libraries/boost/include/boost/hana/fwd/type.hpp
@@ -165,7 +165,7 @@ BOOST_HANA_NAMESPACE_BEGIN
     //! ### Rationale for stripping the references
     //! The rules for template argument deduction are such that a perfect
     //! solution that always matches `decltype` is impossible. Hence, we
-    //! have to settle on a solution that's good and and consistent enough
+    //! have to settle on a solution that's good and consistent enough
     //! for our needs. One case where matching `decltype`'s behavior is
     //! impossible is when the argument is a plain, unparenthesized variable
     //! or function parameter. In that case, `decltype_`'s argument will be

--- a/libraries/boost/include/boost/move/algo/adaptive_sort.hpp
+++ b/libraries/boost/include/boost/move/algo/adaptive_sort.hpp
@@ -261,7 +261,7 @@ bool adaptive_sort_combine_all_blocks
       //    Implies l_block == l_intbuf && use_internal_buf == true
       //If l_intbuf is zero, see if half keys can be reused as a reduced emergency buffer,
       //    Implies l_block == n_keys/2 && use_internal_buf == true
-      //Otherwise, just give up and and use all keys to merge using rotations (use_internal_buf = false)
+      //Otherwise, just give up and use all keys to merge using rotations (use_internal_buf = false)
       bool use_internal_buf = false;
       size_type const l_block = lblock_for_combine(l_intbuf, n_keys, 2*l_merged, use_internal_buf);
       BOOST_ASSERT(!l_intbuf || (l_block == l_intbuf));

--- a/libraries/eosiolib/core/eosio/time.hpp
+++ b/libraries/eosiolib/core/eosio/time.hpp
@@ -165,7 +165,7 @@ namespace eosio {
    /**
    *  This class is used in the block headers to represent the block time
    *  It is a parameterised class that takes an Epoch in milliseconds and
-   *  and an interval in milliseconds and computes the number of slots.
+   *  an interval in milliseconds and computes the number of slots.
    *
    *  @ingroup time
    **/

--- a/tools/external/wabt/src/wast-parser.h
+++ b/tools/external/wabt/src/wast-parser.h
@@ -56,7 +56,7 @@ class WastParser {
   Result ErrorExpected(const std::vector<std::string>& expected,
                        const char* example = nullptr);
 
-  // Print an error message, and and return Result::Error if the next token is
+  // Print an error message, and return Result::Error if the next token is
   // '('. This is commonly used after parsing a sequence of s-expressions -- if
   // no more can be parsed, we know that a following '(' is invalid. This
   // function consumes the '(' so a better error message can be provided


### PR DESCRIPTION
## Change Description
resolves #815
fix typos "and and" -> "and"

## API Changes
- [ ] API Changes

## Documentation Additions
- [x] Documentation Additions
