### PR TITLE
[develop] Fix U18 develop build.

### DIFF
--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -29,6 +29,8 @@ else # Linux
     if [[ $BUILDKITE == true ]]; then
         # Generate Base Images
         $CICD_DIR/generate-base-images.sh
+        if [[ "$IMAGE_TAG" == 'ubuntu-18.04' ]]; then
+          FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-develop'
     fi
 
     COMMANDS="$PRE_COMMANDS && $BUILD_COMMANDS"

--- a/.cicd/build.sh
+++ b/.cicd/build.sh
@@ -31,6 +31,7 @@ else # Linux
         $CICD_DIR/generate-base-images.sh
         if [[ "$IMAGE_TAG" == 'ubuntu-18.04' ]]; then
           FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-develop'
+        fi
     fi
 
     COMMANDS="$PRE_COMMANDS && $BUILD_COMMANDS"

--- a/.cicd/integration-tests.sh
+++ b/.cicd/integration-tests.sh
@@ -19,12 +19,12 @@ if [[ -f $BUILDKITE_ENV_FILE ]]; then
         evars="$evars --env ${var%%=*}"
     done < "$BUILDKITE_ENV_FILE"
 fi
-set +e
 
 if [[ "$BUILDKITE" == 'true' && "$IMAGE_TAG" == 'ubuntu-18.04' ]]; then
   FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-develop'
 fi
 
+set +e
 eval docker run $ARGS $evars $FULL_TAG bash -c \"$COMMANDS\"
 EXIT_STATUS=$?
 

--- a/.cicd/integration-tests.sh
+++ b/.cicd/integration-tests.sh
@@ -20,7 +20,12 @@ if [[ -f $BUILDKITE_ENV_FILE ]]; then
     done < "$BUILDKITE_ENV_FILE"
 fi
 set +e
-eval docker run $ARGS $evars $IMAGE_TAG bash -c \"$COMMANDS\"
+
+if [[ "$BUILDKITE" == 'true' && "$IMAGE_TAG" == 'ubuntu-18.04' ]]; then
+  FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-develop'
+fi
+
+eval docker run $ARGS $evars $FULL_TAG bash -c \"$COMMANDS\"
 EXIT_STATUS=$?
 
 # buildkite

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -40,7 +40,7 @@ steps:
       - "./.cicd/build.sh"
       - "tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
     env:
-      IMAGE_TAG: "eosio/ci-contracts-builder:base-ubuntu-18.04-develop"
+      IMAGE_TAG: "ubuntu-18.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
     timeout: ${TIMEOUT:-60}
@@ -321,7 +321,7 @@ steps:
       - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 18.04 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
       - "./.cicd/integration-tests.sh"
     env:
-      IMAGE_TAG: "eosio/ci-contracts-builder:base-ubuntu-18.04-develop"
+      IMAGE_TAG: "ubuntu-18.04"
     agents:
       queue: "automation-eks-eos-tester-fleet"
     timeout: ${TIMEOUT:-10}


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
The Ubuntu 18.04 build was incorrectly building a tag name to use for it's build based on the contract builder image being used:
- Set back to using default `ubuntu-18.04` as `IMAGE_TAG`.
  - Let's us ensure the correct container exists for unit and toolchain tests as well as community PRs.
- Check if Buildkite and using Ubuntu 18.04 for build step.
  - If so, explicitly use the contract builder container.
  - Same for integration test steps.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
