### PR TITLE
Add commandline option -no-missing-ricardian-clause.

### DIFF
--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -11,8 +11,8 @@ endif()
 list(APPEND CMAKE_MODULE_PATH ${EOSIO_CDT_BIN})
 include(EosioCDTMacros)
 
-set(CMAKE_C_FLAGS " ${CMAKE_C_FLAGS} -O3 -Wall ")
-set(CMAKE_CXX_FLAGS " ${CMAKE_CXX_FLAGS} -O3 -Wall ")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -Wall -no-missing-ricardian-clause")
 
 add_subdirectory(libc)
 add_subdirectory(libc++)

--- a/modules/EosioWasmToolchain.cmake.in
+++ b/modules/EosioWasmToolchain.cmake.in
@@ -15,9 +15,9 @@ set(CMAKE_C_COMPILER "@CDT_ROOT_DIR@/bin/eosio-cc")
 set(CMAKE_CXX_COMPILER "@CDT_ROOT_DIR@/bin/eosio-cpp")
 set(CMAKE_ASM_COMPILER "@CDT_ROOT_DIR@/bin/eosio-cc")
 
-set(CMAKE_C_FLAGS " -O3 ")
-set(CMAKE_CXX_FLAGS " -O3 ")
-set(CMAKE_ASM_FLAGS " -fnative -fasm ")
+set(CMAKE_C_FLAGS "-O3")
+set(CMAKE_CXX_FLAGS "-O3")
+set(CMAKE_ASM_FLAGS "-fnative -fasm")
 
 set(WASM_LINKER "@CDT_ROOT_DIR@/bin/eosio-ld")
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,8 @@ else()
    endif()
 endif()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -no-missing-ricardian-clause")
+
 add_test( asset_tests ${CMAKE_BINARY_DIR}/tests/unit/asset_tests )
 set_property(TEST asset_tests PROPERTY LABELS unit_tests)
 add_test( binary_extension_tests ${CMAKE_BINARY_DIR}/tests/unit/binary_extension_tests )

--- a/tools/cc/eosio-cpp.cpp.in
+++ b/tools/cc/eosio-cpp.cpp.in
@@ -107,7 +107,7 @@ namespace eosio { namespace cdt {
    };
 }} // ns eosio::cdt
 
