### PR TITLE
[docs] get rid of the eosio::non_unique from kv_addr_book example

### DIFF
--- a/docs/06_how-to-guides/30_key-value-api/10_how-to-use-kv-table.md
+++ b/docs/06_how-to-guides/30_key-value-api/10_how-to-use-kv-table.md
@@ -9,6 +9,9 @@ This how-to procedure demonstrates how to define and use a `Key-Value Table` (`k
 
 To accomplish this task, define the user type which will be stored in the `kv table`, and extend the `eosio::kv::table` template class with a specialized definition based on the user defined type.
 
+[[caution | Alpha version]]
+| `Key-Value Table` is designated as `alpha` and should not be used in production code.
+
 ## Prerequisites
 
 * The EOSIO development environment, for details consult the [Get Started](https://developers.eos.io/welcome/latest/getting-started/development-environment/introduction) Guide.

--- a/docs/06_how-to-guides/30_key-value-api/20_how-to-create-indexes.md
+++ b/docs/06_how-to-guides/30_key-value-api/20_how-to-create-indexes.md
@@ -157,7 +157,7 @@ Refer to the following possible implementation of a non-unique index on property
 struct person {
   eosio::name account_name;
   std::string first_name;
-  eosio::non_unique<std::string, eosio::name> last_name;
+  std::tuple<std::string, eosio::name> last_name;
   std::string personal_id;
 };
 

--- a/docs/06_how-to-guides/30_key-value-api/20_how-to-create-indexes.md
+++ b/docs/06_how-to-guides/30_key-value-api/20_how-to-create-indexes.md
@@ -110,10 +110,10 @@ class [[eosio::contract]] smrtcontract : public contract {
 ### Define a non-unique index on property first_name using the macro KV_NAMED_INDEX
 
 1. Use the `KV_NAMED_INDEX` with two parameters.
-2. Pass the name of the index as the first parameter. The parameter must be a qualified `eosio:name`. See documentation for the [eosio name restrictions](https://developers.eos.io/welcome/latest/glossary/index#account-name).
+2. Pass the name of the index as the first parameter. The parameter must be a qualified `eosio::name`. See documentation for the [eosio name restrictions](https://developers.eos.io/welcome/latest/glossary/index#account-name).
 3. Pass the name of the property for which the index is defined as the second parameter.
 
-The property used for the second parameter must be of template type `eosio::non_unique`. The first parameter of the template type must be the type of a property name which is unique. In our case the type `eosio::name` is used because property`account_name` is unique. And the second parameter must be the type of the property indexed non-uniquely, in our case the type `std::string` is used because `first_name` is the property indexed non-uniquely. It is important to mention that multiple properties can be indexed non-uniquely, thus after the first parameter type is specified multiple parameter types can follow, corresponding to more than one properties being indexed, not just one, like in your case.
+The property used for the second parameter must be of template type `std::tuple`. The first parameter must be the type of the property indexed non-uniquely, in our case the type `std::string` is used because `first_name` is the property indexed non-uniquely. And the last parameter of the tuple type must be the type of a property name which is unique. In our case the type `eosio::name` is used because property `account_name` is unique. Multiple properties can be indexed non-uniquely as well. In this case the first parameters types correspond to the properties being indexed. And, as previously already mentioned, the last parameter correspond to the type of a property name which is unique.
 
 Refer to the following possible implementation of a non-unique index on property `account_name` using macro `KV_NAMED_INDEX`:
 
@@ -122,7 +122,7 @@ Refer to the following possible implementation of a non-unique index on property
 ```cpp
 struct person {
   eosio::name account_name;
-  eosio::non_unique<eosio::name, std::string> first_name;
+  std::tuple<std::string, eosio::name> first_name;
   std::string last_name;
   std::string personal_id;
 };
@@ -147,7 +147,7 @@ class [[eosio::contract]] smrtcontract : public contract {
 2. Pass as the first parameter the name of the index. It must be a qualified `eosio:name`, see documentation for the [eosio name restrictions](https://developers.eos.io/welcome/latest/glossary/index#account-name).
 3. Pass the reference to the property for which the index is defined, `&person::last_name`, as the second parameter.
 
-The property used for the second parameter must be of template type `eosio::non_unique`. The first parameter of the template type must be the type of a property name which is unique. In our case the type `eosio::name` is used because property`account_name` is unique. And the second parameter must be the type of the property indexed non-uniquely, in our case the type `std::string` is used because `last_name` is the property indexed non-uniquely. It is important to mention that multiple properties can be indexed non-uniquely, thus after the first parameter type is specified multiple parameter types can follow, corresponding to more than one properties being indexed, not just one, like in your case.
+The property used for the second parameter must be of template type `std::tuple`. The first parameter must be the type of the property indexed non-uniquely, in our case the type `std::string` is used because `first_name` is the property indexed non-uniquely. And the last parameter of the tuple type must be the type of a property name which is unique. In our case the type `eosio::name` is used because property `account_name` is unique. Multiple properties can be indexed non-uniquely as well. In this case the first parameters types correspond to the properties being indexed. And, as previously already mentioned, the last parameter correspond to the type of a property name which is unique.
 
 Refer to the following possible implementation of a non-unique index on property `last_name` using `eosio::kv::table::index` template class:
 
@@ -157,7 +157,7 @@ Refer to the following possible implementation of a non-unique index on property
 struct person {
   eosio::name account_name;
   std::string first_name;
-  eosio::non_unique<eosio::name, std::string> last_name;
+  eosio::non_unique<std::string, eosio::name> last_name;
   std::string personal_id;
 };
 

--- a/docs/06_how-to-guides/30_key-value-api/20_how-to-create-indexes.md
+++ b/docs/06_how-to-guides/30_key-value-api/20_how-to-create-indexes.md
@@ -14,6 +14,9 @@ This how-to procedure provides instructions to create the following indexes on a
 
 The  `KV_NAMED_INDEX` macro and the `eosio::kv::table::index` template class are provided by the KV API.
 
+[[caution | Alpha version]]
+| `Key-Value Table` is designated as `alpha` and should not be used in production code.
+
 ## Prerequisites
 
 Before you begin, complete the following prerequisites:

--- a/docs/06_how-to-guides/30_key-value-api/20_how-to-create-indexes.md
+++ b/docs/06_how-to-guides/30_key-value-api/20_how-to-create-indexes.md
@@ -164,7 +164,7 @@ struct person {
 class [[eosio::contract]] smrtcontract : public contract {
     struct [[eosio::table]] address_table : eosio::kv::table<person, "kvaddrbook"_n> {
 
-     index<non_unique<name, string>> last_name_idx {
+     index<std::tuple<name, string>> last_name_idx {
         name{"persid"_n},
         &person::last_name};
 

--- a/docs/06_how-to-guides/30_key-value-api/30_how-to-upsert-into-table.md
+++ b/docs/06_how-to-guides/30_key-value-api/30_how-to-upsert-into-table.md
@@ -7,6 +7,9 @@ link_text: "How-To Upsert Into Key-Value Table"
 
 This how-to procedure provides instructions to upsert into `Key-Value Table` (`kv table`).
 
+[[caution | Alpha version]]
+| `Key-Value Table` is designated as `alpha` and should not be used in production code.
+
 Use the method `put` defined by the `eosio::kv::table` type to accomplish this task.
 
 ## Prerequisites

--- a/docs/06_how-to-guides/30_key-value-api/40_how-to-delete-from-table.md
+++ b/docs/06_how-to-guides/30_key-value-api/40_how-to-delete-from-table.md
@@ -5,7 +5,7 @@ link_text: "How-To Delete from Key-Value Table"
 
 ## Summary
 
-This how-to procedure provides instructions to delete an object from a `Key-Value Table` (`kv table’).
+This how-to procedure provides instructions to delete an object from a `Key-Value Table` (`kv table`).
 
 [[caution | Alpha version]]
 | `Key-Value Table` is designated as `alpha` and should not be used in production code.

--- a/docs/06_how-to-guides/30_key-value-api/40_how-to-delete-from-table.md
+++ b/docs/06_how-to-guides/30_key-value-api/40_how-to-delete-from-table.md
@@ -7,6 +7,9 @@ link_text: "How-To Delete from Key-Value Table"
 
 This how-to procedure provides instructions to delete an object from a `Key-Value Table` (`kv table’).
 
+[[caution | Alpha version]]
+| `Key-Value Table` is designated as `alpha` and should not be used in production code.
+
 Use the method `erase` defined by the `eosio::kv::table` type to accomplish this task.
 
 ## Prerequisites

--- a/docs/06_how-to-guides/30_key-value-api/50_how-to-iterate.md
+++ b/docs/06_how-to-guides/30_key-value-api/50_how-to-iterate.md
@@ -7,8 +7,10 @@ link_text: "How-To Iterate Through Key-Value Table"
 
 This how-to procedure provides instructions to iterate through a `Key-Value Table` (`kv table`) and read values from it.
 
-Use the `iterator` defined by the `eosio::kv::table::index` class to accomplish this task.
+[[caution | Alpha version]]
+| `Key-Value Table` is designated as `alpha` and should not be used in production code.
 
+Use the `iterator` defined by the `eosio::kv::table::index` class to accomplish this task.
 
 ## Prerequisites
 

--- a/docs/06_how-to-guides/30_key-value-api/60_how-to-check-a-record.md
+++ b/docs/06_how-to-guides/30_key-value-api/60_how-to-check-a-record.md
@@ -7,6 +7,9 @@ link_text: "How-To Check a Record in a Key-Value Table"
 
 This how-to procedure provides instructions to check if a specific object exists in a `Key-Value Table` (`kv table`).
 
+[[caution | Alpha version]]
+| `Key-Value Table` is designated as `alpha` and should not be used in production code.
+
 Use the  method `exists` defined by the `eosio::kv::table::index` class to accomplish this task.
 
 ## Prerequisites

--- a/docs/06_how-to-guides/30_key-value-api/70_how-to-find-in-table.md
+++ b/docs/06_how-to-guides/30_key-value-api/70_how-to-find-in-table.md
@@ -7,6 +7,9 @@ link_text: "How-To Find in Key-Value Table"
 
 This how-to procedure provides instructions to find a specific object in a `Key-Value Table` (`kv table`).
 
+[[caution | Alpha version]]
+| `Key-Value Table` is designated as `alpha` and should not be used in production code.
+
 Use the method  `find()` defined by the `eosio::kv::table::index` class to accomplish this task.
 
 ## Prerequisites

--- a/docs/06_how-to-guides/30_key-value-api/80_how-to-query-range-in-table.md
+++ b/docs/06_how-to-guides/30_key-value-api/80_how-to-query-range-in-table.md
@@ -47,7 +47,7 @@ class [[eosio::contract]] smrtcontract : public contract {
         name{"accname"_n},
         &person::account_name };
 
-     index<non_unique<name, string>> last_name_idx {
+     index<std::tuple<name, string>> last_name_idx {
         name{"lastname"_n},
         &person::last_name};
 
@@ -82,7 +82,7 @@ class [[eosio::contract]] smrtcontract : public contract {
         name{"accname"_n},
         &person::account_name };
 
-     index<non_unique<name, string>> last_name_idx {
+     index<std::tuple<name, string>> last_name_idx {
         name{"lastname"_n},
         &person::last_name};
 

--- a/docs/06_how-to-guides/30_key-value-api/80_how-to-query-range-in-table.md
+++ b/docs/06_how-to-guides/30_key-value-api/80_how-to-query-range-in-table.md
@@ -7,6 +7,9 @@ link_text: "How-To Query Range in Key-Value Table"
 
 This how-to procedure provides instructions to retrieve a list of values, from a `Key-Value Table` (`kv table`) index, which share a particular commonality.
 
+[[caution | Alpha version]]
+| `Key-Value Table` is designated as `alpha` and should not be used in production code.
+
 Use the method `range` defined by the `eosio::kv::table::index` class to accomplish this task.
 
 ## Prerequisites

--- a/docs/06_how-to-guides/30_key-value-api/90_how-to-allow-users-to-pay.md
+++ b/docs/06_how-to-guides/30_key-value-api/90_how-to-allow-users-to-pay.md
@@ -7,6 +7,9 @@ link_text: "How-To Allow Users to Pay for Key-Value Table Resources"
 
 This how-to procedure provides instructions to allow users to pay for the resources needed to store data in a `Key-Value Table` (`kv table`).
 
+[[caution | Alpha version]]
+| `Key-Value Table` is designated as `alpha` and should not be used in production code.
+
 Use the method `put` defined by the `eosio::kv::table` type to accomplish this task and provide as the second parameter the account name which is the payer for the resources needed.
 
 ## Prerequisites

--- a/docs/06_how-to-guides/30_key-value-api/index.md
+++ b/docs/06_how-to-guides/30_key-value-api/index.md
@@ -7,6 +7,9 @@ link_text: "Key-Value API"
 
 The Key-Value API provides a set of C++ classes and structures which facilitates the creation of datastore key value tables on-chain. It is meant to provide the same functionality the multi-index provides in a `simpler` and more `flexible` API with comparable performance.
 
+[[caution | Alpha version]]
+| `Key-Value Table` is designated as `alpha` and should not be used in production code.
+
 ## Concept
 
 The Key-Value API, or KV API, is a new option for developers to create datastore key value tables on-chain. KV API is more flexible than multi-index and allows developers to search the table in a more human-readable way, unlike multi-index tables where search is over 64-bit values.

--- a/examples/kv_addr_book/include/kv_addr_book.hpp
+++ b/examples/kv_addr_book/include/kv_addr_book.hpp
@@ -113,10 +113,6 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
       [[eosio::action]]
       std::vector<person> getbylastname(std::string last_name);
 
-      //[[eosio::action]]
-      //std::vector<person> getbylstname(std::string last_name);
-
-
       [[eosio::action]]
       std::vector<person> getbyaddress(
          std::string street, 
@@ -151,7 +147,6 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
       using get_action = eosio::action_wrapper<"get"_n, &kv_addr_book::get>;
       using get_by_cntry_pers_id_action = eosio::action_wrapper<"getbycntrpid"_n, &kv_addr_book::getbycntrpid>;
       using get_by_last_name_action = eosio::action_wrapper<"getbylastname"_n, &kv_addr_book::getbylastname>;
-      //using get_by_lst_name_action = eosio::action_wrapper<"getbylstname"_n, &kv_addr_book::getbylstname>;
       using get_buy_address_action = eosio::action_wrapper<"getbyaddress"_n, &kv_addr_book::getbyaddress>;
       using upsert_action = eosio::action_wrapper<"upsert"_n, &kv_addr_book::upsert>;
       using del_action = eosio::action_wrapper<"del"_n, &kv_addr_book::del>;

--- a/examples/kv_addr_book/include/kv_addr_book.hpp
+++ b/examples/kv_addr_book/include/kv_addr_book.hpp
@@ -1,46 +1,35 @@
 #include <eosio/eosio.hpp>
 #include <eosio/table.hpp>
 
+using namespace eosio;
+using namespace std;
+
+using fullname_t = std::tuple<std::string, std::string>;
+using address_t = std::tuple<std::string, std::string, std::string, std::string, eosio::name>;
+using country_personal_id_t = std::pair<std::string, std::string>;
+
+// TO DO: testing...
+using last_name_idx_t = std::tuple<std::string>;
+
 // this structure defines the data stored in the kv::table
 struct person {
    eosio::name account_name;
-   std::tuple<eosio::name, std::string> first_name;
-   std::tuple<eosio::name, std::string> last_name;
-   std::tuple<eosio::name, std::string, std::string, std::string, std::string> street_city_state_cntry;
-   std::tuple<eosio::name, std::string> personal_id;
-   std::pair<std::string, std::string> country_personal_id;
+   std::string first_name;
+   std::string last_name;
+   std::string street;
+   std::string city;
+   std::string state; 
+   std::string country;
+   std::string personal_id;
 
-   eosio::name get_account_name() const {
-      return account_name;
-   }
-   std::string get_first_name() const {
-      // from the std::tuple we extract the value with key 1, the first name
-      return std::get<1>(first_name);
-   }
-   std::string get_last_name() const {
-      // from the std::tuple we extract the value with key 1, the last name
-      return std::get<1>(last_name);
-   }
-   std::string get_street() const {
-      // from the std::tuple we extract the value with key 1, the street
-      return std::get<1>(street_city_state_cntry);
-   }
-   std::string get_city() const {
-      // from the std::tuple we extract the value with key 2, the city
-      return std::get<2>(street_city_state_cntry);
-   }
-   std::string get_state() const {
-      // from the std::tuple we extract the value with key 3, the state
-      return std::get<3>(street_city_state_cntry);
-   }
-   std::string get_country() const {
-      // from the std::tuple we extract the value with key 4, the country
-      return std::get<4>(street_city_state_cntry);
-   }
-   std::string get_personal_id() const {
-      // from the std::tuple we extract the value with key 1, the personal id
-      return std::get<1>(personal_id);
-   }
+   // data members supporting the indexes built for this structure
+   fullname_t full_name_first_last;
+   fullname_t full_name_last_first;
+   address_t address;
+   country_personal_id_t country_personal_id;
+
+   // TO DO: testing...
+   last_name_idx_t last_name_idx_data_member;
 };
 
 // helper factory to easily build person objects
@@ -56,11 +45,18 @@ struct person_factory {
       std::string personal_id) {
          return person {
             .account_name = account_name,
-            .first_name = {account_name, first_name},
-            .last_name = {account_name, last_name},
-            .street_city_state_cntry = {account_name, street, city, state, country},
-            .personal_id = {account_name, personal_id},
-            .country_personal_id = {country, personal_id}
+            .first_name = first_name,
+            .last_name = last_name,
+            .street = street,
+            .city = city,
+            .state = state,
+            .country = country,
+            .personal_id = personal_id,
+            .full_name_first_last = {first_name, last_name},
+            .full_name_last_first = {last_name, first_name},
+            .address = {street, city, state, country, account_name},
+            .country_personal_id = {country, personal_id},
+            .last_name_idx_data_member = {last_name}
          };
       }
 };
@@ -73,43 +69,36 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
       // 2. unique indexes for multiple properties of the kv::table parameter type
       //    are defined with the help of a pair or a tuple; a pair if the index has 
       //    two properties or a tuple in case of more than two
-      index<eosio::name> account_name_uidx {
-         eosio::name{"accname"_n},
+      index<name> account_name_uidx {
+         name{"accname"_n},
          &person::account_name };
-      index<std::pair<std::string, std::string>> country_personal_id_uidx {
-         eosio::name{"cntrypersid"_n},
+      index<country_personal_id_t> country_personal_id_uidx {
+         name{"cntrypersid"_n},
          &person::country_personal_id };
       
       // non-unique indexes definitions
-      // 1. non unique indexes need to be defined for at least two properties, 
-      // 2. the first one needs to be a property that stores unique values, because 
-      //    under the hood every index (non-unique or unique) is stored as an unique 
-      //    index, and by providing as the first property one that has unique values
-      //    it ensures the uniques of the values combined (including non-unique ones)
-      // 3. the rest of the properties are the ones wanted to be indexed non-uniquely
-      index<std::tuple<eosio::name, std::string>> first_name_idx {
-         eosio::name{"firstname"_n},
-         &person::first_name};
-      index<std::tuple<eosio::name, std::string>> last_name_idx {
-         eosio::name{"lastname"_n},
-         &person::last_name};
-      index<std::tuple<eosio::name, std::string>> personal_id_idx {
-         eosio::name{"persid"_n},
-         &person::personal_id};
-      // non-unique index defined using the KV_NAMED_INDEX macro
-      // note: you can not name your index like you were able to do before (ending in `_idx`),
-      // instead when using the macro you have to pass the name of the data member which 
-      // is indexed and that will give the name of the index as well
-      KV_NAMED_INDEX("address"_n, street_city_state_cntry)
+      index<fullname_t> full_name_first_last_idx {
+         name{"frstnameidx"_n},
+         &person::full_name_first_last};
+      index<fullname_t> full_name_last_first_idx {
+         name{"lastnameidx"_n},
+         &person::full_name_last_first};
+      index<address_t> address_idx {
+         name{"addressidx"_n},
+         &person::address};
+
+      // TO DO: testing...
+      index<last_name_idx_t> last_name_idx {
+         name{"lstnameidx"},
+         &person::last_name_idx_data_member};
 
       address_table(eosio::name contract_name) {
          init(contract_name,
             account_name_uidx,
             country_personal_id_uidx,
-            first_name_idx,
-            last_name_idx,
-            personal_id_idx,
-            street_city_state_cntry);
+            full_name_first_last_idx,
+            full_name_last_first_idx,
+            address_idx);
       }
    };
 
@@ -130,7 +119,10 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
       [[eosio::action]]
       std::vector<person> getbylastname(std::string last_name);
 
-      // retrieves list of persons with the same address
+      //[[eosio::action]]
+      //std::vector<person> getbylstname(std::string last_name);
+
+
       [[eosio::action]]
       std::vector<person> getbyaddress(
          std::string street, 
@@ -165,6 +157,7 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
       using get_action = eosio::action_wrapper<"get"_n, &kv_addr_book::get>;
       using get_by_cntry_pers_id_action = eosio::action_wrapper<"getbycntrpid"_n, &kv_addr_book::getbycntrpid>;
       using get_by_last_name_action = eosio::action_wrapper<"getbylastname"_n, &kv_addr_book::getbylastname>;
+      //using get_by_lst_name_action = eosio::action_wrapper<"getbylstname"_n, &kv_addr_book::getbylstname>;
       using get_buy_address_action = eosio::action_wrapper<"getbyaddress"_n, &kv_addr_book::getbyaddress>;
       using upsert_action = eosio::action_wrapper<"upsert"_n, &kv_addr_book::upsert>;
       using del_action = eosio::action_wrapper<"del"_n, &kv_addr_book::del>;
@@ -172,6 +165,6 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
       using iterate_action = eosio::action_wrapper<"iterate"_n, &kv_addr_book::iterate>;
 
    private:
-      void print_person(const person& person);
+      void print_person(const person& person, bool new_line = true);
       address_table addresses{"kvaddrbook"_n};
 };

--- a/examples/kv_addr_book/include/kv_addr_book.hpp
+++ b/examples/kv_addr_book/include/kv_addr_book.hpp
@@ -4,12 +4,7 @@
 using namespace eosio;
 using namespace std;
 
-using fullname_t = std::tuple<std::string, std::string>;
-using address_t = std::tuple<std::string, std::string, std::string, std::string, eosio::name>;
 using country_personal_id_t = std::pair<std::string, std::string>;
-
-// TO DO: testing...
-using last_name_idx_t = std::tuple<std::string>;
 
 // this structure defines the data stored in the kv::table
 struct person {
@@ -23,13 +18,7 @@ struct person {
    std::string personal_id;
 
    // data members supporting the indexes built for this structure
-   fullname_t full_name_first_last;
-   fullname_t full_name_last_first;
-   address_t address;
    country_personal_id_t country_personal_id;
-
-   // TO DO: testing...
-   last_name_idx_t last_name_idx_data_member;
 };
 
 // helper factory to easily build person objects
@@ -52,11 +41,7 @@ struct person_factory {
             .state = state,
             .country = country,
             .personal_id = personal_id,
-            .full_name_first_last = {first_name, last_name},
-            .full_name_last_first = {last_name, first_name},
-            .address = {street, city, state, country, account_name},
             .country_personal_id = {country, personal_id},
-            .last_name_idx_data_member = {last_name}
          };
       }
 };
@@ -76,29 +61,10 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
          name{"cntrypersid"_n},
          &person::country_personal_id };
       
-      // non-unique indexes definitions
-      index<fullname_t> full_name_first_last_idx {
-         name{"frstnameidx"_n},
-         &person::full_name_first_last};
-      index<fullname_t> full_name_last_first_idx {
-         name{"lastnameidx"_n},
-         &person::full_name_last_first};
-      index<address_t> address_idx {
-         name{"addressidx"_n},
-         &person::address};
-
-      // TO DO: testing...
-      index<last_name_idx_t> last_name_idx {
-         name{"lstnameidx"},
-         &person::last_name_idx_data_member};
-
       address_table(eosio::name contract_name) {
          init(contract_name,
             account_name_uidx,
-            country_personal_id_uidx,
-            full_name_first_last_idx,
-            full_name_last_first_idx,
-            address_idx);
+            country_personal_id_uidx);
       }
    };
 
@@ -114,21 +80,6 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
       // retrieves a person based on unique index defined by country and personal_id
       [[eosio::action]]
       person getbycntrpid(std::string country, std::string personal_id);
-
-      // retrieves list of persons with the same last name
-      [[eosio::action]]
-      std::vector<person> getbylastname(std::string last_name);
-
-      //[[eosio::action]]
-      //std::vector<person> getbylstname(std::string last_name);
-
-
-      [[eosio::action]]
-      std::vector<person> getbyaddress(
-         std::string street, 
-         std::string city, 
-         std::string state, 
-         std::string country);
 
       // creates if not exists, or updates if already exists, a person
       [[eosio::action]]
@@ -156,9 +107,6 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
 
       using get_action = eosio::action_wrapper<"get"_n, &kv_addr_book::get>;
       using get_by_cntry_pers_id_action = eosio::action_wrapper<"getbycntrpid"_n, &kv_addr_book::getbycntrpid>;
-      using get_by_last_name_action = eosio::action_wrapper<"getbylastname"_n, &kv_addr_book::getbylastname>;
-      //using get_by_lst_name_action = eosio::action_wrapper<"getbylstname"_n, &kv_addr_book::getbylstname>;
-      using get_buy_address_action = eosio::action_wrapper<"getbyaddress"_n, &kv_addr_book::getbyaddress>;
       using upsert_action = eosio::action_wrapper<"upsert"_n, &kv_addr_book::upsert>;
       using del_action = eosio::action_wrapper<"del"_n, &kv_addr_book::del>;
       using is_pers_id_in_cntry_action = eosio::action_wrapper<"checkpidcntr"_n, &kv_addr_book::checkpidcntr>;

--- a/examples/kv_addr_book/include/kv_addr_book.hpp
+++ b/examples/kv_addr_book/include/kv_addr_book.hpp
@@ -1,43 +1,44 @@
 #include <eosio/eosio.hpp>
+#include <eosio/table.hpp>
 
 // this structure defines the data stored in the kv::table
 struct person {
    eosio::name account_name;
-   eosio::non_unique<eosio::name, std::string> first_name;
-   eosio::non_unique<eosio::name, std::string> last_name;
-   eosio::non_unique<eosio::name, std::string, std::string, std::string, std::string> street_city_state_cntry;
-   eosio::non_unique<eosio::name, std::string> personal_id;
+   std::tuple<eosio::name, std::string> first_name;
+   std::tuple<eosio::name, std::string> last_name;
+   std::tuple<eosio::name, std::string, std::string, std::string, std::string> street_city_state_cntry;
+   std::tuple<eosio::name, std::string> personal_id;
    std::pair<std::string, std::string> country_personal_id;
 
    eosio::name get_account_name() const {
       return account_name;
    }
    std::string get_first_name() const {
-      // from the non_unique tuple we extract the value with key 1, the first name
+      // from the std::tuple we extract the value with key 1, the first name
       return std::get<1>(first_name);
    }
    std::string get_last_name() const {
-      // from the non_unique tuple we extract the value with key 1, the last name
+      // from the std::tuple we extract the value with key 1, the last name
       return std::get<1>(last_name);
    }
    std::string get_street() const {
-      // from the non_unique tuple we extract the value with key 1, the street
+      // from the std::tuple we extract the value with key 1, the street
       return std::get<1>(street_city_state_cntry);
    }
    std::string get_city() const {
-      // from the non_unique tuple we extract the value with key 2, the city
+      // from the std::tuple we extract the value with key 2, the city
       return std::get<2>(street_city_state_cntry);
    }
    std::string get_state() const {
-      // from the non_unique tuple we extract the value with key 3, the state
+      // from the std::tuple we extract the value with key 3, the state
       return std::get<3>(street_city_state_cntry);
    }
    std::string get_country() const {
-      // from the non_unique tuple we extract the value with key 4, the country
+      // from the std::tuple we extract the value with key 4, the country
       return std::get<4>(street_city_state_cntry);
    }
    std::string get_personal_id() const {
-      // from the non_unique tuple we extract the value with key 1, the personal id
+      // from the std::tuple we extract the value with key 1, the personal id
       return std::get<1>(personal_id);
    }
 };
@@ -86,13 +87,13 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
       //    index, and by providing as the first property one that has unique values
       //    it ensures the uniques of the values combined (including non-unique ones)
       // 3. the rest of the properties are the ones wanted to be indexed non-uniquely
-      index<eosio::non_unique<eosio::name, std::string>> first_name_idx {
+      index<std::tuple<eosio::name, std::string>> first_name_idx {
          eosio::name{"firstname"_n},
          &person::first_name};
-      index<eosio::non_unique<eosio::name, std::string>> last_name_idx {
+      index<std::tuple<eosio::name, std::string>> last_name_idx {
          eosio::name{"lastname"_n},
          &person::last_name};
-      index<eosio::non_unique<eosio::name, std::string>> personal_id_idx {
+      index<std::tuple<eosio::name, std::string>> personal_id_idx {
          eosio::name{"persid"_n},
          &person::personal_id};
       // non-unique index defined using the KV_NAMED_INDEX macro

--- a/examples/kv_addr_book/include/kv_addr_book.hpp
+++ b/examples/kv_addr_book/include/kv_addr_book.hpp
@@ -4,7 +4,12 @@
 using namespace eosio;
 using namespace std;
 
+using fullname_t = std::tuple<std::string, std::string>;
+using address_t = std::tuple<std::string, std::string, std::string, std::string, eosio::name>;
 using country_personal_id_t = std::pair<std::string, std::string>;
+
+// TO DO: testing...
+using last_name_idx_t = std::tuple<std::string>;
 
 // this structure defines the data stored in the kv::table
 struct person {
@@ -18,7 +23,13 @@ struct person {
    std::string personal_id;
 
    // data members supporting the indexes built for this structure
+   fullname_t full_name_first_last;
+   fullname_t full_name_last_first;
+   address_t address;
    country_personal_id_t country_personal_id;
+
+   // TO DO: testing...
+   last_name_idx_t last_name_idx_data_member;
 };
 
 // helper factory to easily build person objects
@@ -41,7 +52,11 @@ struct person_factory {
             .state = state,
             .country = country,
             .personal_id = personal_id,
+            .full_name_first_last = {first_name, last_name},
+            .full_name_last_first = {last_name, first_name},
+            .address = {street, city, state, country, account_name},
             .country_personal_id = {country, personal_id},
+            .last_name_idx_data_member = {last_name}
          };
       }
 };
@@ -61,10 +76,29 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
          name{"cntrypersid"_n},
          &person::country_personal_id };
       
+      // non-unique indexes definitions
+      index<fullname_t> full_name_first_last_idx {
+         name{"frstnameidx"_n},
+         &person::full_name_first_last};
+      index<fullname_t> full_name_last_first_idx {
+         name{"lastnameidx"_n},
+         &person::full_name_last_first};
+      index<address_t> address_idx {
+         name{"addressidx"_n},
+         &person::address};
+
+      // TO DO: testing...
+      index<last_name_idx_t> last_name_idx {
+         name{"lstnameidx"},
+         &person::last_name_idx_data_member};
+
       address_table(eosio::name contract_name) {
          init(contract_name,
             account_name_uidx,
-            country_personal_id_uidx);
+            country_personal_id_uidx,
+            full_name_first_last_idx,
+            full_name_last_first_idx,
+            address_idx);
       }
    };
 
@@ -80,6 +114,21 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
       // retrieves a person based on unique index defined by country and personal_id
       [[eosio::action]]
       person getbycntrpid(std::string country, std::string personal_id);
+
+      // retrieves list of persons with the same last name
+      [[eosio::action]]
+      std::vector<person> getbylastname(std::string last_name);
+
+      //[[eosio::action]]
+      //std::vector<person> getbylstname(std::string last_name);
+
+
+      [[eosio::action]]
+      std::vector<person> getbyaddress(
+         std::string street, 
+         std::string city, 
+         std::string state, 
+         std::string country);
 
       // creates if not exists, or updates if already exists, a person
       [[eosio::action]]
@@ -107,6 +156,9 @@ class [[eosio::contract]] kv_addr_book : public eosio::contract {
 
       using get_action = eosio::action_wrapper<"get"_n, &kv_addr_book::get>;
       using get_by_cntry_pers_id_action = eosio::action_wrapper<"getbycntrpid"_n, &kv_addr_book::getbycntrpid>;
+      using get_by_last_name_action = eosio::action_wrapper<"getbylastname"_n, &kv_addr_book::getbylastname>;
+      //using get_by_lst_name_action = eosio::action_wrapper<"getbylstname"_n, &kv_addr_book::getbylstname>;
+      using get_buy_address_action = eosio::action_wrapper<"getbyaddress"_n, &kv_addr_book::getbyaddress>;
       using upsert_action = eosio::action_wrapper<"upsert"_n, &kv_addr_book::upsert>;
       using del_action = eosio::action_wrapper<"del"_n, &kv_addr_book::del>;
       using is_pers_id_in_cntry_action = eosio::action_wrapper<"checkpidcntr"_n, &kv_addr_book::checkpidcntr>;

--- a/examples/kv_addr_book/src/kv_addr_book.cpp
+++ b/examples/kv_addr_book/src/kv_addr_book.cpp
@@ -44,82 +44,6 @@ person kv_addr_book::get(eosio::name account_name) {
    }
 }
 
-// retrieves a person based on unique index defined by country and personal_id
-[[eosio::action]]
-person kv_addr_book::getbycntrpid(std::string country, std::string personal_id) {
-   address_table addresses{"kvaddrbook"_n};
-
-   const auto& person_found = addresses.country_personal_id_uidx.get({country, personal_id});
-   if (person_found.has_value()) {
-      print_person(person_found.value());
-      // return found person from action
-      return person_found.value();
-   }
-   else {
-      eosio::print_f("Person not found in addressbook.");
-      // return empty person from action
-      return person{};
-   }
-}
-
-// retrieves list of persons with the same last name
-[[eosio::action]]
-std::vector<person> kv_addr_book::getbylastname(std::string last_name) {
-   address_table addresses{"kvaddrbook"_n};
-
-   std::string min_first_name("A");
-   std::string max_first_name(100, 'z');
-   auto list_of_persons = addresses.full_name_last_first_idx.range(
-      {last_name, min_first_name},
-      {last_name, max_first_name});
-
-   eosio::print_f("Found % person(s). ", list_of_persons.size());
-
-   for (auto& person : list_of_persons) {
-      print_person(person, false);
-   }
-   // return found list of person from action
-   return list_of_persons;
-}
-
-// retrieves list of persons with the same last name using last_name_idx
-// [[eosio::action]]
-// std::vector<person> kv_addr_book::getbylstname(std::string last_name) {
-//    address_table addresses{"kvaddrbook"_n};
-//
-//    auto list_of_persons = addresses.last_name_idx.range({"A"}, {last_name});
-//
-//    eosio::print_f("Found % person(s). ", list_of_persons.size());
-//
-//    for (auto& person : list_of_persons) {
-//       print_person(person, false);
-//    }
-//       // return found list of person from action
-//    return list_of_persons;
-// }
-
-// retrieves list of persons with the same address
-[[eosio::action]]
-std::vector<person> kv_addr_book::getbyaddress(
-   std::string street, std::string city, std::string state, std::string country) {
-   address_table addresses{"kvaddrbook"_n};
-
-   eosio::name min_account_name{0};
-   eosio::name max_account_name{UINT_MAX};
-
-   auto list_of_persons = addresses.address_idx.range(
-      {street, city, state, country, min_account_name}, 
-      {street, city, state, country, max_account_name});
-
-   eosio::print_f("Found % person(s). ", list_of_persons.size());
-
-   for (auto& person : list_of_persons) {
-      print_person(person, false);
-   }
-   // return found list of persons from action
-   return list_of_persons;
-}
-
 // creates if not exists, or updates if already exists, a person
 [[eosio::action]]
 void kv_addr_book::upsert(
@@ -187,6 +111,24 @@ bool kv_addr_book::checkpidcntr(std::string personal_id, std::string country) {
    address_table addresses{"kvaddrbook"_n};
 
    return addresses.country_personal_id_uidx.exists({personal_id, country});
+}
+
+// retrieves a person based on unique index defined by country and personal_id
+[[eosio::action]]
+person kv_addr_book::getbycntrpid(std::string country, std::string personal_id) {
+   address_table addresses{"kvaddrbook"_n};
+
+   const auto& person_found = addresses.country_personal_id_uidx.get({country, personal_id});
+   if (person_found.has_value()) {
+      print_person(person_found.value());
+      // return found person from action
+      return person_found.value();
+   }
+   else {
+      eosio::print_f("Person not found in addressbook.");
+      // return empty person from action
+      return person{};
+   }
 }
 
 // iterates over the first iterations_count persons in the table 

--- a/examples/kv_addr_book/src/kv_addr_book.cpp
+++ b/examples/kv_addr_book/src/kv_addr_book.cpp
@@ -1,15 +1,20 @@
 #include <kv_addr_book.hpp>
 
-void kv_addr_book::print_person(const person& person) {
+void kv_addr_book::print_person(const person& person, bool new_line) {
+   // when using "/n" in the string printed by eosio everything else
+   // printed after this print for the current action will not be shown
+   // in the console, therefore use it as the last print statement only.
    eosio::print_f(
-      "Person found: {%, %, %, %, %, %, %s}\n", 
-      person.get_first_name(), 
-      person.get_last_name(), 
-      person.get_street(),
-      person.get_city(),
-      person.get_state(),
-      person.get_country(),
-      person.get_personal_id());
+      new_line 
+         ? "Person found: {%, %, %, %, %, %, %}\n"
+         : "Person found: {%, %, %, %, %, %, %}. ", 
+      person.first_name, 
+      person.last_name, 
+      person.street,
+      person.city,
+      person.state,
+      person.country,
+      person.personal_id);
 }
 
 // retrieves a person based on primary key account_name
@@ -62,14 +67,36 @@ person kv_addr_book::getbycntrpid(std::string country, std::string personal_id) 
 std::vector<person> kv_addr_book::getbylastname(std::string last_name) {
    address_table addresses{"kvaddrbook"_n};
 
-   eosio::name min_account_name{0};
-   eosio::name max_account_name{UINT_MAX};
-   auto list_of_persons = addresses.last_name_idx.range(
-      {min_account_name, last_name},
-      {max_account_name, last_name});
+   std::string min_first_name("A");
+   std::string max_first_name(100, 'z');
+   auto list_of_persons = addresses.full_name_last_first_idx.range(
+      {last_name, min_first_name},
+      {last_name, max_first_name});
+
+   eosio::print_f("Found % person(s). ", list_of_persons.size());
+
+   for (auto& person : list_of_persons) {
+      print_person(person, false);
+   }
    // return found list of person from action
    return list_of_persons;
 }
+
+// retrieves list of persons with the same last name using last_name_idx
+// [[eosio::action]]
+// std::vector<person> kv_addr_book::getbylstname(std::string last_name) {
+//    address_table addresses{"kvaddrbook"_n};
+//
+//    auto list_of_persons = addresses.last_name_idx.range({"A"}, {last_name});
+//
+//    eosio::print_f("Found % person(s). ", list_of_persons.size());
+//
+//    for (auto& person : list_of_persons) {
+//       print_person(person, false);
+//    }
+//       // return found list of person from action
+//    return list_of_persons;
+// }
 
 // retrieves list of persons with the same address
 [[eosio::action]]
@@ -79,10 +106,17 @@ std::vector<person> kv_addr_book::getbyaddress(
 
    eosio::name min_account_name{0};
    eosio::name max_account_name{UINT_MAX};
-   auto list_of_persons = addresses.street_city_state_cntry.range(
-      {min_account_name, street, city, state, country}, 
-      {max_account_name, street, city, state, country});
-   // return found list of person from action
+
+   auto list_of_persons = addresses.address_idx.range(
+      {street, city, state, country, min_account_name}, 
+      {street, city, state, country, max_account_name});
+
+   eosio::print_f("Found % person(s). ", list_of_persons.size());
+
+   for (auto& person : list_of_persons) {
+      print_person(person, false);
+   }
+   // return found list of persons from action
    return list_of_persons;
 }
 
@@ -111,13 +145,13 @@ void kv_addr_book::upsert(
       personal_id);
 
    // retreive the person by account name, if it doesn't exist we get an emtpy person
-   const person& existing_person = get(person_update.get_account_name());
+   const person& existing_person = get(person_update.account_name);
 
    // upsert into kv::table
    addresses.put(person_update, get_self());
 
    // print customized message for insert vs update
-   if (existing_person.get_account_name().value == 0) {
+   if (existing_person.account_name.value == 0) {
       eosio::print_f("Person was successfully added to addressbook.");
    }
    else {
@@ -167,9 +201,9 @@ void kv_addr_book::iterate(int iterations_count) {
    int current_iteration = 0;
    while (begin_itr != end_itr && current_iteration < iterations_count) {
       eosio::print_f(
-         "Person found: {%, %}\n", 
-         begin_itr.value().get_first_name(),
-         begin_itr.value().get_last_name());
+         "Person found: {%, %}. ", 
+         begin_itr.value().first_name,
+         begin_itr.value().last_name);
 
       ++ begin_itr;
       ++ current_iteration;

--- a/examples/kv_addr_book/src/kv_addr_book.cpp
+++ b/examples/kv_addr_book/src/kv_addr_book.cpp
@@ -69,9 +69,12 @@ std::vector<person> kv_addr_book::getbylastname(std::string last_name) {
 
    std::string min_first_name("A");
    std::string max_first_name(100, 'z');
+   eosio::name min_account_name{0};
+   eosio::name max_account_name{UINT_MAX};
+
    auto list_of_persons = addresses.full_name_last_first_idx.range(
-      {last_name, min_first_name},
-      {last_name, max_first_name});
+      {last_name, min_first_name, min_account_name},
+      {last_name, max_first_name, max_account_name});
 
    eosio::print_f("Found % person(s). ", list_of_persons.size());
 
@@ -81,22 +84,6 @@ std::vector<person> kv_addr_book::getbylastname(std::string last_name) {
    // return found list of person from action
    return list_of_persons;
 }
-
-// retrieves list of persons with the same last name using last_name_idx
-// [[eosio::action]]
-// std::vector<person> kv_addr_book::getbylstname(std::string last_name) {
-//    address_table addresses{"kvaddrbook"_n};
-//
-//    auto list_of_persons = addresses.last_name_idx.range({"A"}, {last_name});
-//
-//    eosio::print_f("Found % person(s). ", list_of_persons.size());
-//
-//    for (auto& person : list_of_persons) {
-//       print_person(person, false);
-//    }
-//       // return found list of person from action
-//    return list_of_persons;
-// }
 
 // retrieves list of persons with the same address
 [[eosio::action]]

--- a/examples/kv_map/CMakeLists.txt
+++ b/examples/kv_map/CMakeLists.txt
@@ -1,0 +1,17 @@
+include(ExternalProject)
+# if no cdt root is given use default path
+if(EOSIO_CDT_ROOT STREQUAL "" OR NOT EOSIO_CDT_ROOT)
+   find_package(eosio.cdt)
+endif()
+
+ExternalProject_Add(
+   kv_map_project
+   SOURCE_DIR ${CMAKE_SOURCE_DIR}/src
+   BINARY_DIR ${CMAKE_BINARY_DIR}/kv_map
+   CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${EOSIO_CDT_ROOT}/lib/cmake/eosio.cdt/EosioWasmToolchain.cmake
+   UPDATE_COMMAND ""
+   PATCH_COMMAND ""
+   TEST_COMMAND ""
+   INSTALL_COMMAND ""
+   BUILD_ALWAYS 1
+)

--- a/examples/kv_map/README.txt
+++ b/examples/kv_map/README.txt
@@ -1,0 +1,20 @@
+--- kv_map Project ---
+
+ -- How to Build with CMake and Make --
+   - cd into the 'build' directory
+   - run the command 'cmake ..'
+   - run the command 'make'
+
+ - After build -
+   - The built smart contract is under the 'kv_map' directory in the 'build' directory
+   - You can then do a 'set contract' action with 'cleos' and point to the './build/kv_map' directory
+
+ - Additions to CMake should be done to the CMakeLists.txt in the './src' directory and not in the top level CMakeLists.txt
+
+ -- How to build with eosio-cpp --
+   - cd into the 'build' directory
+   - run the command 'eosio-cpp -abigen ../src/kv_map.cpp -o kv_map.wasm -I ../include/'
+
+ - After build -
+   - The built smart contract is in the 'build' directory
+   - You can then do a 'set contract' action with 'cleos' and point to the 'build' directory

--- a/examples/kv_map/include/kv_map.hpp
+++ b/examples/kv_map/include/kv_map.hpp
@@ -56,7 +56,7 @@ struct person_factory {
 
 class [[eosio::contract]] kv_map : public eosio::contract {
 
-   using my_map_t = eosio::kv::map<"kvmap"_n, std::string, person>;
+   using my_map_t = eosio::kv::map<"kvmap"_n, int, person>;
 
    public:
       using contract::contract;
@@ -65,11 +65,11 @@ class [[eosio::contract]] kv_map : public eosio::contract {
 
       // retrieves a person based on map key
       [[eosio::action]]
-      person get(std::string);
+      person get(int id);
 
       // creates if not exists, or updates if already exists, a person
       [[eosio::action]]
-      void upsert(std::string map_id,
+      void upsert(int id,
          eosio::name account_name,
          std::string first_name,
          std::string last_name,
@@ -81,7 +81,7 @@ class [[eosio::contract]] kv_map : public eosio::contract {
 
       // deletes a person based on primary key account_name
       [[eosio::action]]
-      void del(std::string map_id);
+      void del(int id);
 
       // checks if a person exists with a given personal_id and country
       [[eosio::action]]

--- a/examples/kv_map/include/kv_map.hpp
+++ b/examples/kv_map/include/kv_map.hpp
@@ -1,0 +1,105 @@
+#include <eosio/eosio.hpp>
+#include <eosio/map.hpp>
+
+using namespace eosio;
+using namespace std;
+
+using fullname_t = std::tuple<std::string, std::string, eosio::name>;
+using address_t = std::tuple<std::string, std::string, std::string, std::string, eosio::name>;
+using country_personal_id_t = std::pair<std::string, std::string>;
+
+// this structure defines the data stored in the kv::map
+struct person {
+   eosio::name account_name;
+   std::string first_name;
+   std::string last_name;
+   std::string street;
+   std::string city;
+   std::string state; 
+   std::string country;
+   std::string personal_id;
+
+   // data members supporting the indexes built for this structure
+   fullname_t full_name_first_last;
+   fullname_t full_name_last_first;
+   address_t address;
+   country_personal_id_t country_personal_id;
+};
+
+// helper factory to easily build person objects
+struct person_factory {
+   static person get_person(
+      eosio::name account_name,
+      std::string first_name,
+      std::string last_name,
+      std::string street,
+      std::string city,
+      std::string state, 
+      std::string country,
+      std::string personal_id) {
+         return person {
+            .account_name = account_name,
+            .first_name = first_name,
+            .last_name = last_name,
+            .street = street,
+            .city = city,
+            .state = state,
+            .country = country,
+            .personal_id = personal_id,
+            .full_name_first_last = {first_name, last_name, account_name},
+            .full_name_last_first = {last_name, first_name, account_name},
+            .address = {street, city, state, country, account_name},
+            .country_personal_id = {country, personal_id},
+         };
+      }
+};
+
+class [[eosio::contract]] kv_map : public eosio::contract {
+
+   using my_map_t = eosio::kv::map<"kvmap"_n, std::string, person>;
+
+   public:
+      using contract::contract;
+      kv_map(eosio::name receiver, eosio::name code, eosio::datastream<const char*> ds)
+         : contract(receiver, code, ds) {}
+
+      // retrieves a person based on map key
+      [[eosio::action]]
+      person get(std::string);
+
+      // creates if not exists, or updates if already exists, a person
+      [[eosio::action]]
+      void upsert(std::string map_id,
+         eosio::name account_name,
+         std::string first_name,
+         std::string last_name,
+         std::string street,
+         std::string city,
+         std::string state, 
+         std::string country,
+         std::string personal_id);
+
+      // deletes a person based on primary key account_name
+      [[eosio::action]]
+      void del(std::string map_id);
+
+      // checks if a person exists with a given personal_id and country
+      [[eosio::action]]
+      bool checkpidcntr(std::string personal_id, std::string country);
+
+      // iterates over the first iterations_count persons in the table 
+      // and prints their first and last names
+      [[eosio::action]]
+      void iterate(int iterations_count);
+
+      using get_action = eosio::action_wrapper<"get"_n, &kv_map::get>;
+      using upsert_action = eosio::action_wrapper<"upsert"_n, &kv_map::upsert>;
+      using del_action = eosio::action_wrapper<"del"_n, &kv_map::del>;
+      using is_pers_id_in_cntry_action = eosio::action_wrapper<"checkpidcntr"_n, &kv_map::checkpidcntr>;
+      using iterate_action = eosio::action_wrapper<"iterate"_n, &kv_map::iterate>;
+
+   private:
+      void print_person(const person& person, bool new_line = true);
+
+      my_map_t my_map{};
+};

--- a/examples/kv_map/ricardian/kv_example.contracts.md
+++ b/examples/kv_map/ricardian/kv_example.contracts.md
@@ -1,0 +1,3 @@
+<h1 class="contract"> hi </h1>
+
+Stub for hi action's ricardian contract

--- a/examples/kv_map/src/CMakeLists.txt
+++ b/examples/kv_map/src/CMakeLists.txt
@@ -1,0 +1,8 @@
+project(kv_map)
+
+set(EOSIO_WASM_OLD_BEHAVIOR "Off")
+find_package(eosio.cdt)
+
+add_contract( kv_map kv_map kv_map.cpp )
+target_include_directories( kv_map PUBLIC ${CMAKE_SOURCE_DIR}/../include )
+target_ricardian_directory( kv_map ${CMAKE_SOURCE_DIR}/../ricardian )

--- a/examples/kv_map/src/kv_map.cpp
+++ b/examples/kv_map/src/kv_map.cpp
@@ -1,0 +1,138 @@
+#include <kv_map.hpp>
+
+void kv_map::print_person(const person& person, bool new_line) {
+   // when using "/n" in the string printed by eosio everything else
+   // printed after this print for the current action will not be shown
+   // in the console, therefore use it as the last print statement only.
+   eosio::print_f(
+      new_line 
+         ? "Person found: {%, %, %, %, %, %, %}\n"
+         : "Person found: {%, %, %, %, %, %, %}. ", 
+      person.first_name, 
+      person.last_name, 
+      person.street,
+      person.city,
+      person.state,
+      person.country,
+      person.personal_id);
+}
+
+// retrieves a person based on primary key account_name
+// we make use of index find function, which returns an iterator, 
+//    and then use iterator value
+[[eosio::action]]
+person kv_map::get(std::string map_id) {
+
+   auto itr = my_map.find(map_id);
+
+   // check if person was found
+   if (itr != my_map.end()) {
+      // extract person from iterator, print it and return it to the action sender
+      const auto& person_found = itr->second();
+
+      print_person(person_found, false);
+      
+      // return found person from action
+      return person_found;
+   }
+   else {
+      eosio::print_f("Person with ID % not found.", map_id);
+      // return empty person from action
+      return person{};
+   }
+}
+
+// creates if not exists, or updates if already exists, a person
+[[eosio::action]]
+void kv_map::upsert(
+      std::string map_id,
+      eosio::name account_name,
+      std::string first_name,
+      std::string last_name,
+      std::string street,
+      std::string city,
+      std::string state, 
+      std::string country,
+      std::string personal_id) {
+
+   // create the person object which will be stored in kv::map
+   const person& person_update = person_factory::get_person(
+      account_name,
+      first_name,
+      last_name,
+      street,
+      city,
+      state, 
+      country,
+      personal_id);
+
+   // retreive the person by account name, if it doesn't exist we get an emtpy person
+   const person& existing_person = get(map_id);
+
+   // upsert into kv::map
+   my_map[map_id] = person_update;
+
+   // print customized message for insert vs update
+   if (existing_person.account_name.value == 0) {
+      eosio::print_f("Person (%, %, %) was successfully added.",
+         person_update.first_name, person_update.last_name, person_update.personal_id);
+   }
+   else {
+      eosio::print_f("Person with ID % was successfully updated.", map_id);
+   }
+}
+
+// deletes a person based on primary key account_name
+[[eosio::action]]
+void kv_map::del(std::string map_id) {
+
+   // search for person by primary key account_name
+   auto itr = my_map.find(map_id);
+
+   // check if person was found
+   if (itr != my_map.end()) {
+      // extract person from iterator and delete it
+      const auto& person_found = itr->second();
+
+      // delete it from kv::map
+      my_map.erase(map_id);
+      eosio::print_f("Person (%, %, %) was successfully deleted.",
+         person_found.first_name, person_found.last_name, person_found.personal_id);
+   }
+   else {
+      eosio::print_f("Person with ID % not found.", map_id);
+   }
+}
+
+// checks if a person exists with a given personal_id and country
+[[eosio::action]]
+bool kv_map::checkpidcntr(std::string personal_id, std::string country) {
+   
+   for ( const auto& person_detail : my_map ) {
+      if (person_detail.second().country == country
+            && person_detail.second().personal_id == personal_id);
+         return true;
+   }
+   return false;
+}
+
+// iterates over the first iterations_count persons 
+// and prints their first and last names
+[[eosio::action]]
+void kv_map::iterate(int iterations_count) {
+
+   auto begin_itr = my_map.begin();
+   auto end_itr = my_map.end();
+
+   int current_iteration = 0;
+   while (begin_itr != end_itr && current_iteration < iterations_count) {
+      eosio::print_f(
+         "Person %: {%, %}. ",
+         current_iteration + 1,
+         begin_itr->second().first_name,
+         begin_itr->second().last_name);
+
+      ++ begin_itr;
+      ++ current_iteration;
+   }
+}

--- a/examples/kv_map/src/kv_map.cpp
+++ b/examples/kv_map/src/kv_map.cpp
@@ -21,9 +21,9 @@ void kv_map::print_person(const person& person, bool new_line) {
 // we make use of index find function, which returns an iterator, 
 //    and then use iterator value
 [[eosio::action]]
-person kv_map::get(std::string map_id) {
+person kv_map::get(int id) {
 
-   auto itr = my_map.find(map_id);
+   auto itr = my_map.find(id);
 
    // check if person was found
    if (itr != my_map.end()) {
@@ -36,7 +36,7 @@ person kv_map::get(std::string map_id) {
       return person_found;
    }
    else {
-      eosio::print_f("Person with ID % not found.", map_id);
+      eosio::print_f("Person with ID % not found.", id);
       // return empty person from action
       return person{};
    }
@@ -45,7 +45,7 @@ person kv_map::get(std::string map_id) {
 // creates if not exists, or updates if already exists, a person
 [[eosio::action]]
 void kv_map::upsert(
-      std::string map_id,
+      int id,
       eosio::name account_name,
       std::string first_name,
       std::string last_name,
@@ -67,10 +67,10 @@ void kv_map::upsert(
       personal_id);
 
    // retreive the person by account name, if it doesn't exist we get an emtpy person
-   const person& existing_person = get(map_id);
+   const person& existing_person = get(id);
 
    // upsert into kv::map
-   my_map[map_id] = person_update;
+   my_map[id] = person_update;
 
    // print customized message for insert vs update
    if (existing_person.account_name.value == 0) {
@@ -78,16 +78,16 @@ void kv_map::upsert(
          person_update.first_name, person_update.last_name, person_update.personal_id);
    }
    else {
-      eosio::print_f("Person with ID % was successfully updated.", map_id);
+      eosio::print_f("Person with ID % was successfully updated.", id);
    }
 }
 
 // deletes a person based on primary key account_name
 [[eosio::action]]
-void kv_map::del(std::string map_id) {
+void kv_map::del(int id) {
 
    // search for person by primary key account_name
-   auto itr = my_map.find(map_id);
+   auto itr = my_map.find(id);
 
    // check if person was found
    if (itr != my_map.end()) {
@@ -95,12 +95,12 @@ void kv_map::del(std::string map_id) {
       const auto& person_found = itr->second();
 
       // delete it from kv::map
-      my_map.erase(map_id);
+      my_map.erase(id);
       eosio::print_f("Person (%, %, %) was successfully deleted.",
          person_found.first_name, person_found.last_name, person_found.personal_id);
    }
    else {
-      eosio::print_f("Person with ID % not found.", map_id);
+      eosio::print_f("Person with ID % not found.", id);
    }
 }
 
@@ -109,10 +109,16 @@ void kv_map::del(std::string map_id) {
 bool kv_map::checkpidcntr(std::string personal_id, std::string country) {
    
    for ( const auto& person_detail : my_map ) {
-      if (person_detail.second().country == country
-            && person_detail.second().personal_id == personal_id);
+      if (person_detail.second().country == country && 
+          person_detail.second().personal_id == personal_id) {
+         eosio::print_f("Person with personal id % and country % found in db with ID %d.",
+                        personal_id, 
+                        country, 
+                        person_detail.key);
          return true;
+      }
    }
+   eosio::print_f("Person with personal id % not found in country %.", personal_id, country);
    return false;
 }
 


### PR DESCRIPTION
1. get rid of the eosio::non_unique from kv_addr_book example
2. clean the kv table related content files (.md)
3. add kv_map example
4. cosmetic clean up (unnecessary comments, dead code, back-ticks vs single-ticks, etc.)
