### PR TITLE
Make the contracts generated with --allow-names usable.

### DIFF
--- a/tools/external/wabt/src/tools/postpass.cc
+++ b/tools/external/wabt/src/tools/postpass.cc
@@ -68,6 +68,12 @@ static void ParseOptions(int argc, char** argv) {
         s_outfile = argument;
         ConvertBackslashToSlash(&s_outfile);
       });
+  parser.AddOption(
+      'n', "allow-names",
+      "Preserve the name section",
+      []() {
+         s_write_binary_options.write_debug_names = true;
+      });
   parser.AddArgument("filename", OptionParser::ArgumentCount::One,
                      [](const char* argument) {
                        s_infile = argument;
@@ -145,7 +151,7 @@ int ProgramMain(int argc, char** argv) {
     Module module;
     const bool kStopOnFirstError = true;
     ReadBinaryOptions options(s_features, s_log_stream_s.get(),
-                              stub, kStopOnFirstError,
+                              s_write_binary_options.write_debug_names, kStopOnFirstError,
                               stub);
     result = ReadBinaryIr(s_infile.c_str(), file_data.data(),
                           file_data.size(), &options, &error_handler, &module);

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -598,7 +598,6 @@ static Options CreateOptions(bool add_defaults=true) {
    if (!entry_opt.empty())
       ldopts.insert(ldopts.end(), {"--entry", entry_opt});
    if (allow_names_opt) {
-      ldopts.emplace_back("-fno-post-pass");
       ldopts.emplace_back("--allow-names");
    }
 #endif

--- a/tools/ld/eosio-ld.cpp.in
+++ b/tools/ld/eosio-ld.cpp.in
@@ -43,7 +43,12 @@ int main(int argc, const char **argv) {
         std::cout << "Error: eosio.pp not found! (Try reinstalling eosio.wasmsdk)" << std::endl;
         return -1;
      }
-     if (!eosio::cdt::environment::exec_subprogram("eosio-pp", {opts.output_fn})) 
+     std::vector<std::string> pp_opts;
+     if(allow_names_opt) {
+        pp_opts.push_back("--allow-names");
+     }
+     pp_opts.push_back(opts.output_fn);
+     if (!eosio::cdt::environment::exec_subprogram("eosio-pp", pp_opts))
         return -1;
      if ( !llvm::sys::fs::exists( opts.output_fn ) ) {
         return -1;

--- a/tools/toolchain-tester/main.py
+++ b/tools/toolchain-tester/main.py
@@ -10,7 +10,6 @@ from typing import List
 from printer import Printer as P
 from printer import print_test_results, print_test_results_machine
 
-from settings import Config
 from testrunner import TestRunner
 from testsuite import TestSuite
 
@@ -49,7 +48,6 @@ def main():
 
     args = parser.parse_args()
 
-    Config.cdt_path = args.cdt
     P.verbose = args.verbose
 
     abs_test_directory = os.path.abspath(args.test_directory)
@@ -68,7 +66,7 @@ def main():
         if os.path.isdir(abs_f):
             test_directories.append(abs_f)
 
-    test_suites = list(map(lambda d: TestSuite(d), test_directories))
+    test_suites = list(map(lambda d: TestSuite(d, args.cdt), test_directories))
 
     start = timer()
     test_runner = TestRunner(test_suites, args.tests, args.jobs)

--- a/tools/toolchain-tester/tests.py
+++ b/tools/toolchain-tester/tests.py
@@ -45,7 +45,7 @@ class Test(ABC):
         cf = self.test_json.get("compile_flags")
         args = cf if cf else []
 
-        eosio_cpp = os.path.join(Config.cdt_path, "eosio-cpp")
+        eosio_cpp = os.path.join(self.test_suite.cdt_path, "eosio-cpp")
         self._run(eosio_cpp, args)
 
     def handle_test_result(self, res: subprocess.CompletedProcess, expected_pass=True):

--- a/tools/toolchain-tester/testsuite.py
+++ b/tools/toolchain-tester/testsuite.py
@@ -12,8 +12,9 @@ class TestSuite:
     by the directory structure.
     """
 
-    def __init__(self, directory: str):
+    def __init__(self, directory: str, cdt_path: str):
         self.directory = directory
+        self.cdt_path = cdt_path
         self.tests: List[tests.Test] = []
         self.name = self._get_name()
         self.test_type = self._get_test_type()


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

This allows creating contracts that can be used with profiler (https://github.com/EOSIO/eos/pull/9541) to get human readable names for functions.

Note that the contracts may be too large to put on chain.  Running `wasm-strip` will remove the debug names section while still allowing the unstripped wasm to be used with off-chain tooling.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
