### PR TITLE
Building on macOS with no dependencies installed did not work.

### DIFF
--- a/scripts/eosiocdt_build_darwin.sh
+++ b/scripts/eosiocdt_build_darwin.sh
@@ -119,11 +119,11 @@ fi
 if [ $COUNT -gt 1 ]; then
 	printf "\\nThe following dependencies are required to install EOSIO:\\n"
 	printf "${DISPLAY}\\n\\n"
-	if [ $1 == 0 ]; then read -p "Do you wish to install these packages? (y/n) " answer; fi
+	if [ -z "$1" ]; then read -p "Do you wish to install these packages? (y/n) " answer; fi
 	case ${answer} in
 		1 | [Yy]* )
 			"${XCODESELECT}" --install 2>/dev/null;
-			if [ $1 == 0 ]; then read -p "Do you wish to update homebrew packages first? (y/n) " answer; fi
+			if [ -z "$1" ]; then read -p "Do you wish to update homebrew packages first? (y/n) " answer; fi
 			case ${answer} in
 				1 | [Yy]* )
 					if ! brew update; then


### PR DESCRIPTION
## Change Description
Building on a fresh macOS installation with no dependencies failed with a bash error:  `line 122: [: =: unary operator expected`.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
