### PR TITLE
Add support for passing reference to secondary index

### DIFF
--- a/libraries/eosiolib/contracts/eosio/multi_index.hpp
+++ b/libraries/eosiolib/contracts/eosio/multi_index.hpp
@@ -704,6 +704,11 @@ class multi_index
                _multidx->modify( *itr, payer, std::forward<Lambda&&>(updater) );
             }
 
+            template<typename Lambda>
+            void modify( const T& obj, eosio::name payer, Lambda&& updater ) {
+               _multidx->modify( obj, payer, std::forward<Lambda&&>(updater) );
+            }
+
             const_iterator erase( const_iterator itr ) {
                eosio::check( itr != cend(), "cannot pass end iterator to erase" );
 


### PR DESCRIPTION
## Change Description
Add support for passing reference to secondary index. Currently, primary index supports passing both iterator and object reference, but secondary indices only supports the case of iterator.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
