### PR TITLE
Final CDT key value cleanup

### DIFF
--- a/docs/06_how-to-guides/06_key_value/01_key_value_examples.md
+++ b/docs/06_how-to-guides/06_key_value/01_key_value_examples.md
@@ -1,4 +1,4 @@
-### kv_table Example:
+### kv::table Example:
 ```cpp
 #include <eosio/eosio.hpp>
 using namespace eosio;
@@ -15,7 +15,7 @@ struct address {
    auto full_name() const { return first_name + " " + last_name; }
 };
 
-struct address_table : kv_table<address> {
+struct address_table : kv::table<address> {
    index<name>    account_name{"accname"_n, &address::account_name};
    index<std::string> full_name{"fullname"_n, &address::full_name};
 
@@ -35,7 +35,7 @@ class addressbook : contract {
 ### KV_NAMED_INDEX Example:
 ```cpp
 // Assume the address definition above
-struct address_table : kv_table<address> {
+struct address_table : kv::table<address> {
    KV_NAMED_INDEX("accname"_n, account_name)
    KV_NAMED_INDEX("fullname"_n, full_name)
 
@@ -53,14 +53,14 @@ struct myrecord {
    std::tuple<uint32_t, bool> secondary_2;
 }
 
-struct myramtable : kv_table<myrecord> {
+struct myramtable : kv::table<myrecord> {
     // Assume some indexes
     myramtable(eosio::name contract_name) {
         init(contract_name, "testtable"_n, "eosio.kvram"_n, ...)
     }
 }
 
-struct mydisktable : kv_table<myrecord> {
+struct mydisktable : kv::table<myrecord> {
     // Assume some indexes
     mydisktable(eosio::name contract_name) {
         init(contract_name, "testtable"_n, "eosio.kvdisk"_n, ...)
@@ -68,7 +68,7 @@ struct mydisktable : kv_table<myrecord> {
 }
 ```
 
-### kv_table::put Example:
+### kv::table::put Example:
 ```cpp
 // This assumes the code from the class example.
 void myaction() {
@@ -84,7 +84,7 @@ void myaction() {
 }
 ```
 
-### kv_table::erase Example:
+### kv::table::erase Example:
 ```cpp
 // This assumes the code from the class example.
 void myaction() {

--- a/libraries/eosiolib/contracts/eosio/key_value.hpp
+++ b/libraries/eosiolib/contracts/eosio/key_value.hpp
@@ -187,14 +187,15 @@ static constexpr eosio::name kv_disk = "eosio.kvdisk"_n;
 template <typename ...Types>
 using non_unique = std::tuple<Types...>;
 
+namespace kv {
 template<typename T>
-class kv_table;
+class table;
 
-namespace kv_detail {
+namespace internal {
 
-   class kv_table_base;
+   class table_base;
 
-   class kv_index {
+   class index_base {
 
    public:
       eosio::name index_name;
@@ -204,10 +205,10 @@ namespace kv_detail {
       key_type to_table_key(const key_type& k) const { return prefix + k; }
 
    protected:
-      kv_index() = default;
+      index_base() = default;
 
       template <typename KF, typename T>
-      kv_index(eosio::name index_name, KF&& kf, T*) : index_name{index_name} {
+      index_base(eosio::name index_name, KF&& kf, T*) : index_name{index_name} {
          key_function = [=](const void* t) {
             return make_key(std::invoke(kf, static_cast<const T*>(t)));
          };
@@ -219,13 +220,13 @@ namespace kv_detail {
 
       void get(const key_type& key, void* ret_val, void (*deserialize)(void*, const void*, std::size_t)) const;
 
-      kv_table_base* tbl;
+      table_base* tbl;
       key_type prefix;
 
    private:
       template<typename T>
-      friend class eosio::kv_table;
-      friend class kv_table_base;
+      friend class table;
+      friend class table_base;
       friend class iterator_base;
 
       std::function<key_type(const void*)> key_function;
@@ -233,9 +234,9 @@ namespace kv_detail {
       virtual void setup() = 0;
    };
 
-   class kv_table_base {
+   class table_base {
     protected:
-      friend class kv_index;
+      friend class index_base;
       friend class iterator_base;
       eosio::name contract_name;
       eosio::name table_name;
@@ -243,8 +244,8 @@ namespace kv_detail {
 
       eosio::name primary_index_name;
 
-      kv_index* primary_index;
-      std::vector<kv_index*> secondary_indices;
+      index_base* primary_index;
+      std::vector<index_base*> secondary_indices;
 
       void put(const void* value, void* old_value,
                std::size_t (*get_size)(const void*),
@@ -326,9 +327,9 @@ namespace kv_detail {
 
          internal_use_do_not_use::kv_erase(db_name, contract_name.value, tbl_key.data(), tbl_key.size());
       }
-   };
+   }; // end of table_base
 
-   inline void kv_index::get(const key_type& key, void* ret_val, void (*deserialize)(void*, const void*, std::size_t)) const {
+   inline void index_base::get(const key_type& key, void* ret_val, void (*deserialize)(void*, const void*, std::size_t)) const {
       uint32_t value_size;
       uint32_t actual_data_size;
 
@@ -376,7 +377,7 @@ namespace kv_detail {
 
       iterator_base() = default;
 
-      iterator_base(uint32_t itr, status itr_stat, const kv_index* index) : itr{itr}, itr_stat{itr_stat}, index{index} {}
+      iterator_base(uint32_t itr, status itr_stat, const index_base* idx) : itr{itr}, itr_stat{itr_stat}, idx{idx} {}
 
       iterator_base(iterator_base&& other) :
          itr(std::exchange(other.itr, 0)),
@@ -427,13 +428,13 @@ namespace kv_detail {
          void* deserialize_buffer = buffer;
          size_t deserialize_size = actual_value_size;
 
-         bool is_primary = index->index_name == index->tbl->primary_index_name;
+         bool is_primary = idx->index_name == idx->tbl->primary_index_name;
          if (!is_primary) {
-            auto success = internal_use_do_not_use::kv_get(index->tbl->db_name, index->contract_name.value, (char*)buffer, actual_value_size, actual_data_size);
+            auto success = internal_use_do_not_use::kv_get(idx->tbl->db_name, idx->contract_name.value, (char*)buffer, actual_value_size, actual_data_size);
             eosio::check(success, "failure getting primary key in `value()`");
 
             void* pk_buffer = actual_data_size > detail::max_stack_buffer_size ? malloc(actual_data_size) : alloca(actual_data_size);
-            internal_use_do_not_use::kv_get_data(index->tbl->db_name, 0, (char*)pk_buffer, actual_data_size);
+            internal_use_do_not_use::kv_get_data(idx->tbl->db_name, 0, (char*)pk_buffer, actual_data_size);
 
             deserialize_buffer = pk_buffer;
             deserialize_size = actual_data_size;
@@ -469,7 +470,7 @@ namespace kv_detail {
       uint32_t itr;
       status itr_stat;
 
-      const kv_index* index;
+      const index_base* idx;
 
       int compare(const iterator_base& b) const {
          bool a_is_end = !itr || itr_stat == status::iterator_end;
@@ -484,9 +485,9 @@ namespace kv_detail {
             return internal_use_do_not_use::kv_it_compare(itr, b.itr);
          }
       }
-   };
+   }; // end of iterator_base
 
-}
+}  // namespace internal
 
 /**
  * @defgroup keyvalue Key Value Table
@@ -501,15 +502,15 @@ namespace kv_detail {
  * @tparam T         - the type of the data stored as the value of the table
   */
 template<typename T>
-class kv_table : kv_detail::kv_table_base {
+class table : internal::table_base {
 public:
    template<typename K>
    class index;
 
 private:
-   using kv_index = kv_detail::kv_index;
+   using index_base = internal::index_base;
 
-   class base_iterator : public kv_detail::iterator_base {
+   class base_iterator : public internal::iterator_base {
    public:
       using iterator_base::iterator_base;
       /**
@@ -520,7 +521,7 @@ private:
        */
       T value() const {
          T val;
-         iterator_base::value(&val, &kv_table::deserialize_fun);
+         iterator_base::value(&val, &table::deserialize_fun);
          return val;
       }
    };
@@ -528,7 +529,7 @@ private:
    class iterator : public base_iterator {
       using base_iterator::itr;
       using base_iterator::itr_stat;
-      using base_iterator::index;
+      using base_iterator::idx;
 
       template<typename K>
       friend class index;
@@ -538,7 +539,7 @@ private:
 
       iterator() = default;
 
-      iterator(uint32_t itr, status itr_stat, const kv_index* index) : base_iterator{itr, itr_stat, index} {}
+      iterator(uint32_t itr, status itr_stat, const index_base* idx) : base_iterator{itr, itr_stat, idx} {}
 
       iterator(iterator&& other) : base_iterator{std::move(other)} {}
 
@@ -548,7 +549,7 @@ private:
          }
          itr = std::exchange(other.itr, 0);
          itr_stat = std::move(other.itr_stat);
-         index = std::move(other.index);
+         idx = std::move(other.idx);
          return *this;
       }
 
@@ -560,7 +561,7 @@ private:
 
       iterator& operator--() {
          if (!itr) {
-            itr = internal_use_do_not_use::kv_it_create(static_cast<kv_table*>(index->tbl)->db_name, index->contract_name.value, index->prefix.data(), index->prefix.size());
+            itr = internal_use_do_not_use::kv_it_create(static_cast<table*>(idx->tbl)->db_name, idx->contract_name.value, idx->prefix.data(), idx->prefix.size());
          }
          itr_stat = static_cast<status>(internal_use_do_not_use::kv_it_prev(itr));
          eosio::check(itr_stat != status::iterator_end, "decremented past the beginning");
@@ -595,14 +596,14 @@ private:
    class reverse_iterator : public base_iterator {
       using base_iterator::itr;
       using base_iterator::itr_stat;
-      using base_iterator::index;
+      using base_iterator::idx;
 
    public:
       using status = typename base_iterator::status;
 
       reverse_iterator() = default;
 
-      reverse_iterator(uint32_t itr, status itr_stat, const kv_index* index) : base_iterator{itr, itr_stat, index} {}
+      reverse_iterator(uint32_t itr, status itr_stat, const index_base* idx) : base_iterator{itr, itr_stat, idx} {}
 
       reverse_iterator(reverse_iterator&& other) : base_iterator{std::move(other)} {}
 
@@ -612,7 +613,7 @@ private:
          }
          itr = std::exchange(other.itr, 0);
          itr_stat = std::move(other.itr_stat);
-         index = std::move(other.index);
+         idx = std::move(other.idx);
          return *this;
       }
 
@@ -624,7 +625,7 @@ private:
 
       reverse_iterator& operator--() {
          if (!itr) {
-            itr = internal_use_do_not_use::kv_it_create(static_cast<kv_table*>(index->tbl)->db_name, index->contract_name.value, index->prefix.data(), index->prefix.size());
+            itr = internal_use_do_not_use::kv_it_create(static_cast<table*>(idx->tbl)->db_name, idx->contract_name.value, idx->prefix.data(), idx->prefix.size());
             itr_stat = static_cast<status>(internal_use_do_not_use::kv_it_lower_bound(itr, "", 0));
          }
          itr_stat = static_cast<status>(internal_use_do_not_use::kv_it_next(itr));
@@ -672,7 +673,7 @@ private:
    };
 
 public:
-   using iterator = kv_table::iterator;
+   using iterator = table::iterator;
    using value_type = T;
 
    /**
@@ -686,18 +687,18 @@ public:
     *
     * @tparam K - The type of the key used in the index.
     */
-   template <typename K>
-   class index : public kv_index {
+   template<typename K>
+   class tbl_index : public index_base {
    public:
-      using iterator = kv_table::iterator;
-      using kv_table<T>::kv_index::tbl;
-      using kv_table<T>::kv_index::table_name;
-      using kv_table<T>::kv_index::contract_name;
-      using kv_table<T>::kv_index::index_name;
-      using kv_table<T>::kv_index::prefix;
+      using iterator = table::iterator;
+      using table<T>::index_base::tbl;
+      using table<T>::index_base::table_name;
+      using table<T>::index_base::contract_name;
+      using table<T>::index_base::index_name;
+      using table<T>::index_base::prefix;
 
       template <typename KF>
-      index(eosio::name name, KF&& kf) : kv_index{name, kf, (T*)nullptr} {
+      tbl_index(eosio::name name, KF&& kf) : index_base{name, kf, (T*)nullptr} {
          static_assert(std::is_same_v<K, std::remove_cv_t<std::decay_t<decltype(std::invoke(kf, std::declval<const T*>()))>>>,
                "Make sure the variable/function passed to the constructor returns the same type as the template parameter.");
       }
@@ -712,7 +713,7 @@ public:
       iterator find(const K& key) const {
          auto t_key = prefix + make_key(key);
 
-         uint32_t itr = internal_use_do_not_use::kv_it_create(static_cast<kv_table*>(tbl)->db_name, contract_name.value, prefix.data(), prefix.size());
+         uint32_t itr = internal_use_do_not_use::kv_it_create(static_cast<table*>(tbl)->db_name, contract_name.value, prefix.data(), prefix.size());
          int32_t itr_stat = internal_use_do_not_use::kv_it_lower_bound(itr, t_key.data(), t_key.size());
 
          auto cmp = internal_use_do_not_use::kv_it_key_compare(itr, t_key.data(), t_key.size());
@@ -736,7 +737,7 @@ public:
          uint32_t value_size;
          auto t_key = prefix + make_key(key);
 
-         return internal_use_do_not_use::kv_get(static_cast<kv_table*>(tbl)->db_name, contract_name.value, t_key.data(), t_key.size(), value_size);
+         return internal_use_do_not_use::kv_get(static_cast<table*>(tbl)->db_name, contract_name.value, t_key.data(), t_key.size(), value_size);
       }
 
       /**
@@ -762,7 +763,7 @@ public:
       std::optional<T> get(const K& key) const {
          std::optional<T> ret_val;
          auto k = prefix + make_key(key);
-         kv_index::get(k, &ret_val, &deserialize_optional_fun);
+         index_base::get(k, &ret_val, &deserialize_optional_fun);
          return ret_val;
       }
 
@@ -773,7 +774,7 @@ public:
        * @return An iterator to the object with the lowest key (by this index) in the table.
        */
       iterator begin() const {
-         uint32_t itr = internal_use_do_not_use::kv_it_create(static_cast<kv_table*>(tbl)->db_name, contract_name.value, prefix.data(), prefix.size());
+         uint32_t itr = internal_use_do_not_use::kv_it_create(static_cast<table*>(tbl)->db_name, contract_name.value, prefix.data(), prefix.size());
          int32_t itr_stat = internal_use_do_not_use::kv_it_lower_bound(itr, "", 0);
 
          return {itr, static_cast<typename iterator::status>(itr_stat), this};
@@ -796,7 +797,7 @@ public:
        * @return A reverse iterator to the object with the highest key (by this index) in the table.
        */
       reverse_iterator rbegin() const {
-         uint32_t itr = internal_use_do_not_use::kv_it_create(static_cast<kv_table*>(tbl)->db_name, contract_name.value, prefix.data(), prefix.size());
+         uint32_t itr = internal_use_do_not_use::kv_it_create(static_cast<table*>(tbl)->db_name, contract_name.value, prefix.data(), prefix.size());
          int32_t itr_stat = internal_use_do_not_use::kv_it_prev(itr);
 
          return {itr, static_cast<typename iterator::status>(itr_stat), this};
@@ -821,7 +822,7 @@ public:
       iterator lower_bound(const K& key) const {
          auto t_key = prefix + make_key(key);
 
-         uint32_t itr = internal_use_do_not_use::kv_it_create(static_cast<kv_table*>(tbl)->db_name, contract_name.value, prefix.data(), prefix.size());
+         uint32_t itr = internal_use_do_not_use::kv_it_create(static_cast<table*>(tbl)->db_name, contract_name.value, prefix.data(), prefix.size());
          int32_t itr_stat = internal_use_do_not_use::kv_it_lower_bound(itr, t_key.data(), t_key.size());
 
          return {itr, static_cast<typename iterator::status>(itr_stat), this};
@@ -885,7 +886,7 @@ public:
     */
    void put(const T& value, eosio::name payer) {
       T old_value;
-      kv_table_base::put(&value, &old_value, &get_size_fun, &deserialize_fun, &serialize_fun, payer);
+      table_base::put(&value, &old_value, &get_size_fun, &deserialize_fun, &serialize_fun, payer);
    }
 
    /* @cond PRIVATE */
@@ -911,15 +912,15 @@ public:
     * @param key - The key of the value to be removed.
     */
    void erase(const T& value) {
-      kv_table_base::erase(&value);
+      table_base::erase(&value);
    }
 
 protected:
-   kv_table() = default;
+   table() = default;
 
    template <typename I>
    void setup_indices(I& index) {
-      kv_index* idx = &index;
+      index_base* idx = &index;
       idx->contract_name = contract_name;
       idx->table_name = table_name;
       idx->tbl = this;
@@ -955,8 +956,9 @@ private:
 
    template <typename Type>
    constexpr void validate_types(Type& t) {
-      constexpr bool is_kv_index = std::is_base_of_v<kv_index, std::decay_t<Type>>;
-      static_assert(is_kv_index, "Incorrect type passed to init. Must be a reference to an index.");
+      constexpr bool is_index = std::is_base_of_v<index_base, std::decay_t<Type>>;
+      static_assert(is_index, "Incorrect type passed to init. Must be a reference to an index.");
    }
-};
-} // eosio
+}; // class table
+} // namespace kv
+} // namespace eosio

--- a/tests/unit/test_contracts/kv_make_key_tests.cpp
+++ b/tests/unit/test_contracts/kv_make_key_tests.cpp
@@ -34,7 +34,7 @@ struct my_struct {
    }
 };
 
-struct my_table : eosio::kv_table<my_struct> {
+struct my_table : eosio::kv::table<my_struct> {
    KV_NAMED_INDEX("t1"_n, tname)
    KV_NAMED_INDEX("t2"_n, tstring)
    KV_NAMED_INDEX("t3"_n, tui64)

--- a/tests/unit/test_contracts/kv_multiple_indices_tests.cpp
+++ b/tests/unit/test_contracts/kv_multiple_indices_tests.cpp
@@ -19,7 +19,7 @@ struct my_struct {
    }
 };
 
-struct my_table : eosio::kv_table<my_struct> {
+struct my_table : eosio::kv::table<my_struct> {
    KV_NAMED_INDEX("primarykey"_n, primary_key)
    KV_NAMED_INDEX("foo"_n, foo)
    KV_NAMED_INDEX("bar"_n, bar)

--- a/tests/unit/test_contracts/kv_single_index_tests.cpp
+++ b/tests/unit/test_contracts/kv_single_index_tests.cpp
@@ -8,7 +8,7 @@ struct my_struct {
    }
 };
 
-struct my_table : eosio::kv_table<my_struct> {
+struct my_table : eosio::kv::table<my_struct> {
    KV_NAMED_INDEX("primary"_n, primary_key);
 
    my_table(eosio::name contract_name) {

--- a/tests/unit/test_contracts/kv_variant_tests.cpp
+++ b/tests/unit/test_contracts/kv_variant_tests.cpp
@@ -11,7 +11,7 @@ struct my_struct_v2 {
    uint64_t age;
 };
 
-struct my_table : eosio::kv_table<my_struct_v> {
+struct my_table : eosio::kv::table<my_struct_v> {
    KV_NAMED_INDEX("fullname"_n, full_name);
    KV_NAMED_INDEX("age"_n, age);
 
@@ -20,7 +20,7 @@ struct my_table : eosio::kv_table<my_struct_v> {
    }
 };
 
-struct my_table_v : eosio::kv_table<std::variant<my_struct_v, my_struct_v2>> {
+struct my_table_v : eosio::kv::table<std::variant<my_struct_v, my_struct_v2>> {
    index<std::string> primary_key{"fullname"_n, [](const auto& obj) {
       return std::visit([&](auto&& a) {
          using V = std::decay_t<decltype(a)>;


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
Currently, the key value API in EOSIO.CDT has the prefix 'kv_' used almost everywhere.  This is problematic in a couple of ways, one is that the user has to type 'kv_' a lot and it is a bit reminiscent of C style "namespacing".  So, we should simply add the namespace 'kv' over these data types.  These names will also need to be updated in tests, abigen, and docs.

It also, appears that 'kv_singleton' either made its way back in or it fully wasn't removed in any of the previous PRs.  This data type can be massive foot gun for developers and it is difficult to concisely express the semantics of it.  The remedy is to just remove the data type 'kv_singleton' and any usages from the tests.
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
