### PR TITLE
Enable support of setkvparams in CDT

### DIFF
--- a/libraries/eosiolib/capi/eosio/privileged.h
+++ b/libraries/eosiolib/capi/eosio/privileged.h
@@ -106,6 +106,16 @@ __attribute__((eosio_wasm_import))
 uint32_t get_blockchain_parameters_packed( char* data, uint32_t datalen );
 
 /**
+ * Set the KV parameters
+ *
+ * @param data - pointer to KV parameters packed as bytes
+ * @param datalen - size of the packed KV parameters
+ * @pre `data` is a valid pointer to a range of memory at least `datalen` bytes long that contains packed KV params data
+ */
+__attribute__((eosio_wasm_import))
+void set_kv_parameters_packed( const char* data, uint32_t datalen );
+
+/**
  * Pre-activate protocol feature
  *
  * @param feature_digest - digest of the protocol feature to pre-activate

--- a/libraries/eosiolib/contracts/eosio/privileged.hpp
+++ b/libraries/eosiolib/contracts/eosio/privileged.hpp
@@ -27,6 +27,9 @@ namespace eosio {
          __attribute__((eosio_wasm_import))
          uint32_t get_blockchain_parameters_packed( char* data, uint32_t datalen );
 
+         __attribute__((eosio_wasm_import))
+         void set_kv_parameters_packed( const char* data, uint32_t datalen );
+
          __attribute((eosio_wasm_import))
          int64_t set_proposed_producers( char*, uint32_t );
 
@@ -51,8 +54,8 @@ namespace eosio {
    struct blockchain_parameters {
 
       /**
-      * The maxiumum net usage in instructions for a block
-      * @brief the maxiumum net usage in instructions for a block
+      * The maximum net usage in instructions for a block
+      * @brief the maximum net usage in instructions for a block
       */
       uint64_t max_block_net_usage;
 
