### PR TITLE
Build and Push GCR Image

### DIFF
--- a/.cicd/legacy-docker-build.sh
+++ b/.cicd/legacy-docker-build.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 set -eo pipefail
-echo "--- :arrow_down: Downloading package"
+echo '--- :arrow_down: Downloading Package :package:'
 buildkite-agent artifact download '*.deb' . --step ':ubuntu: Ubuntu 18.04 - Package Builder'
-echo "--- :key: AUTHENTICATING GOOGLE SERVICE ACCOUNT"
+echo '--- :key: Authenticating Google Service Account :gcloud:'
 gcloud --quiet auth activate-service-account b1-automation-svc@b1-automation-dev.iam.gserviceaccount.com --key-file=/etc/gcp-service-account.json
 docker-credential-gcr configure-docker
-echo "--- :hammer_and_wrench: BUILDING BUILD IMAGE"
-[[ "$BUILDKITE_TAG" != "" ]] && docker build -f .cicd/legacy.dockerfile -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH -t eosio/cdt:$BUILDKITE_TAG . || docker build -f .cicd/legacy.dockerfile -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH .
+echo '+++ :docker: Building Image'
+[[ "$BUILDKITE_TAG" != '' ]] && docker build -f .cicd/legacy.dockerfile -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH -t eosio/cdt:$BUILDKITE_TAG . || docker build -f .cicd/legacy.dockerfile -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH .
 docker tag eosio/cdt:$BUILDKITE_COMMIT gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
 docker tag eosio/cdt:$BUILDKITE_BRANCH gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
-[[ "$BUILDKITE_TAG" != "" ]] && docker tag eosio/cdt:$BUILDKITE_TAG gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :
+[[ "$BUILDKITE_TAG" != '' ]] && docker tag eosio/cdt:$BUILDKITE_TAG gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :
 docker tag eosio/cdt:latest gcr.io/b1-automation-dev/eosio/cdt:latest
-echo "--- :hand: PUSHING DOCKER IMAGES"
+echo '+++ :arrow_up: Pushing Docker Images'
 docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
 docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
-[[ "$BUILDKITE_TAG" != "" ]] && docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :
+[[ "$BUILDKITE_TAG" != '' ]] && docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :
 docker push gcr.io/b1-automation-dev/eosio/cdt:latest
-echo "--- :thought_balloon: TRASHING OLD IMAGES"
+echo '+++ :put_litter_in_its_place: Cleaning Up'
 docker rmi eosio/cdt:$BUILDKITE_COMMIT
 docker rmi eosio/cdt:$BUILDKITE_BRANCH
-[[ "$BUILDKITE_TAG" != "" ]] && docker rmi eosio/cdt:$BUILDKITE_TAG || :
+[[ "$BUILDKITE_TAG" != '' ]] && docker rmi eosio/cdt:$BUILDKITE_TAG || :
 docker rmi eosio/cdt:latest
 docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
 docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
-[[ "$BUILDKITE_TAG" != "" ]] && docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :
+[[ "$BUILDKITE_TAG" != '' ]] && docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :
 docker rmi gcr.io/b1-automation-dev/eosio/cdt:latest

--- a/.cicd/legacy-docker-build.sh
+++ b/.cicd/legacy-docker-build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -eo pipefail
+echo '+++ :evergreen_tree: Configuring Environment'
+[[ ! -z "$DOCKER_REGISTRY" ]] || export DOCKER_REGISTRY="${1:-"gcr.io/b1-automation-dev/eosio/cdt"}"
 echo '--- :arrow_down: Downloading Package :package:'
 buildkite-agent artifact download '*.deb' . --step ':ubuntu: Ubuntu 18.04 - Package Builder'
 echo '--- :key: Authenticating Google Service Account :gcloud:'
@@ -9,21 +11,21 @@ echo '+++ :docker: Building Image'
 DOCKER_BUILD_COMMAND="docker build -f '.cicd/legacy.dockerfile' -t 'eosio/cdt:latest' -t 'eosio/cdt:$BUILDKITE_COMMIT' -t 'eosio/cdt:$BUILDKITE_BRANCH'$([[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || echo " -t 'eosio/cdt:$BUILDKITE_TAG'") ."
 echo "$ $DOCKER_BUILD_COMMAND"
 eval $DOCKER_BUILD_COMMAND
