### PR TITLE
Fix incorrect linker option name -fno-lto

### DIFF
--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -798,7 +798,7 @@ static Options CreateOptions(bool add_defaults=true) {
       }
       ldopts.emplace_back("-stack-size=" + std::to_string(stack_size_opt));
       if (fno_lto_opt) {
-         ldopts.emplace_back("-fno-lto-opt");
+         ldopts.emplace_back("-fno-lto");
       }
       else if (!lto_opt_opt.empty()) {
          ldopts.emplace_back("-lto-opt="+lto_opt_opt);


### PR DESCRIPTION
## Change Description

Fix the issue that `-fno-lto` cannot be passed.

```
eosio-ld: Unknown command line argument '-fno-lto-opt'.  Try: '/usr/opt/eosio.cdt/1.7.0/bin/eosio-ld -help'
eosio-ld: Did you mean '-fno-lto'?
```


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
