### PR TITLE
[docs] adding missing docs.json and improve annotations

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       IMAGE_TAG: "amazonlinux-2"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-60}
     skip: $SKIP_AMAZON_LINUX_2
 
   - label: ":centos: CentOS 7.7 - Build"
@@ -21,7 +21,7 @@ steps:
       IMAGE_TAG: "centos-7.7"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-60}
     skip: $SKIP_CENTOS_7
 
   - label: ":ubuntu: Ubuntu 16.04 - Build"
@@ -32,7 +32,7 @@ steps:
       IMAGE_TAG: "ubuntu-16.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-60}
     skip: $SKIP_UBUNTU_16
 
   - label: ":ubuntu: Ubuntu 18.04 - Build"
@@ -43,7 +43,7 @@ steps:
       IMAGE_TAG: "ubuntu-18.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
-    timeout: ${TIMEOUT:-10}
+    timeout: ${TIMEOUT:-60}
     skip: $SKIP_UBUNTU_18
 
   - label: ":darwin: macOS 10.14 - Build"

--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,32 @@
+{
+	"name": "eosio.cdt",
+	"generators": [
+    {
+			"name": "collate_markdown",
+			"options": {
+				"docs_dir": "docs",
+				"disable_default_filters": true,
+				"filters": [
+					{ "name": "sort" },
+					{ "name": "remove_extension" },
+					{ "name": "sanitize", "options": { "exclude": ["command-reference/eosio-*.md"] } },
+					{ "name": "capitalize", "options": { "exclude": ["command-reference/eosio-*.md"] } }
+				]
+			}
+		},
+		{
+			"name": "doxygen_to_xml",
+			"options": {
+				"INPUT": "libraries/eosiolib/contracts libraries/eosiolib/core",
+				"EXCLUDE": "libraries/eosiolib/memory.h libraries/eosiolib/memory.hpp libraries/eosiolib/action.h libraries/eosiolib/permission.h libraries/eosiolib/privileged.h libraries/eosiolib/print.h libraries/eosiolib/system.h",
+				"EXCLUDE_PATTERNS": "*.cpp *.c *.h"
+			},
+			"disable_default_filters": true,
+			"filters": []
+		},
+    {
+			"name": "doxybook",
+			"options": {}
+		}
+	]
+}

--- a/libraries/eosiolib/asset.hpp
+++ b/libraries/eosiolib/asset.hpp
@@ -21,7 +21,8 @@ namespace eosio {
     */
 
    /**
-    * @struct Stores information for owner of asset
+    * @struct asset
+    * @brief Stores information for owner of asset
     */
 
    struct asset {
@@ -382,7 +383,8 @@ namespace eosio {
    };
 
   /**
-   * @struct Extended asset which stores the information of the owner of the asset
+   * @struct extended_asset
+   * @brief Extended asset which stores the information of the owner of the asset
    */
    struct extended_asset {
       /**

--- a/libraries/eosiolib/core/eosio/asset.hpp
+++ b/libraries/eosiolib/core/eosio/asset.hpp
@@ -19,7 +19,8 @@ namespace eosio {
     */
 
    /**
-    *  Stores information for owner of asset
+    *  @struct asset
+    *  @brief Stores information for owner of asset
     *
     *  @ingroup asset
     */
@@ -385,7 +386,8 @@ namespace eosio {
    };
 
   /**
-   *  Extended asset which stores the information of the owner of the asset
+   *  @struct extended_asset
+   *  @brief Extended asset which stores the information of the owner of the asset
    *
    *  @ingroup asset
    */

--- a/libraries/eosiolib/core/eosio/symbol.hpp
+++ b/libraries/eosiolib/core/eosio/symbol.hpp
@@ -22,7 +22,8 @@ namespace eosio {
    */
 
    /**
-    *  Stores the symbol code as a uint64_t value
+    *  @class symbol_code
+    *  @brief Stores the symbol code as a uint64_t value
     *
     *  @ingroup symbol
     */
@@ -236,7 +237,8 @@ namespace eosio {
    }
 
    /**
-    *  Stores information about a symbol, the symbol can be 7 characters long.
+    *  @class symbol
+    *  @brief Stores information about a symbol, the symbol can be 7 characters long
     *
     *  @ingroup symbol
     */
@@ -374,7 +376,8 @@ namespace eosio {
    }
 
    /**
-    *  Extended asset which stores the information of the owner of the symbol
+    *  @class extended_symbol
+    *  @brief Extended asset which stores the information of the owner of the symbol
     *
     *  @ingroup symbol
     */

--- a/libraries/eosiolib/symbol.hpp
+++ b/libraries/eosiolib/symbol.hpp
@@ -24,7 +24,7 @@ namespace eosio {
    */
 
    /**
-    * @class Stores the symbol code
+    * @class symbol_code
     * @brief Stores the symbol code as a uint64_t value
     */
    class symbol_code {
@@ -230,9 +230,9 @@ namespace eosio {
    };
 
    /**
-    * @struct Stores information about a symbol, the symbol can be 7 characters long.
+    * @struct symbol
     *
-    * @brief Stores information about a symbol
+    * @brief information about a symbol, the symbol can be 7 characters long
     */
    class symbol {
    public:
@@ -349,8 +349,9 @@ namespace eosio {
    };
 
    /**
-    * @struct Extended asset which stores the information of the owner of the symbol
-    *
+    * @struct extended_symbol
+    * 
+    * @brief Extended asset which stores the information of the owner of the symbol
     */
    class extended_symbol
    {


### PR DESCRIPTION
a bunch of broken links were generated in reference documentation for cdt 1.6 because the docs.json
also a bit of improvements for annotations were done
addressing DEVREL-436