### PR TITLE
turn off Werror for wabt

### DIFF
--- a/tools/external/wabt/CMakeLists.txt
+++ b/tools/external/wabt/CMakeLists.txt
@@ -101,7 +101,7 @@ else ()
   #   interfaces, etc.
   # disable -Wpointer-arith: this is a GCC extension, and doesn't work in MSVC.
   add_definitions(
-    -Wall -Wextra -Werror -Wno-unused-parameter -Wpointer-arith -g -std=c++11
+    -Wall -Wextra -Wno-unused-parameter -Wpointer-arith -g -std=c++11
     -Wold-style-cast -Wuninitialized
   )
 


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Turn off building wabt with `-Werror`. This is too hostile IMO (we removed it in EOSIO too) and it's causing cdt to fail building with gcc10. Another option could consider is disabling only the warnings that are causing gcc10 failures.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
