### PR TITLE
Fix: add executed to EOSIO_DISPATCH()

### DIFF
--- a/libraries/eosiolib/contracts/eosio/dispatcher.hpp
+++ b/libraries/eosiolib/contracts/eosio/dispatcher.hpp
@@ -178,6 +178,7 @@ extern "C" { \
    [[eosio::wasm_entry]] \
    void apply( uint64_t receiver, uint64_t code, uint64_t action ) { \
       if( code == receiver ) { \
+         bool executed = false; \
          switch( action ) { \
             EOSIO_DISPATCH_HELPER( TYPE, MEMBERS ) \
          } \


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Related to Issue #868.

In the current code, `EOSIO_DISPATCH_INTERNAL` assumes the existence of boolean variable `executed`. There are two external entry points for that:

```
Path 1: EOSIO_ACTIONS --> EOSIO_DISPATCH_HELPER --> EOSIO_DISPATCH_INTERNAL
Path 2: EOSIO_DISPATCH --> EOSIO_DISPATCH_HELPER --> EOSIO_DISPATCH_INTERNAL
```

While `executed` is defined in `EOSIO_ACTIONS`, it is not defined in `EOSIO_DISPATCH`. This quick fix adds `executed` to `EOSIO_DISPATCH` (and does nothing else), so the assumption of the existence of `executed` now holds in both paths.