-docker tag eosio/cdt:$BUILDKITE_COMMIT gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
-docker tag eosio/cdt:$BUILDKITE_BRANCH gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
-[[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || docker tag eosio/cdt:$BUILDKITE_TAG gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG
-docker tag eosio/cdt:latest gcr.io/b1-automation-dev/eosio/cdt:latest
+docker tag eosio/cdt:$BUILDKITE_COMMIT $DOCKER_REGISTRY:$BUILDKITE_COMMIT
+docker tag eosio/cdt:$BUILDKITE_BRANCH $DOCKER_REGISTRY:$BUILDKITE_BRANCH
+[[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || docker tag eosio/cdt:$BUILDKITE_TAG $DOCKER_REGISTRY:$BUILDKITE_TAG
+docker tag eosio/cdt:latest $DOCKER_REGISTRY:latest
 echo '+++ :arrow_up: Pushing Docker Images'
-docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
-docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
-[[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG
-docker push gcr.io/b1-automation-dev/eosio/cdt:latest
+docker push $DOCKER_REGISTRY:$BUILDKITE_COMMIT
+docker push $DOCKER_REGISTRY:$BUILDKITE_BRANCH
+[[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || docker push $DOCKER_REGISTRY:$BUILDKITE_TAG
+docker push $DOCKER_REGISTRY:latest
 echo '+++ :put_litter_in_its_place: Cleaning Up'
 docker rmi eosio/cdt:$BUILDKITE_COMMIT
 docker rmi eosio/cdt:$BUILDKITE_BRANCH
 [[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || docker rmi eosio/cdt:$BUILDKITE_TAG
 docker rmi eosio/cdt:latest
-docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
-docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
-[[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG
-docker rmi gcr.io/b1-automation-dev/eosio/cdt:latest
+docker rmi $DOCKER_REGISTRY:$BUILDKITE_COMMIT
+docker rmi $DOCKER_REGISTRY:$BUILDKITE_BRANCH
+[[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || docker rmi $DOCKER_REGISTRY:$BUILDKITE_TAG
+docker rmi $DOCKER_REGISTRY:latest

--- a/.cicd/legacy-docker-build.sh
+++ b/.cicd/legacy-docker-build.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 set -eo pipefail
 echo "--- :arrow_down: Downloading package"
-buildkite-agent artifact download "build/packages/*.deb" docker/dev/. --step ":ubuntu: Ubuntu 18.04 Package Builder"
+buildkite-agent artifact download '*.deb' . --step ':ubuntu: Ubuntu 18.04 - Package Builder'
 echo "--- :key: AUTHENTICATING GOOGLE SERVICE ACCOUNT"
 gcloud --quiet auth activate-service-account b1-automation-svc@b1-automation-dev.iam.gserviceaccount.com --key-file=/etc/gcp-service-account.json
 docker-credential-gcr configure-docker
 echo "--- :hammer_and_wrench: BUILDING BUILD IMAGE"
-cd docker/dev
-[[ "$BUILDKITE_TAG" != "" ]] && docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH -t eosio/cdt:$BUILDKITE_TAG . || docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH .
+[[ "$BUILDKITE_TAG" != "" ]] && docker build -f .cicd/legacy.dockerfile -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH -t eosio/cdt:$BUILDKITE_TAG . || docker build -f .cicd/legacy.dockerfile -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH .
 docker tag eosio/cdt:$BUILDKITE_COMMIT gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
 docker tag eosio/cdt:$BUILDKITE_BRANCH gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
 [[ "$BUILDKITE_TAG" != "" ]] && docker tag eosio/cdt:$BUILDKITE_TAG gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :

--- a/.cicd/legacy-docker-build.sh
+++ b/.cicd/legacy-docker-build.sh
@@ -6,24 +6,24 @@ echo '--- :key: Authenticating Google Service Account :gcloud:'
 gcloud --quiet auth activate-service-account b1-automation-svc@b1-automation-dev.iam.gserviceaccount.com --key-file=/etc/gcp-service-account.json
 docker-credential-gcr configure-docker
 echo '+++ :docker: Building Image'
-DOCKER_BUILD_COMMAND="docker build -f '.cicd/legacy.dockerfile' -t 'eosio/cdt:latest' -t 'eosio/cdt:$BUILDKITE_COMMIT' -t 'eosio/cdt:$BUILDKITE_BRANCH'$([[ -z "$BUILDKITE_TAG" ]] || echo " -t 'eosio/cdt:$BUILDKITE_TAG'") ."
+DOCKER_BUILD_COMMAND="docker build -f '.cicd/legacy.dockerfile' -t 'eosio/cdt:latest' -t 'eosio/cdt:$BUILDKITE_COMMIT' -t 'eosio/cdt:$BUILDKITE_BRANCH'$([[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || echo " -t 'eosio/cdt:$BUILDKITE_TAG'") ."
 echo "$ $DOCKER_BUILD_COMMAND"
 eval $DOCKER_BUILD_COMMAND
 docker tag eosio/cdt:$BUILDKITE_COMMIT gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
 docker tag eosio/cdt:$BUILDKITE_BRANCH gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
-[[ "$BUILDKITE_TAG" != '' ]] && docker tag eosio/cdt:$BUILDKITE_TAG gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :
+[[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || docker tag eosio/cdt:$BUILDKITE_TAG gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG
 docker tag eosio/cdt:latest gcr.io/b1-automation-dev/eosio/cdt:latest
 echo '+++ :arrow_up: Pushing Docker Images'
 docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
 docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
-[[ "$BUILDKITE_TAG" != '' ]] && docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :
+[[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG
 docker push gcr.io/b1-automation-dev/eosio/cdt:latest
 echo '+++ :put_litter_in_its_place: Cleaning Up'
 docker rmi eosio/cdt:$BUILDKITE_COMMIT
 docker rmi eosio/cdt:$BUILDKITE_BRANCH
-[[ "$BUILDKITE_TAG" != '' ]] && docker rmi eosio/cdt:$BUILDKITE_TAG || :
+[[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || docker rmi eosio/cdt:$BUILDKITE_TAG
 docker rmi eosio/cdt:latest
 docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
 docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
-[[ "$BUILDKITE_TAG" != '' ]] && docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :
+[[ -z "$BUILDKITE_TAG" || "$BUILDKITE_BRANCH" == "$BUILDKITE_TAG" ]] || docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG
 docker rmi gcr.io/b1-automation-dev/eosio/cdt:latest

--- a/.cicd/legacy-docker-build.sh
+++ b/.cicd/legacy-docker-build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+echo "--- :arrow_down: Downloading package" && \
+buildkite-agent artifact download "build/packages/*.deb" docker/dev/. --step ":ubuntu: Ubuntu 18.04 Package Builder" && \
+echo "--- :key: AUTHENTICATING GOOGLE SERVICE ACCOUNT" && \
+gcloud --quiet auth activate-service-account b1-automation-svc@b1-automation-dev.iam.gserviceaccount.com --key-file=/etc/gcp-service-account.json && \
+docker-credential-gcr configure-docker && \
+echo "--- :hammer_and_wrench: BUILDING BUILD IMAGE" && \
+cd docker/dev && \
+[[ "$BUILDKITE_TAG" != "" ]] && docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH -t eosio/cdt:$BUILDKITE_TAG . || docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH . && \
+docker tag eosio/cdt:$BUILDKITE_COMMIT gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
+docker tag eosio/cdt:$BUILDKITE_BRANCH gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH && \
+[[ "$BUILDKITE_TAG" != "" ]] && docker tag eosio/cdt:$BUILDKITE_TAG gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || : && \
+docker tag eosio/cdt:latest gcr.io/b1-automation-dev/eosio/cdt:latest && \
+echo "--- :hand: PUSHING DOCKER IMAGES" && \
+docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
+docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH && \
+[[ "$BUILDKITE_TAG" != "" ]] && docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || : && \
+docker push gcr.io/b1-automation-dev/eosio/cdt:latest && \
+echo "--- :thought_balloon: TRASHING OLD IMAGES" && \
+docker rmi eosio/cdt:$BUILDKITE_COMMIT && \
+docker rmi eosio/cdt:$BUILDKITE_BRANCH && \
+[[ "$BUILDKITE_TAG" != "" ]] && docker rmi eosio/cdt:$BUILDKITE_TAG || : && \
+docker rmi eosio/cdt:latest && \
+docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
+docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH && \
+[[ "$BUILDKITE_TAG" != "" ]] && docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || : && \
+docker rmi gcr.io/b1-automation-dev/eosio/cdt:latest

--- a/.cicd/legacy-docker-build.sh
+++ b/.cicd/legacy-docker-build.sh
@@ -6,7 +6,9 @@ echo '--- :key: Authenticating Google Service Account :gcloud:'
 gcloud --quiet auth activate-service-account b1-automation-svc@b1-automation-dev.iam.gserviceaccount.com --key-file=/etc/gcp-service-account.json
 docker-credential-gcr configure-docker
 echo '+++ :docker: Building Image'
-[[ "$BUILDKITE_TAG" != '' ]] && docker build -f .cicd/legacy.dockerfile -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH -t eosio/cdt:$BUILDKITE_TAG . || docker build -f .cicd/legacy.dockerfile -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH .
+DOCKER_BUILD_COMMAND="docker build -f '.cicd/legacy.dockerfile' -t 'eosio/cdt:latest' -t 'eosio/cdt:$BUILDKITE_COMMIT' -t 'eosio/cdt:$BUILDKITE_BRANCH'$([[ -z "$BUILDKITE_TAG" ]] || echo " -t 'eosio/cdt:$BUILDKITE_TAG'") ."
+echo "$ $DOCKER_BUILD_COMMAND"
+eval $DOCKER_BUILD_COMMAND
 docker tag eosio/cdt:$BUILDKITE_COMMIT gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
 docker tag eosio/cdt:$BUILDKITE_BRANCH gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
 [[ "$BUILDKITE_TAG" != '' ]] && docker tag eosio/cdt:$BUILDKITE_TAG gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :

--- a/.cicd/legacy-docker-build.sh
+++ b/.cicd/legacy-docker-build.sh
@@ -1,27 +1,28 @@
 #!/bin/bash
-echo "--- :arrow_down: Downloading package" && \
-buildkite-agent artifact download "build/packages/*.deb" docker/dev/. --step ":ubuntu: Ubuntu 18.04 Package Builder" && \
-echo "--- :key: AUTHENTICATING GOOGLE SERVICE ACCOUNT" && \
-gcloud --quiet auth activate-service-account b1-automation-svc@b1-automation-dev.iam.gserviceaccount.com --key-file=/etc/gcp-service-account.json && \
-docker-credential-gcr configure-docker && \
-echo "--- :hammer_and_wrench: BUILDING BUILD IMAGE" && \
-cd docker/dev && \
-[[ "$BUILDKITE_TAG" != "" ]] && docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH -t eosio/cdt:$BUILDKITE_TAG . || docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH . && \
-docker tag eosio/cdt:$BUILDKITE_COMMIT gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
-docker tag eosio/cdt:$BUILDKITE_BRANCH gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH && \
-[[ "$BUILDKITE_TAG" != "" ]] && docker tag eosio/cdt:$BUILDKITE_TAG gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || : && \
-docker tag eosio/cdt:latest gcr.io/b1-automation-dev/eosio/cdt:latest && \
-echo "--- :hand: PUSHING DOCKER IMAGES" && \
-docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
-docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH && \
-[[ "$BUILDKITE_TAG" != "" ]] && docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || : && \
-docker push gcr.io/b1-automation-dev/eosio/cdt:latest && \
-echo "--- :thought_balloon: TRASHING OLD IMAGES" && \
-docker rmi eosio/cdt:$BUILDKITE_COMMIT && \
-docker rmi eosio/cdt:$BUILDKITE_BRANCH && \
-[[ "$BUILDKITE_TAG" != "" ]] && docker rmi eosio/cdt:$BUILDKITE_TAG || : && \
-docker rmi eosio/cdt:latest && \
-docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
-docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH && \
-[[ "$BUILDKITE_TAG" != "" ]] && docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || : && \
+set -eo pipefail
+echo "--- :arrow_down: Downloading package"
+buildkite-agent artifact download "build/packages/*.deb" docker/dev/. --step ":ubuntu: Ubuntu 18.04 Package Builder"
+echo "--- :key: AUTHENTICATING GOOGLE SERVICE ACCOUNT"
+gcloud --quiet auth activate-service-account b1-automation-svc@b1-automation-dev.iam.gserviceaccount.com --key-file=/etc/gcp-service-account.json
+docker-credential-gcr configure-docker
+echo "--- :hammer_and_wrench: BUILDING BUILD IMAGE"
+cd docker/dev
+[[ "$BUILDKITE_TAG" != "" ]] && docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH -t eosio/cdt:$BUILDKITE_TAG . || docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH .
+docker tag eosio/cdt:$BUILDKITE_COMMIT gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
+docker tag eosio/cdt:$BUILDKITE_BRANCH gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
+[[ "$BUILDKITE_TAG" != "" ]] && docker tag eosio/cdt:$BUILDKITE_TAG gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :
+docker tag eosio/cdt:latest gcr.io/b1-automation-dev/eosio/cdt:latest
+echo "--- :hand: PUSHING DOCKER IMAGES"
+docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
+docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
+[[ "$BUILDKITE_TAG" != "" ]] && docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :
+docker push gcr.io/b1-automation-dev/eosio/cdt:latest
+echo "--- :thought_balloon: TRASHING OLD IMAGES"
+docker rmi eosio/cdt:$BUILDKITE_COMMIT
+docker rmi eosio/cdt:$BUILDKITE_BRANCH
+[[ "$BUILDKITE_TAG" != "" ]] && docker rmi eosio/cdt:$BUILDKITE_TAG || :
+docker rmi eosio/cdt:latest
+docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT
+docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH
+[[ "$BUILDKITE_TAG" != "" ]] && docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || :
 docker rmi gcr.io/b1-automation-dev/eosio/cdt:latest

--- a/.cicd/legacy.dockerfile
+++ b/.cicd/legacy.dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+
+# Install required packages
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates curl wget && rm -rf /var/lib/apt/lists/*
+
+# Install CDT from deb package
+ADD build/packages/*.deb /
+RUN for filename in $(ls *.deb); do /usr/bin/dpkg -i "$filename" && rm -f "$filename"; done
+
+USER root

--- a/.cicd/legacy.dockerfile
+++ b/.cicd/legacy.dockerfile
@@ -1,8 +1,10 @@
 FROM ubuntu:18.04
-
-# Install required packages
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install openssl ca-certificates curl wget && rm -rf /var/lib/apt/lists/*
-
+# aptitude
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive && \
+    apt-get install -y ca-certificates curl openssl wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 # Install CDT from deb package
 ADD build/packages/*.deb /
 RUN for filename in $(ls *.deb); do /usr/bin/dpkg -i "$filename" && rm -f "$filename"; done

--- a/.cicd/legacy.dockerfile
+++ b/.cicd/legacy.dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && \
     apt-get install -y ca-certificates curl openssl wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-# Install CDT from deb package
-ADD build/packages/*.deb /
-RUN for filename in $(ls *.deb); do /usr/bin/dpkg -i "$filename" && rm -f "$filename"; done
-
+# eosio.cdt
+ADD ./*.deb /eosio.cdt/
+RUN cd /eosio.cdt && \
+    for filename in $(ls *.deb); do /usr/bin/dpkg -i "$filename" && rm -f "$filename"; done
 USER root

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -423,8 +423,8 @@ steps:
 
   - wait
 
-  - command: .cicd/legacy-docker-build.sh | # Docker Build
-    label: "Docker Build Builder"
+  - label: ":docker: Docker Build"
+    command: .cicd/legacy-docker-build.sh | # Docker Build
     agents:
       queue: "automation-docker-builder-fleet"
     timeout: 300

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -424,7 +424,7 @@ steps:
   - wait
 
   - label: ":docker: Docker Build"
-    command: .cicd/legacy-docker-build.sh | # Docker Build
+    command: .cicd/legacy-docker-build.sh # legacy docker Build
     agents:
       queue: "automation-docker-builder-fleet"
     timeout: 300

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -421,3 +421,37 @@ steps:
     agents:
       queue: "automation-basic-builder-fleet"
     timeout: 5
+
+  - wait
+
+  - command: | # Docker Build
+        echo "--- :arrow_down: Downloading package" && \
+        buildkite-agent artifact download "build/packages/*.deb" docker/dev/. --step ":ubuntu: Ubuntu 18.04 Package Builder" && \
+        echo "--- :key: AUTHENTICATING GOOGLE SERVICE ACCOUNT" && \
+        gcloud --quiet auth activate-service-account b1-automation-svc@b1-automation-dev.iam.gserviceaccount.com --key-file=/etc/gcp-service-account.json && \
+        docker-credential-gcr configure-docker && \
+        echo "--- :hammer_and_wrench: BUILDING BUILD IMAGE" && \
+        cd docker/dev && \
+        [[ "$BUILDKITE_TAG" != "" ]] && docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH -t eosio/cdt:$BUILDKITE_TAG . || docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH . && \
+        docker tag eosio/cdt:$BUILDKITE_COMMIT gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
+        docker tag eosio/cdt:$BUILDKITE_BRANCH gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH && \
+        [[ "$BUILDKITE_TAG" != "" ]] && docker tag eosio/cdt:$BUILDKITE_TAG gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || : && \
+        docker tag eosio/cdt:latest gcr.io/b1-automation-dev/eosio/cdt:latest && \
+        echo "--- :hand: PUSHING DOCKER IMAGES" && \
+        docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
+        docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH && \
+        [[ "$BUILDKITE_TAG" != "" ]] && docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || : && \
+        docker push gcr.io/b1-automation-dev/eosio/cdt:latest && \
+        echo "--- :thought_balloon: TRASHING OLD IMAGES" && \
+        docker rmi eosio/cdt:$BUILDKITE_COMMIT && \
+        docker rmi eosio/cdt:$BUILDKITE_BRANCH && \
+        [[ "$BUILDKITE_TAG" != "" ]] && docker rmi eosio/cdt:$BUILDKITE_TAG || : && \
+        docker rmi eosio/cdt:latest && \
+        docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
+        docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH && \
+        [[ "$BUILDKITE_TAG" != "" ]] && docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || : && \
+        docker rmi gcr.io/b1-automation-dev/eosio/cdt:latest
+    label: "Docker Build Builder"
+    agents:
+      queue: "automation-docker-builder-fleet"
+    timeout: 300

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -423,33 +423,7 @@ steps:
 
   - wait
 
-  - command: | # Docker Build
-        echo "--- :arrow_down: Downloading package" && \
-        buildkite-agent artifact download "build/packages/*.deb" docker/dev/. --step ":ubuntu: Ubuntu 18.04 Package Builder" && \
-        echo "--- :key: AUTHENTICATING GOOGLE SERVICE ACCOUNT" && \
-        gcloud --quiet auth activate-service-account b1-automation-svc@b1-automation-dev.iam.gserviceaccount.com --key-file=/etc/gcp-service-account.json && \
-        docker-credential-gcr configure-docker && \
-        echo "--- :hammer_and_wrench: BUILDING BUILD IMAGE" && \
-        cd docker/dev && \
-        [[ "$BUILDKITE_TAG" != "" ]] && docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH -t eosio/cdt:$BUILDKITE_TAG . || docker build -t eosio/cdt:latest -t eosio/cdt:$BUILDKITE_COMMIT -t eosio/cdt:$BUILDKITE_BRANCH . && \
-        docker tag eosio/cdt:$BUILDKITE_COMMIT gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
-        docker tag eosio/cdt:$BUILDKITE_BRANCH gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH && \
-        [[ "$BUILDKITE_TAG" != "" ]] && docker tag eosio/cdt:$BUILDKITE_TAG gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || : && \
-        docker tag eosio/cdt:latest gcr.io/b1-automation-dev/eosio/cdt:latest && \
-        echo "--- :hand: PUSHING DOCKER IMAGES" && \
-        docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
-        docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH && \
-        [[ "$BUILDKITE_TAG" != "" ]] && docker push gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || : && \
-        docker push gcr.io/b1-automation-dev/eosio/cdt:latest && \
-        echo "--- :thought_balloon: TRASHING OLD IMAGES" && \
-        docker rmi eosio/cdt:$BUILDKITE_COMMIT && \
-        docker rmi eosio/cdt:$BUILDKITE_BRANCH && \
-        [[ "$BUILDKITE_TAG" != "" ]] && docker rmi eosio/cdt:$BUILDKITE_TAG || : && \
-        docker rmi eosio/cdt:latest && \
-        docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_COMMIT && \
-        docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_BRANCH && \
-        [[ "$BUILDKITE_TAG" != "" ]] && docker rmi gcr.io/b1-automation-dev/eosio/cdt:$BUILDKITE_TAG || : && \
-        docker rmi gcr.io/b1-automation-dev/eosio/cdt:latest
+  - command: .cicd/legacy-docker-build.sh | # Docker Build
     label: "Docker Build Builder"
     agents:
       queue: "automation-docker-builder-fleet"

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -1,5 +1,4 @@
 steps:
-
   - wait
 
   - label: ":aws: Amazon_Linux 2 - Build"


### PR DESCRIPTION
## Change Description
From [AUTO-323](https://blockone.atlassian.net/browse/AUTO-323), I attempted to resurrect an old GCR docker build and push step in our current CI pipeline, but the original build fleet must be gone because [it failed to acquire an agent](https://buildkite.com/EOSIO/eosio-dot-cdt/builds/2280#c355a85b-6563-4bed-b0a3-b80d484f80ab).

## API Changes
- [ ] API Changes
None.

## Documentation Additions
- [ ] Documentation Additions
None.