### PR TITLE
Fix test_chain::get_history

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       IMAGE_TAG: "amazonlinux-2"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-30}
+    timeout: ${TIMEOUT:-60}
     skip: $SKIP_AMAZON_LINUX_2
 
   - label: ":centos: CentOS 7.7 - Build"
@@ -21,7 +21,7 @@ steps:
       IMAGE_TAG: "centos-7.7"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-30}
+    timeout: ${TIMEOUT:-60}
     skip: $SKIP_CENTOS_7
 
   - label: ":ubuntu: Ubuntu 16.04 - Build"
@@ -32,7 +32,7 @@ steps:
       IMAGE_TAG: "ubuntu-16.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-30}
+    timeout: ${TIMEOUT:-60}
     skip: $SKIP_UBUNTU_16
 
   - label: ":ubuntu: Ubuntu 18.04 - Build"
@@ -43,7 +43,7 @@ steps:
       IMAGE_TAG: "ubuntu-18.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-30}
+    timeout: ${TIMEOUT:-60}
     skip: $SKIP_UBUNTU_18
 
   - label: ":darwin: macOS 10.14 - Build"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       IMAGE_TAG: "amazonlinux-2"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-20}
     skip: $SKIP_AMAZON_LINUX_2
 
   - label: ":centos: CentOS 7.7 - Build"
@@ -21,7 +21,7 @@ steps:
       IMAGE_TAG: "centos-7.7"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-20}
     skip: $SKIP_CENTOS_7
 
   - label: ":ubuntu: Ubuntu 16.04 - Build"
@@ -32,7 +32,7 @@ steps:
       IMAGE_TAG: "ubuntu-16.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-20}
     skip: $SKIP_UBUNTU_16
 
   - label: ":ubuntu: Ubuntu 18.04 - Build"
@@ -43,7 +43,7 @@ steps:
       IMAGE_TAG: "ubuntu-18.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-20}
     skip: $SKIP_UBUNTU_18
 
   - label: ":darwin: macOS 10.14 - Build"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       IMAGE_TAG: "amazonlinux-2"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-20}
+    timeout: ${TIMEOUT:-30}
     skip: $SKIP_AMAZON_LINUX_2
 
   - label: ":centos: CentOS 7.7 - Build"
@@ -21,7 +21,7 @@ steps:
       IMAGE_TAG: "centos-7.7"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-20}
+    timeout: ${TIMEOUT:-30}
     skip: $SKIP_CENTOS_7
 
   - label: ":ubuntu: Ubuntu 16.04 - Build"
@@ -32,7 +32,7 @@ steps:
       IMAGE_TAG: "ubuntu-16.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-20}
+    timeout: ${TIMEOUT:-30}
     skip: $SKIP_UBUNTU_16
 
   - label: ":ubuntu: Ubuntu 18.04 - Build"
@@ -43,7 +43,7 @@ steps:
       IMAGE_TAG: "ubuntu-18.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-20}
+    timeout: ${TIMEOUT:-30}
     skip: $SKIP_UBUNTU_18
 
   - label: ":darwin: macOS 10.14 - Build"

--- a/libraries/eosiolib/tester/tester.cpp
+++ b/libraries/eosiolib/tester/tester.cpp
@@ -388,7 +388,7 @@ std::optional<eosio::test_chain::get_history_result> eosio::test_chain::get_hist
    ship_protocol::result r;
    (void)convert_from_bin(r, ret->memory);
 
-   std::visit([&ret](const auto& v) { build_history_result(*ret, v); }, r);
+   std::visit([&ret](auto& v) { build_history_result(*ret, v); }, r);
    return ret;
 }
 


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

Passing a const argument to build_history_result causes it always to choose the error overload.

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
