### PR TITLE
Don't default to merging data sections, it can blow out nodeos limits

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       IMAGE_TAG: "amazonlinux-2"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-30}
+    timeout: ${TIMEOUT:-60}
     skip: $SKIP_AMAZON_LINUX_2
 
   - label: ":centos: CentOS 7.7 - Build"
@@ -21,7 +21,7 @@ steps:
       IMAGE_TAG: "centos-7.7"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-30}
+    timeout: ${TIMEOUT:-60}
     skip: $SKIP_CENTOS_7
 
   - label: ":ubuntu: Ubuntu 16.04 - Build"
@@ -32,7 +32,7 @@ steps:
       IMAGE_TAG: "ubuntu-16.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-30}
+    timeout: ${TIMEOUT:-60}
     skip: $SKIP_UBUNTU_16
 
   - label: ":ubuntu: Ubuntu 18.04 - Build"
@@ -43,7 +43,7 @@ steps:
       IMAGE_TAG: "ubuntu-18.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-30}
+    timeout: ${TIMEOUT:-60}
     skip: $SKIP_UBUNTU_18
 
   - label: ":darwin: macOS 10.14 - Build"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       IMAGE_TAG: "amazonlinux-2"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-30}
     skip: $SKIP_AMAZON_LINUX_2
 
   - label: ":centos: CentOS 7.7 - Build"
@@ -21,7 +21,7 @@ steps:
       IMAGE_TAG: "centos-7.7"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-30}
     skip: $SKIP_CENTOS_7
 
   - label: ":ubuntu: Ubuntu 16.04 - Build"
@@ -32,7 +32,7 @@ steps:
       IMAGE_TAG: "ubuntu-16.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-30}
     skip: $SKIP_UBUNTU_16
 
   - label: ":ubuntu: Ubuntu 18.04 - Build"
@@ -43,7 +43,7 @@ steps:
       IMAGE_TAG: "ubuntu-18.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-30}
     skip: $SKIP_UBUNTU_18
 
   - label: ":darwin: macOS 10.14 - Build"

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -461,7 +461,7 @@ static void GetLdDefaults(std::vector<std::string>& ldopts) {
          ldopts.emplace_back("--gc-sections");
          ldopts.emplace_back("--strip-all");
       }
-      ldopts.emplace_back("--merge-data-segments");
+      ldopts.emplace_back("--no-merge-data-segments");
       if (fquery_opt || fquery_server_opt || fquery_client_opt) {
          ldopts.emplace_back("--export-table");
          ldopts.emplace_back("-other-model");


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

In LLVM9, special handling was added for `rodata` when creating the data segments. Before that, it was not handled and therefore was always not merged. This restores that behaviour to prevent having segments that are too large.

An alternative would be to remove the handling inside lld, but this feels like the less intrusive solution and clearly communicates the behaviour we want.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