-void generate(const std::vector<std::string>& base_options, std::string input, std::string contract_name, const std::vector<std::string>& resource_paths, const std::pair<int, int>& abi_version, bool abigen) {
+void generate(const std::vector<std::string>& base_options, std::string input, std::string contract_name, const std::vector<std::string>& resource_paths, const std::pair<int, int>& abi_version, bool abigen, bool suppress_ricardian_warning) {
    std::vector<std::string> options;
    options.push_back("eosio-cpp");
    options.push_back(input); // don't remove oddity of CommonOptionsParser?
@@ -131,6 +131,7 @@ void generate(const std::vector<std::string>& base_options, std::string input, s
    get_abigen_ref().set_contract_name(contract_name);
    get_abigen_ref().set_resource_dirs(resource_paths);
    get_abigen_ref().set_abi_version(std::get<0>(abi_version), std::get<1>(abi_version));
+   get_abigen_ref().set_suppress_ricardian_warning(suppress_ricardian_warning);
    codegen::get().set_contract_name(contract_name);
 
    EosioMethodMatcher eosio_method_matcher;
@@ -190,7 +191,7 @@ int main(int argc, const char **argv) {
             tool_opts.erase(std::remove_if(tool_opts.begin(), tool_opts.end(),
                                            [&](const auto& opt){ return non_tool_opts.count(opt); }),
                             tool_opts.end());
-            generate(tool_opts, input, opts.abigen_contract, opts.abigen_resources, opts.abi_version, opts.abigen);
+            generate(tool_opts, input, opts.abigen_contract, opts.abigen_resources, opts.abi_version, opts.abigen, opts.suppress_ricardian_warning);
 
             auto src = SmallString<64>(input);
             llvm::sys::path::remove_filename(src);

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -34,6 +34,11 @@ static cl::opt<bool> no_abigen_opt(
     "no-abigen",
     cl::desc("Disable ABI file generation"),
     cl::cat(LD_CAT));
+static cl::opt<bool> no_missing_ricardian_clause_opt(
+    "no-missing-ricardian-clause",
+    cl::desc("Disable warnings for missing Ricardian clauses"),
+    cl::init(false),
+    cl::cat(LD_CAT));
 static cl::opt<bool> fquery_opt(
     "fquery",
     cl::desc("Produce binaries for wasmql"),
@@ -172,22 +177,22 @@ static cl::opt<std::string> abigen_output_opt(
     cl::cat(EosioCompilerToolCategory));
 // ignore for now
 static cl::opt<bool> g_opt(
-      "g",
-      cl::desc("debug build <ignored>"),
-      cl::Hidden,
-      cl::ZeroOrMore,
-      cl::cat(EosioCompilerToolCategory));
+    "g",
+    cl::desc("debug build <ignored>"),
+    cl::Hidden,
+    cl::ZeroOrMore,
+    cl::cat(EosioCompilerToolCategory));
 static cl::opt<std::string> x_opt(
-      "x",
-      cl::desc("<ignored>"),
-      cl::Hidden,
-      cl::Prefix,
-      cl::cat(EosioCompilerToolCategory));
+    "x",
+    cl::desc("<ignored>"),
+    cl::Hidden,
+    cl::Prefix,
+    cl::cat(EosioCompilerToolCategory));
 static cl::opt<bool> pch_opt(
-      "fpch-preprocess",
-      cl::desc("<ignored>"),
-      cl::Hidden,
-      cl::cat(EosioCompilerToolCategory));
+    "fpch-preprocess",
+    cl::desc("<ignored>"),
+    cl::Hidden,
+    cl::cat(EosioCompilerToolCategory));
 static cl::opt<bool> CC_opt(
     "CC",
     cl::desc("Include comments from within macros in preprocessed output"),
@@ -359,6 +364,7 @@ struct Options {
    std::vector<std::string> inputs;
    bool link;
    bool abigen;
+   bool suppress_ricardian_warning;
    bool pp_only;
    std::string eosio_pp_dir;
    std::string abigen_output;
@@ -374,7 +380,6 @@ struct Options {
 
 static void GetCompDefaults(std::vector<std::string>& copts) {
    const char* eosio_apply_suff = "${CMAKE_SHARED_LIBRARY_SUFFIX}";
-   std::string apply_lib;
    // add the define for whether this is compiling with CDT and version macros
    copts.emplace_back("-D__eosio_cdt__");
    copts.emplace_back(std::string("-D__eosio_cdt_major__=")+"${VERSION_MAJOR}");
@@ -624,8 +629,9 @@ static Options CreateOptions(bool add_defaults=true) {
       link = false;
       copts.emplace_back("-E");
    }
-   if(g_opt)
+   if(g_opt) {
       copts.emplace_back("-g");
+   }
    if (!x_opt.empty()) {
       // x_opt should precede input files
       copts.insert(copts.begin(), "-x"+x_opt);
@@ -884,8 +890,8 @@ static Options CreateOptions(bool add_defaults=true) {
    }
 
 #ifndef ONLY_LD
-   return {output_fn, inputs, link, abigen, pp_only, pp_dir, abigen_output, abigen_contract, copts, ldopts, agopts, agresources, debug, fnative_opt, {abi_version_major, abi_version_minor}};
+   return {output_fn, inputs, link, abigen, no_missing_ricardian_clause_opt, pp_only, pp_dir, abigen_output, abigen_contract, copts, ldopts, agopts, agresources, debug, fnative_opt, {abi_version_major, abi_version_minor}};
 #else
-   return {output_fn, {}, link, abigen, pp_only, pp_dir, abigen_output, abigen_contract, copts, ldopts, agopts, agresources, debug, fnative_opt, {abi_version_major, abi_version_minor}};
+   return {output_fn, {}, link, abigen, no_missing_ricardian_clause_opt, pp_only, pp_dir, abigen_output, abigen_contract, copts, ldopts, agopts, agresources, debug, fnative_opt, {abi_version_major, abi_version_minor}};
 #endif
 }

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -57,8 +57,9 @@ namespace eosio { namespace cdt {
          abi_action ret;
          auto action_name = decl->getEosioActionAttr()->getName();
 
-         if (rcs[get_action_name(decl)].empty())
-            std::cout << "Warning, action <"+get_action_name(decl)+"> does not have a ricardian contract\n";
+         if (!suppress_ricardian_warnings)
+            if (rcs[get_action_name(decl)].empty())
+               std::cout << "Warning, action <"+get_action_name(decl)+"> does not have a ricardian contract\n";
 
          ret.ricardian_contract = rcs[get_action_name(decl)];
 
@@ -89,8 +90,9 @@ namespace eosio { namespace cdt {
 
          auto action_name = decl->getEosioActionAttr()->getName();
 
-         if (rcs[get_action_name(decl)].empty())
-            std::cout << "Warning, action <"+get_action_name(decl)+"> does not have a ricardian contract\n";
+         if (!suppress_ricardian_warnings)
+            if (rcs[get_action_name(decl)].empty())
+               std::cout << "Warning, action <"+get_action_name(decl)+"> does not have a ricardian contract\n";
 
          ret.ricardian_contract = rcs[get_action_name(decl)];
 

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -104,6 +104,7 @@ struct generation_utils {
    std::function<void()> error_handler;
    std::vector<std::string> resource_dirs;
    std::string contract_name;
+   bool suppress_ricardian_warnings;
 
    generation_utils( std::function<void()> err ) : error_handler(err), resource_dirs({"./"}) {}
    generation_utils( std::function<void()> err, const std::vector<std::string>& paths ) : error_handler(err), resource_dirs(paths) {}
@@ -216,6 +217,10 @@ struct generation_utils {
       return {};
    }
 
+   inline void set_suppress_ricardian_warning(bool suppress_ricardian_warnings) {
+      this->suppress_ricardian_warnings = suppress_ricardian_warnings;
+   }
+
    inline std::string get_ricardian_clauses() {
       return read_file(get_clauses_filename());
    }
@@ -228,7 +233,9 @@ struct generation_utils {
       std::map<std::string, std::string> rcs;
       simple_ricardian_tokenizer srt(contracts);
       if (contracts.empty()) {
-         std::cout << "Warning, empty ricardian clause file\n";
+         if (!suppress_ricardian_warnings) {
+            std::cout << "Warning, empty ricardian clause file\n";
+         }
          return rcs;
       }
 
@@ -244,7 +251,9 @@ struct generation_utils {
       std::vector<std::pair<std::string, std::string>> clause_pairs;
       simple_ricardian_tokenizer srt(clauses);
       if (clauses.empty()) {
-         std::cout << "Warning, empty ricardian clause file\n";
+         if (!suppress_ricardian_warnings) {
+            std::cout << "Warning, empty ricardian clause file\n";
+         }
          return clause_pairs;
       }
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description

Add commandline option `-no-missing-ricardian-clause` to `eosio-cpp`.  Apply option to build process, suppressing warnings generated while building the contract version of libc++ and the tests.  Includes some whitespace cleanup.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions

Commandline option `-no-missing-ricardian-clause` added to `eosio-cpp`.  Defaulting to false, if enabled, it suppresses warnings concerning missing Ricardian clauses on contracts and contract actions, including warnings generated when there is also no independent Ricardian clause file.  Any copy of the `-help` output of `eosio-cpp` should be refreshed to show the new option.