@@ -92,8 +95,8 @@ namespace eosio {
       uint32_t context_free_discount_net_usage_den;
 
       /**
-      * The maxiumum billable cpu usage (in microseconds) for a block
-      * @brief The maxiumum billable cpu usage (in microseconds) for a block
+      * The maximum billable cpu usage (in microseconds) for a block
+      * @brief The maximum billable cpu usage (in microseconds) for a block
       */
       uint32_t max_block_cpu_usage;
 
@@ -181,6 +184,43 @@ namespace eosio {
     *  @param params - It will be replaced with the retrieved blockchain params
     */
    void get_blockchain_parameters(eosio::blockchain_parameters& params);
+
+   /**
+    *  Tunable KV configuration that can be changed via consensus
+    *  @ingroup privileged
+    */
+   struct kv_parameters {
+      /**
+      * The maximum key size
+      * @brief The maximum key size
+      */
+      uint32_t max_key_size;
+
+      /**
+      * The maximum value size
+      * @brief The maximum value size
+      */
+      uint32_t max_value_size;
+
+      /**
+       * The maximum number of iterators
+      * @brief The maximum number of iterators
+       */
+      uint32_t max_iterators;
+
+      EOSLIB_SERIALIZE( kv_parameters,
+                        (max_key_size)
+                        (max_value_size)(max_iterators)
+      )
+   };
+
+   /**
+    *  Set the kv parameters
+    *
+    *  @ingroup privileged
+    *  @param params - New kv parameters to set
+    */
+   void set_kv_parameters(const eosio::kv_parameters& params);
 
     /**
     *  Get the resource limits of an account

--- a/libraries/eosiolib/eosiolib.cpp
+++ b/libraries/eosiolib/eosiolib.cpp
@@ -14,6 +14,8 @@ namespace eosio {
      __attribute__((eosio_wasm_import))
      uint32_t get_blockchain_parameters_packed(char*, uint32_t);
      __attribute__((eosio_wasm_import))
+     void set_kv_parameters_packed(const char*, uint32_t);
+     __attribute__((eosio_wasm_import))
      int64_t set_proposed_producers( char *producer_data, uint32_t producer_data_size );
      __attribute__((eosio_wasm_import))
      uint32_t get_active_producers(uint64_t*, uint32_t);
@@ -60,6 +62,19 @@ namespace eosio {
       eosio::check( size <= sizeof(buf), "buffer is too small" );
       eosio::datastream<const char*> ds( buf, size_t(size) );
       ds >> params;
+   }
+
+   void set_kv_parameters(const eosio::kv_parameters& params) {
+      // set_kv_parameters_packed expects version, max_key_size,
+      // max_value_size, and max_iterators,
+      // while kv_parameters only contains max_key_size, max_value_size,
+      // and max_iterators. That's why we place uint32_t in front
+      // of kv_parameters in buf
+      char buf[sizeof(uint32_t) + sizeof(eosio::kv_parameters)];
+      eosio::datastream<char *> ds( buf, sizeof(buf) );
+      ds << uint32_t(0);  // fill in version
+      ds << params;
+      set_kv_parameters_packed( buf, ds.tellp() );
    }
 
    std::optional<uint64_t> set_proposed_producers( const std::vector<producer_key>& prods ) {

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -34,6 +34,9 @@ extern "C" {
    void set_blockchain_parameters_packed( char* data, uint32_t datalen ) {
       return intrinsics::get().call<intrinsics::set_blockchain_parameters_packed>(data, datalen);
    }
+   void set_kv_parameters_packed( const char* data, uint32_t datalen ) {
+      return intrinsics::get().call<intrinsics::set_kv_parameters_packed>(data, datalen);
+   }
    bool is_privileged( capi_name account ) {
       return intrinsics::get().call<intrinsics::is_privileged>(account);
    }

--- a/libraries/native/native/eosio/intrinsics_def.hpp
+++ b/libraries/native/native/eosio/intrinsics_def.hpp
@@ -46,6 +46,7 @@ intrinsic_macro(set_proposed_producers) \
 intrinsic_macro(set_proposed_producers_ex) \
 intrinsic_macro(get_blockchain_parameters_packed) \
 intrinsic_macro(set_blockchain_parameters_packed) \
+intrinsic_macro(set_kv_parameters_packed) \
 intrinsic_macro(is_privileged) \
 intrinsic_macro(set_privileged) \
 intrinsic_macro(is_feature_activated) \

--- a/tests/unit/test_contracts/kv_bios/kv_bios.cpp
+++ b/tests/unit/test_contracts/kv_bios/kv_bios.cpp
@@ -4,7 +4,7 @@
 
 extern "C" __attribute__((eosio_wasm_import)) void set_resource_limit(int64_t, int64_t, int64_t);
 extern "C" __attribute__((eosio_wasm_import)) uint32_t get_kv_parameters_packed(void* params, uint32_t size, uint32_t max_version);
-extern "C" __attribute__((eosio_wasm_import)) void set_kv_parameters_packed(const void* params, uint32_t size);
+extern "C" __attribute__((eosio_wasm_import)) void set_kv_parameters_packed(const char* params, uint32_t size);
 
 using namespace eosio;
 
@@ -30,7 +30,9 @@ class [[eosio::contract]] kv_bios : eosio::contract {
       limits[1] = k;
       limits[2] = v;
       limits[3] = i;
-      set_kv_parameters_packed(limits, sizeof(limits));
+      char limits_buf[sizeof(limits)];
+      memcpy(limits_buf, limits, sizeof(limits));
+      set_kv_parameters_packed(limits_buf, sizeof(limits));
       int sz = get_kv_parameters_packed(nullptr, 0, 0);
       std::fill_n(limits, sizeof(limits)/sizeof(limits[0]), 0xFFFFFFFFu);
       check(sz == 16, "wrong kv parameters size");


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This PR is the CDT part of the task that adding support for setting KV Parameters to `eosio.system` contract and `eosio.bios` contract https://github.com/EOSIO/eosio.contracts/pull/532. It adds `set_kv_parameters` and all necessary definitions. The changes were tested using the tests introduced in https://github.com/EOSIO/eosio.contracts/pull/532.


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
