### PR TITLE
[docs] WiP: fix the non-unique indexes in kv-address-book example

### DIFF
--- a/examples/kv_addr_book/include/kv_addr_book.hpp
+++ b/examples/kv_addr_book/include/kv_addr_book.hpp
@@ -3,10 +3,12 @@
 using namespace eosio;
 using namespace std;
 
-using last_name_idx_t = std::tuple<std::string>;
 using fullname_t = std::tuple<std::string, std::string>;
 using address_t = std::tuple<std::string, std::string, std::string, std::string, eosio::name>;
 using country_personal_id_t = std::pair<std::string, std::string>;
+
+// TO DO: testing...
+using last_name_idx_t = std::tuple<std::string>;
 
 // this structure defines the data stored in the kv::table
 struct person {
@@ -24,6 +26,8 @@ struct person {
    fullname_t full_name_last_first;
    address_t address;
    country_personal_id_t country_personal_id;
+
+   // TO DO: testing...
    last_name_idx_t last_name_idx_data_member;
 };
 
@@ -84,15 +88,14 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
       index<fullname_t> full_name_last_first_idx {
          name{"lastnameidx"_n},
          &person::full_name_last_first};
+      index<address_t> address_idx {
+         name{"addressidx"_n},
+         &person::address};
+
+      // TO DO: testing...
       index<last_name_idx_t> last_name_idx {
          name{"lstnameidx"},
          &person::last_name_idx_data_member};
-
-      // non-unique index defined using the KV_NAMED_INDEX macro
-      // note: you can not name your index like you were able to do before (ending in `_idx`),
-      // instead when using the macro you have to pass the name of the data member which 
-      // is indexed and that will give the name of the index as well
-      KV_NAMED_INDEX("address"_n, address)
 
       address_table(eosio::name contract_name) {
          init(contract_name,
@@ -100,7 +103,7 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
             country_personal_id_uidx,
             full_name_first_last_idx,
             full_name_last_first_idx,
-            address);
+            address_idx);
       }
    };
 

--- a/examples/kv_addr_book/include/kv_addr_book.hpp
+++ b/examples/kv_addr_book/include/kv_addr_book.hpp
@@ -19,7 +19,7 @@ struct person {
    std::string country;
    std::string personal_id;
 
-   // data members supporting the indexes built this structure
+   // data members supporting the indexes built for this structure
    fullname_t full_name_first_last;
    fullname_t full_name_last_first;
    street_city_state_cntry_t street_city_state_cntry;

--- a/examples/kv_addr_book/include/kv_addr_book.hpp
+++ b/examples/kv_addr_book/include/kv_addr_book.hpp
@@ -5,7 +5,7 @@ using namespace std;
 
 using last_name_idx_t = std::tuple<std::string>;
 using fullname_t = std::tuple<std::string, std::string>;
-using street_city_state_cntry_t = std::tuple<std::string, std::string, std::string, std::string, eosio::name>;
+using address_t = std::tuple<std::string, std::string, std::string, std::string, eosio::name>;
 using country_personal_id_t = std::pair<std::string, std::string>;
 
 // this structure defines the data stored in the kv::table
@@ -22,7 +22,7 @@ struct person {
    // data members supporting the indexes built for this structure
    fullname_t full_name_first_last;
    fullname_t full_name_last_first;
-   street_city_state_cntry_t street_city_state_cntry;
+   address_t address;
    country_personal_id_t country_personal_id;
    last_name_idx_t last_name_idx_data_member;
 };
@@ -49,7 +49,7 @@ struct person_factory {
             .personal_id = personal_id,
             .full_name_first_last = {first_name, last_name},
             .full_name_last_first = {last_name, first_name},
-            .street_city_state_cntry = {street, city, state, country, account_name},
+            .address = {street, city, state, country, account_name},
             .country_personal_id = {country, personal_id},
             .last_name_idx_data_member = {last_name}
          };
@@ -92,7 +92,7 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
       // note: you can not name your index like you were able to do before (ending in `_idx`),
       // instead when using the macro you have to pass the name of the data member which 
       // is indexed and that will give the name of the index as well
-      KV_NAMED_INDEX("address"_n, street_city_state_cntry)
+      KV_NAMED_INDEX("address"_n, address)
 
       address_table(eosio::name contract_name) {
          init(contract_name,
@@ -100,7 +100,7 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
             country_personal_id_uidx,
             full_name_first_last_idx,
             full_name_last_first_idx,
-            street_city_state_cntry);
+            address);
       }
    };
 

