### PR TITLE
[docs] 1.7.x content and annotations updates

### DIFF
--- a/docs/05_best-practices/05_securing_your_contract.md
+++ b/docs/05_best-practices/05_securing_your_contract.md
@@ -2,16 +2,35 @@
 content_title: Securing your contract
 ---
 
-These are basic recommendations that should be the foundation of securing your smart contract:
+## Basic Recommendations
 
-1. The master git branch has the `has_auth`, `require_auth`, `require_auth2` and `require_recipient` methods available in the EOSIO library.  They can be found in detail [here](https://eosio.github.io/eosio.cdt/1.6.0-rc1/group__action.html#function-requirerecipient) and implemented [here](https://github.com/EOSIO/eos/blob/3fddb727b8f3615917707281dfd3dd3cc5d3d66d/libraries/chain/apply_context.cpp#L144) (they end up calling the methods implemented in the `apply_context` class).
+The following are basic recommendations which can be the foundation for securing your smart contract.
 
-2. Understand how each of your contracts' actions is impacting the RAM, CPU, and NET consumption, and which account ends up paying for these resources.
+### 1. Authorization Checks
 
-3. Have a solid and comprehensive development process that includes security considerations from day one of the product planning and development.
+The following methods are available in the `EOSIO` library and they can be used to implemented authorization checks in your smart contracts:
 
-4. Test your smart contracts with every update announced for the blockchain you have deployed to. To ease your work, automate the testing as much as possible so you can run them often, and improve them periodically.
+- [`has_auth`](../group__action/#function-has_auth)
+- [`require_auth`](../group__action/#function-require_auth)
+- [`require_auth2`](../how-to-guides/authorization/how_to_restrict_access_to_an_action_by_user/#3-using-require_auth2)
+- [`require_recipient`](../group__action/#function-require_recipient)
 
-5. Conduct independent smart contract audits, at least two from different organizations.
+### 2. Resource Management
 
-6. Host periodic bug bounties on your smart contracts and keep a continuous commitment to reward real security problems reported at any time.
+Understand how each of your contracts' actions is impacting the RAM, CPU, and NET consumption, and which account ends up paying for these resources.
+
+### 3. Secure by Default
+
+Have a solid and comprehensive development process that includes security considerations from day one of the product planning and development.
+
+### 4. Continuous Integration And Continuous Delivery
+
+Test your smart contracts with every update announced for the blockchain you have deployed to. To ease your work, automate the testing as much as possible so you can run them often, and improve them periodically.
+
+### 5. Security Audits
+
+Conduct independent smart contract audits, at least two from different organizations.
+
+### 6. Bug Bounties
+
+Host periodic bug bounties on your smart contracts and keep a continuous commitment to reward real security problems reported at any time.

--- a/docs/05_best-practices/09_deferred_transactions.md
+++ b/docs/05_best-practices/09_deferred_transactions.md
@@ -6,5 +6,7 @@ Deferred communication conceptually takes the form of action notifications sent 
 
 As already mentioned, deferred communication will get scheduled later at the producer's discretion. From the perspective of the originating transaction, i.e., the transaction that creates the deferred transaction, it can only determine whether the create request was submitted successfully or whether it failed (if it fails, it will fail immediately). Deferred transactions carry the authority of the contract that sends them. A transaction can cancel a deferred transaction.
 
-[[warning | Warning about deferred transaction usage]]
-| Because of the above, it is not recommended to use `deferred transactions`. There is consideration to deprecate deferred transactions in a future version.
+[[warning | Deferred Transactions Are Deprecated]]
+| As of [EOSIO 2.0 RC1](https://github.com/EOSIO/eos/releases/tag/v2.0.0-rc1) deferred transactions are deprecated.
+
+Due to the above described behaviors it is not recommended to use `deferred transactions`.

--- a/docs/06_how-to-guides/05_authorization/how_to_restrict_access_to_an_action_by_user.md
+++ b/docs/06_how-to-guides/05_authorization/how_to_restrict_access_to_an_action_by_user.md
@@ -1,14 +1,42 @@
 ---
-content_title: How to restrict access to an action by a user
+content_title: How To Perform Authorization Checks
+link_text: How To Perform Authorization Checks
 ---
 
 ## Preconditions
-- It is assumed you have the sources for a contract and one of the actions defined is getting as a parameter an account name and it is printing the account name.
 
-To restrict access to the `hi` action, you can do it in two ways:
+The following conditions are assumed:
 
-1. Using require_auth
-The below code is enforcing the action `hi` to be executed only by the account that is sent as parameter to the action, no matter what permission the account is using to sign the transaction (e.g. owner, active, code).
+1. You have the sources of a contract with one of the actions defined, let's call it `hi` action.
+2. The `hi` action has defined one input parameter `user` of type `name`.
+3. The `hi` action prints the name of the `user` account.
+4. The `hi` action needs to authorize the `user` account.
+
+## Authorization Methods
+
+To restrict access to the `hi` action, you can do it in three ways.
+
+### 1. Use eosio::check(eosio::has_auth(...)...)
+
+The below code enforces the action `hi` to be executed only by the account that is sent as parameter to the action, no matter what permission the account uses to sign the transaction (e.g. owner, active, code).
+
+[[info | Error message is custom]]
+| Observe that in this case the yielded error message is a custom one and thus it can be used to provide a better experience for the user.
+
+```cpp
+#include <capi/eosio/action.h>
+
+void hi( name user ) {
+   check(has_auth(user), "User is not authorized to perform this action.");
+   print( "Hello, ", name{user} );
+}
+```
+
+Another example can be found in the [Tic Tac Toe Tutorial](https://developers.eos.io/welcome/latest/tutorials/tic-tac-toe-game-contract/#action-handler---move).
+
+### 2. Use require_auth
+
+The below code enforces the action `hi` to be executed only by the account that is sent as parameter to the action, no matter what permission the account uses to sign the transaction (e.g. owner, active, code).
 
 ```cpp
 void hi( name user ) {
@@ -17,17 +45,21 @@ void hi( name user ) {
 }
 ```
 
-2. Or using require_auth2
+[[info | Error message is not custom]]
+| Note that this time you can not customize the yielded error message, it will be a generic authorization error message.
 
-The below code is enforcing the action `hi` to be executed only by the account that is sent as parameter to the action and only if the permission used to sign the transaction is the 'active' one. In other words, if the same user is signing the transaction with a different permission (e.g. code, owner) the execution of the action is halted.
+### 3. Use require_auth2
+
+The below code is enforces the action `hi` to be executed only by the account that is sent as parameter to the action and only if the permission used to sign the transaction is the 'active' one. In other words, if the same user uses the transaction with a different permission (e.g. code, owner) the execution of the action is halted.
 
 ```cpp
 #include <capi/eosio/action.h>
 
 void hi( name user ) {
-   require_auth2(nm.value, "active"_n.value);
+   require_auth2(user.value, "active"_n.value);
    print( "Hello, ", name{user} );
 }
 ```
 
-An example of this contract can be found [here](https://github.com/EOSIO/eosio.cdt/blob/master/examples/hello/src/hello.cpp)
+[[info | Error message is not custom]]
+| Note that this time, as well as previous method, you can not customize the yielded error message, it will be a generic authorization error message.

--- a/libraries/eosiolib/contracts/eosio/multi_index.hpp
+++ b/libraries/eosiolib/contracts/eosio/multi_index.hpp
@@ -1571,7 +1571,7 @@ class multi_index
        *  @ingroup multiindex
        *
        *  @param itr - an iterator pointing to the object to be updated
-       *  @param payer - account name of the payer for the Storage usage of the updated row
+       *  @param payer - account name of the payer for the storage usage of the updated row
        *  @param updater - lambda function that updates the target object
        *
        *  @pre itr points to an existing element
@@ -1618,7 +1618,7 @@ class multi_index
        *  @ingroup multiindex
        *
        *  @param obj - a reference to the object to be updated
-       *  @param payer - account name of the payer for the Storage usage of the updated row
+       *  @param payer - account name of the payer for the storage usage of the updated row
        *  @param updater - lambda function that updates the target object
        *
        *  @pre obj is an existing object in the table

--- a/libraries/eosiolib/core/eosio/datastream.hpp
+++ b/libraries/eosiolib/core/eosio/datastream.hpp
@@ -88,7 +88,6 @@ class datastream {
      /**
       *  Writes a byte into the stream
       *
-      *  @brief Writes a byte into the stream
       *  @param c byte to write
       *  @return true
       */
@@ -102,7 +101,6 @@ class datastream {
      /**
       *  Reads a byte from the stream
       *
-      *  @brief Reads a byte from the stream
       *  @param c - The reference to destination byte
       *  @return true
       */
@@ -111,7 +109,6 @@ class datastream {
      /**
       *  Reads a byte from the stream
       *
-      *  @brief Reads a byte from the stream
       *  @param c - The reference to destination byte
       *  @return true
       */
@@ -126,7 +123,6 @@ class datastream {
      /**
       *  Retrieves the current position of the stream
       *
-      *  @brief Retrieves the current position of the stream
       *  @return T - The current position of the stream
       */
       T pos()const { return _pos; }
@@ -135,7 +131,6 @@ class datastream {
      /**
       *  Sets the position within the current stream
       *
-      *  @brief Sets the position within the current stream
       *  @param p - The offset relative to the origin
       *  @return true if p is within the range
       *  @return false if p is not within the rawnge
@@ -145,7 +140,6 @@ class datastream {
      /**
       *  Gets the position within the current stream
       *
-      *  @brief Gets the position within the current stream
       *  @return p - The position within the current stream
       */
       inline size_t tellp()const      { return size_t(_pos - _start); }
@@ -153,27 +147,20 @@ class datastream {
      /**
       *  Returns the number of remaining bytes that can be read/skipped
       *
-      *  @brief Returns the number of remaining bytes that can be read/skipped
       *  @return size_t - The number of remaining bytes
       */
       inline size_t remaining()const  { return _end - _pos; }
     private:
       /**
        * The start position of the buffer
-       *
-       * @brief The start position of the buffer
        */
       T _start;
       /**
        * The current position of the buffer
-       *
-       * @brief The current position of the buffer
        */
       T _pos;
       /**
        * The end position of the buffer
-       *
-       * @brief The end position of the buffer
        */
       T _end;
 };
@@ -224,7 +211,6 @@ class datastream<size_t> {
      /**
       * Set new size
       *
-      * @brief Set new size
       * @param p - The new size
       * @return true
       */
@@ -454,7 +440,6 @@ inline datastream<Stream>& operator<<(datastream<Stream>& ds, const bool& d) {
 /**
  *  Deserialize a bool from a stream
  *
- *  @brief Deserialize a bool
  *  @param ds - The stream to read
  *  @param d - The destination for deserialized value
  *  @tparam Stream - Type of datastream buffer
@@ -524,7 +509,6 @@ DataStream& operator << ( DataStream& ds, const std::array<T,N>& v ) {
 /**
  *  Deserialize a fixed size std::array
  *
- *  @brief Deserialize a fixed size std::array
  *  @param ds - The stream to read
  *  @param v - The destination for deserialized value
  *  @tparam DataStream - Type of datastream
@@ -543,7 +527,6 @@ namespace _datastream_detail {
    /**
     * Check if type T is a pointer
     *
-    * @brief Check if type T is a pointer
     * @tparam T - The type to be checked
     * @return true if T is a pointer
     * @return false otherwise
@@ -558,7 +541,6 @@ namespace _datastream_detail {
    /**
     * Check if type T is a primitive type
     *
-    * @brief Check if type T is a primitive type
     * @tparam T - The type to be checked
     * @return true if T is a primitive type
     * @return false otherwise
@@ -571,9 +553,9 @@ namespace _datastream_detail {
 }
 
 /**
- *  Pointer should not be serialized, so this function will always throws an error
+ *  Deserialize a pointer
  *
- *  @brief Deserialize a a pointer
+ *  @brief Pointer should not be serialized, so this function will always throws an error
  *  @param ds - The stream to read
  *  @tparam DataStream - Type of datastream
  *  @tparam T - Type of the pointer
@@ -589,7 +571,6 @@ DataStream& operator >> ( DataStream& ds, T ) {
 /**
  *  Serialize a fixed size C array of non-primitive and non-pointer type
  *
- *  @brief Serialize a fixed size C array of non-primitive and non-pointer type
  *  @param ds - The stream to write
  *  @param v - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -609,7 +590,6 @@ DataStream& operator << ( DataStream& ds, const T (&v)[N] ) {
 /**
  *  Serialize a fixed size C array of primitive type
  *
- *  @brief Serialize a fixed size C array of primitive type
  *  @param ds - The stream to write
  *  @param v - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -627,7 +607,6 @@ DataStream& operator << ( DataStream& ds, const T (&v)[N] ) {
 /**
  *  Deserialize a fixed size C array of non-primitive and non-pointer type
  *
- *  @brief Deserialize a fixed size C array of non-primitive and non-pointer type
  *  @param ds - The stream to read
  *  @param v - The destination for deserialized value
  *  @tparam T - Type of the object contained in the array
@@ -650,7 +629,6 @@ DataStream& operator >> ( DataStream& ds, T (&v)[N] ) {
 /**
  *  Deserialize a fixed size C array of primitive type
  *
- *  @brief Deserialize a fixed size C array of primitive type
  *  @param ds - The stream to read
  *  @param v - The destination for deserialized value
  *  @tparam T - Type of the object contained in the array
@@ -671,7 +649,6 @@ DataStream& operator >> ( DataStream& ds, T (&v)[N] ) {
 /**
  *  Serialize a vector of char
  *
- *  @brief Serialize a vector of char
  *  @param ds - The stream to write
  *  @param v - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -687,7 +664,6 @@ DataStream& operator << ( DataStream& ds, const std::vector<char>& v ) {
 /**
  *  Serialize a vector
  *
- *  @brief Serialize a vector
  *  @param ds - The stream to write
  *  @param v - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -705,7 +681,6 @@ DataStream& operator << ( DataStream& ds, const std::vector<T>& v ) {
 /**
  *  Deserialize a vector of char
  *
- *  @brief Deserialize a vector of char
  *  @param ds - The stream to read
  *  @param v - The destination for deserialized value
  *  @tparam DataStream - Type of datastream
@@ -723,7 +698,6 @@ DataStream& operator >> ( DataStream& ds, std::vector<char>& v ) {
 /**
  *  Deserialize a vector
  *
- *  @brief Deserialize a vector
  *  @param ds - The stream to read
  *  @param v - The destination for deserialized value
  *  @tparam DataStream - Type of datastream
@@ -743,7 +717,6 @@ DataStream& operator >> ( DataStream& ds, std::vector<T>& v ) {
 /**
  *  Serialize a set
  *
- *  @brief Serialize a set
  *  @param ds - The stream to write
  *  @param s - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -763,7 +736,6 @@ DataStream& operator << ( DataStream& ds, const std::set<T>& s ) {
 /**
  *  Deserialize a set
  *
- *  @brief Deserialize a set
  *  @param ds - The stream to read
  *  @param s - The destination for deserialized value
  *  @tparam DataStream - Type of datastream
@@ -786,7 +758,6 @@ DataStream& operator >> ( DataStream& ds, std::set<T>& s ) {
 /**
  *  Serialize a map
  *
- *  @brief Serialize a map
  *  @param ds - The stream to write
  *  @param m - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -806,7 +777,6 @@ DataStream& operator << ( DataStream& ds, const std::map<K,V>& m ) {
 /**
  *  Deserialize a map
  *
- *  @brief Deserialize a map
  *  @param ds - The stream to read
  *  @param m - The destination for deserialized value
  *  @tparam DataStream - Type of datastream
@@ -830,7 +800,6 @@ DataStream& operator >> ( DataStream& ds, std::map<K,V>& m ) {
 /**
  *  Serialize a tuple
  *
- *  @brief Serialize a tuple
  *  @param ds - The stream to write
  *  @param t - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -848,7 +817,6 @@ DataStream& operator<<( DataStream& ds, const std::tuple<Args...>& t ) {
 /**
  *  Deserialize a tuple
  *
- *  @brief Deserialize a tuple
  *  @param ds - The stream to read
  *  @param t - The destination for deserialized value
  *  @tparam DataStream - Type of datastream
@@ -866,7 +834,6 @@ DataStream& operator>>( DataStream& ds, std::tuple<Args...>& t ) {
 /**
  *  Serialize a class
  *
- *  @brief Serialize a class
  *  @param ds - The stream to write
  *  @param v - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -884,7 +851,6 @@ DataStream& operator<<( DataStream& ds, const T& v ) {
 /**
  *  Deserialize a class
  *
- *  @brief Deserialize a class
  *  @param ds - The stream to read
  *  @param v - The destination for deserialized value
  *  @tparam DataStream - Type of datastream
@@ -902,7 +868,6 @@ DataStream& operator>>( DataStream& ds, T& v ) {
 /**
  *  Serialize a primitive type
  *
- *  @brief Serialize a primitive type
  *  @param ds - The stream to write
  *  @param v - The value to serialize
  *  @tparam DataStream - Type of datastream
@@ -918,7 +883,6 @@ DataStream& operator<<( DataStream& ds, const T& v ) {
 /**
  *  Deserialize a primitive type
  *
- *  @brief Deserialize a primitive type
  *  @param ds - The stream to read
  *  @param v - The destination for deserialized value
  *  @tparam DataStream - Type of datastream
@@ -935,7 +899,6 @@ DataStream& operator>>( DataStream& ds, T& v ) {
  * Unpack data inside a fixed size buffer as T
  *
  * @ingroup datastream
- * @brief Unpack data inside a fixed size buffer as T
  * @tparam T - Type of the unpacked data
  * @param buffer - Pointer to the buffer
  * @param len - Length of the buffer
@@ -953,7 +916,6 @@ T unpack( const char* buffer, size_t len ) {
  * Unpack data inside a variable size buffer as T
  *
  * @ingroup datastream
- * @brief Unpack data inside a variable size buffer as T
  * @tparam T - Type of the unpacked data
  * @param bytes - Buffer
  * @return T - The unpacked data
@@ -967,7 +929,6 @@ T unpack( const std::vector<char>& bytes ) {
  * Get the size of the packed data
  *
  * @ingroup datastream
- * @brief Get the size of the packed data
  * @tparam T - Type of the data to be packed
  * @param value - Data to be packed
  * @return size_t - Size of the packed data
@@ -983,7 +944,6 @@ size_t pack_size( const T& value ) {
  * Get packed data
  *
  * @ingroup datastream
- * @brief Get packed data
  * @tparam T - Type of the data to be packed
  * @param value - Data to be packed
  * @return bytes - The packed data


### PR DESCRIPTION
Backport of PR #906 to 1.7

fixes #905 as of eosio 2.0-rc1 deferred transactions are deprecated
fixes #865 Introduce the eosio::check(eosio::has_auth(...))
fixes #866 Corrections are needed on the best practices, securing your contract
fixes #871 "for the Storage usage of the updated row" lowercase inconsistent
fixes #877 delete duplicated lines in datastream class annotations