### PR TITLE
Quoting correction

### DIFF
--- a/docs/09_tutorials/02_abi-variants.md
+++ b/docs/09_tutorials/02_abi-variants.md
@@ -157,4 +157,4 @@ class [[eosio::contract]] multi_index_example : public contract {
 | Be aware, it is not recommend to use `eosio::binary_extension` inside variant definition, this can lead to data corruption unless one is very careful in understanding how these two templates work and how the ABI gets generated!
 
 [[Info | Implementation location]]
-| The implementation for ABI `variants' can be found [here](https://github.com/EOSIO/eos/pull/5652).
+| The implementation for ABI `variants` can be found [here](https://github.com/EOSIO/eos/pull/5652).


### PR DESCRIPTION
Corrected how "variants" is quoted in the final section of the doc.

- [ ] API Changes
- [ ] Documentation Additions
