### PR TITLE
Fix unresolved set_kv_parameters_packed problem

### DIFF
--- a/libraries/eosiolib/contracts/eosio/privileged.hpp
+++ b/libraries/eosiolib/contracts/eosio/privileged.hpp
@@ -220,7 +220,18 @@ namespace eosio {
     *  @ingroup privileged
     *  @param params - New kv parameters to set
     */
-   void set_kv_parameters(const eosio::kv_parameters& params);
+   inline void set_kv_parameters(const eosio::kv_parameters& params) {
+      // set_kv_parameters_packed expects version, max_key_size,
+      // max_value_size, and max_iterators,
+      // while kv_parameters only contains max_key_size, max_value_size,
+      // and max_iterators. That's why we place uint32_t in front
+      // of kv_parameters in buf
+      char buf[sizeof(uint32_t) + sizeof(eosio::kv_parameters)];
+      eosio::datastream<char *> ds( buf, sizeof(buf) );
+      ds << uint32_t(0);  // fill in version
+      ds << params;
+      internal_use_do_not_use::set_kv_parameters_packed( buf, ds.tellp() );
+   }
 
     /**
     *  Get the resource limits of an account

--- a/libraries/eosiolib/eosiolib.cpp
+++ b/libraries/eosiolib/eosiolib.cpp
@@ -17,8 +17,6 @@ namespace eosio {
      __attribute__((eosio_wasm_import))
      uint32_t get_blockchain_parameters_packed(char*, uint32_t);
      __attribute__((eosio_wasm_import))
-     void set_kv_parameters_packed(const char*, uint32_t);
-     __attribute__((eosio_wasm_import))
      int64_t set_proposed_producers( char *producer_data, uint32_t producer_data_size );
      __attribute__((eosio_wasm_import))
      uint32_t get_active_producers(uint64_t*, uint32_t);
@@ -65,19 +63,6 @@ namespace eosio {
       eosio::check( size <= sizeof(buf), "buffer is too small" );
       eosio::datastream<const char*> ds( buf, size_t(size) );
       ds >> params;
-   }
-
-   void set_kv_parameters(const eosio::kv_parameters& params) {
-      // set_kv_parameters_packed expects version, max_key_size,
-      // max_value_size, and max_iterators,
-      // while kv_parameters only contains max_key_size, max_value_size,
-      // and max_iterators. That's why we place uint32_t in front
-      // of kv_parameters in buf
-      char buf[sizeof(uint32_t) + sizeof(eosio::kv_parameters)];
-      eosio::datastream<char *> ds( buf, sizeof(buf) );
-      ds << uint32_t(0);  // fill in version
-      ds << params;
-      set_kv_parameters_packed( buf, ds.tellp() );
    }
 
    std::optional<uint64_t> set_proposed_producers( const std::vector<producer_key>& prods ) {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Implementation of set_kv_parameters was placed in libraries/eosiolib/eosiolib.cpp. This caused the problem that set_kv_parameters_packed was included in every contract, and in turn caused unresolved symbol error when deploying non-bios or non-systm contracts. The fix is to move to to eosiolib/contracts/eosio/privileged.hpp.


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