--- a/examples/kv_addr_book/include/kv_addr_book.hpp
+++ b/examples/kv_addr_book/include/kv_addr_book.hpp
@@ -3,9 +3,9 @@
 using namespace eosio;
 using namespace std;
 
-using last_name_idx_t = eosio::non_unique<std::string>;
-using fullname_t = eosio::non_unique<std::string, std::string>;
-using street_city_state_cntry_t = eosio::non_unique<eosio::name, std::string, std::string, std::string, std::string>;
+using last_name_idx_t = std::tuple<std::string>;
+using fullname_t = std::tuple<std::string, std::string>;
+using street_city_state_cntry_t = std::tuple<std::string, std::string, std::string, std::string, eosio::name>;
 using country_personal_id_t = std::pair<std::string, std::string>;
 
 // this structure defines the data stored in the kv::table
@@ -49,7 +49,7 @@ struct person_factory {
             .personal_id = personal_id,
             .full_name_first_last = {first_name, last_name},
             .full_name_last_first = {last_name, first_name},
-            .street_city_state_cntry = {account_name, street, city, state, country},
+            .street_city_state_cntry = {street, city, state, country, account_name},
             .country_personal_id = {country, personal_id},
             .last_name_idx_data_member = {last_name}
          };

--- a/examples/kv_addr_book/src/kv_addr_book.cpp
+++ b/examples/kv_addr_book/src/kv_addr_book.cpp
@@ -106,10 +106,17 @@ std::vector<person> kv_addr_book::getbyaddress(
 
    eosio::name min_account_name{0};
    eosio::name max_account_name{UINT_MAX};
-   auto list_of_persons = addresses.address.range(
+
+   auto list_of_persons = addresses.address_idx.range(
       {street, city, state, country, min_account_name}, 
       {street, city, state, country, max_account_name});
-   // return found list of person from action
+
+   eosio::print_f("Found % person(s). ", list_of_persons.size());
+
+   for (auto& person : list_of_persons) {
+      print_person(person, false);
+   }
+   // return found list of persons from action
    return list_of_persons;
 }
 

--- a/examples/kv_addr_book/src/kv_addr_book.cpp
+++ b/examples/kv_addr_book/src/kv_addr_book.cpp
@@ -78,7 +78,7 @@ std::vector<person> kv_addr_book::getbylastname(std::string last_name) {
    for (auto& person : list_of_persons) {
       print_person(person, false);
    }
-      // return found list of person from action
+   // return found list of person from action
    return list_of_persons;
 }
 

--- a/examples/kv_addr_book/src/kv_addr_book.cpp
+++ b/examples/kv_addr_book/src/kv_addr_book.cpp
@@ -107,8 +107,8 @@ std::vector<person> kv_addr_book::getbyaddress(
    eosio::name min_account_name{0};
    eosio::name max_account_name{UINT_MAX};
    auto list_of_persons = addresses.street_city_state_cntry.range(
-      {min_account_name, street, city, state, country}, 
-      {max_account_name, street, city, state, country});
+      {street, city, state, country, min_account_name}, 
+      {street, city, state, country, max_account_name});
    // return found list of person from action
    return list_of_persons;
 }

--- a/examples/kv_addr_book/src/kv_addr_book.cpp
+++ b/examples/kv_addr_book/src/kv_addr_book.cpp
@@ -106,7 +106,7 @@ std::vector<person> kv_addr_book::getbyaddress(
 
    eosio::name min_account_name{0};
    eosio::name max_account_name{UINT_MAX};
-   auto list_of_persons = addresses.street_city_state_cntry.range(
+   auto list_of_persons = addresses.address.range(
       {street, city, state, country, min_account_name}, 
       {street, city, state, country, max_account_name});
    // return found list of person from action


### PR DESCRIPTION
WiP

fix the non-unique indexes to be able to showcase the get all persons in the addressbook with the same last name scenario.