### PR TITLE
[docs] release/1.8.x add a few improvements for docs

### DIFF
--- a/docs/05_best-practices/08_abi/00_understanding-abi-files.md
+++ b/docs/05_best-practices/08_abi/00_understanding-abi-files.md
@@ -35,7 +35,7 @@ Start with an empty ABI, for exemplification we will work based on the `eosio.to
 An ABI enables any client or interface to interpret and even generate a GUI for your contract. For this to work consistently, describe the custom types that are used as a parameter in any public action or struct that needs to be described in the ABI.
 
 [[info | Built-in Types]]
-| EOSIO implements a number of custom built-ins. Built-in types don't need to be described in an ABI file. If you would like to familiarize yourself with EOSIO's built-ins, they are defined [here](https://github.com/EOSIO/eos/blob/master/libraries/chain/abi_serializer.cpp#L59-L100)
+| EOSIO implements a number of custom built-ins. Built-in types don't need to be described in an ABI file. If you would like to familiarize yourself with EOSIO's built-ins, they are defined [here](https://github.com/EOSIO/eos/blob/release/2.1.x/libraries/chain/abi_serializer.cpp#L85)
 
 
 ```json

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
 # EOSIO.CDT (Contract Development Toolkit)
 
-## Version : 1.7.0
-
 EOSIO.CDT is a toolchain for WebAssembly (WASM) and set of tools to facilitate smart contract development for the EOSIO platform. In addition to being a general purpose WebAssembly toolchain, [EOSIO](https://github.com/eosio/eos) specific optimizations are available to support building EOSIO smart contracts.  This new toolchain is built around [Clang 7](https://github.com/eosio/llvm), which means that EOSIO.CDT has the most currently available optimizations and analyses from LLVM, but as the WASM target is still considered experimental, some optimizations are incomplete or not available.
 
 ## New Introductions
-As of this release two new repositories are under the suite of tools provided by **EOSIO.CDT**.  These are the [Ricardian Template Toolkit](https://github.com/eosio/ricardian-template-toolkit) and the [Ricardian Specification](https://github.com/eosio/ricardian-spec).  The **Ricardian Template Toolkit** is a set of libraries to facilitate smart contract writers in crafting their Ricardian contracts.  The Ricardian specification is the working specification for the above mentioned toolkit.  Please note that both projects are **alpha** releases and are subject to change.
+
+As of this release two new repositories are under the suite of tools provided by **EOSIO.CDT**.  These are the [Ricardian Template Toolkit](https://github.com/eosio/ricardian-template-toolkit) and the [Ricardian Specification](https://github.com/eosio/ricardian-spec). The **Ricardian Template Toolkit** is a set of libraries to facilitate smart contract writers in crafting their Ricardian contracts.  The Ricardian specification is the working specification for the above mentioned toolkit.  Please note that both projects are **alpha** releases and are subject to change.
 
 ## Upgrading
-There's been a round of braking changes, if you are upgrading please read the [Upgrade guide from 1.2 to 1.3](./04_upgrading/1.2-to-1.3.md) and [Upgrade guide from 1.5 to 1.6](./04_upgrading/1.5-to-1.6.md).
+
+There's been a round of braking changes, if you are upgrading from older version please read the [Upgrade guide from 1.2 to 1.3](./04_upgrading/1.2-to-1.3.md) and [Upgrade guide from 1.5 to 1.6](./04_upgrading/1.5-to-1.6.md).
 
 ## Contributing
 

--- a/examples/kv_map/include/kv_map.hpp
+++ b/examples/kv_map/include/kv_map.hpp
@@ -67,6 +67,10 @@ class [[eosio::contract]] kv_map : public eosio::contract {
          std::string country,
          std::string personal_id);
 
+      // same as upsert only that it takes a user defined type as input parameter
+      [[eosio::action]]
+      void upsert2(int id, person pers);
+
       // inserts a person if not exists, or updates it if already exists.
       // the payer is the account_name, specified as input parameter.
       [[eosio::action]]
@@ -100,6 +104,7 @@ class [[eosio::contract]] kv_map : public eosio::contract {
 
       using get_action = eosio::action_wrapper<"get"_n, &kv_map::get>;
       using upsert_action = eosio::action_wrapper<"upsert"_n, &kv_map::upsert>;
+      using upsert_action2 = eosio::action_wrapper<"upsert2"_n, &kv_map::upsert2>;
       using upsertwpayer_action = eosio::action_wrapper<"upsertwpayer"_n, &kv_map::upsertwpayer>;
       using erase_action = eosio::action_wrapper<"erase"_n, &kv_map::erase>;
       using is_pers_id_in_cntry_action = eosio::action_wrapper<"checkpidcntr"_n, &kv_map::checkpidcntr>;

--- a/examples/kv_map/src/kv_map.cpp
+++ b/examples/kv_map/src/kv_map.cpp
@@ -81,6 +81,36 @@ void kv_map::upsert(
    }
 }
 
+[[eosio::action]]
+void kv_map::upsert2(
+      int id, person pers) {
+
+   const person& person_upsert = person_factory::get_person(
+      pers.account_name,
+      pers.first_name,
+      pers.last_name,
+      pers.street,
+      pers.city,
+      pers.state, 
+      pers.country,
+      pers.personal_id);
+
+   // retrieve the person by account name, if it doesn't exist we get an emtpy person
+   const person& existing_person = get(id);
+
+   // upsert into kv::map, the payer is the account owning the kv::map, owning the smart contract
+   my_map[id] = person_upsert;
+
+   // print customized message for insert vs update
+   if (existing_person.account_name.value == 0) {
+      eosio::print_f("Person (%, %, %) was successfully added.",
+         person_upsert.first_name, person_upsert.last_name, person_upsert.personal_id);
+   }
+   else {
+      eosio::print_f("Person with ID % was successfully updated.", id);
+   }
+}
+
 // inserts a person if not exists, or updates it if already exists.
 // the payer is the account_name, specified as input parameter.
 [[eosio::action]]

--- a/libraries/eosiolib/contracts/eosio/multi_index.hpp
+++ b/libraries/eosiolib/contracts/eosio/multi_index.hpp
@@ -634,11 +634,26 @@ class multi_index
                return lb;
             }
 
+            /**
+             * Gets the object with the smallest primary key in the case where the secondary key is not unique.
+             * 
+             * Avoid the common pitfall of copy-assigning the T& reference returned 
+             * to a stack-allocated local variable and then passing that into modify of the multi-index.
+             * The most common mistake is when the local variable is defined as auto 
+             * typename, instead it should be of type auto& or decltype(auto).
+             */
             const T& get( secondary_key_type&& secondary, const char* error_msg = "unable to find secondary key" )const {
                return get( secondary, error_msg );
             }
 
-            // Gets the object with the smallest primary key in the case where the secondary key is not unique.
+            /**
+             * Gets the object with the smallest primary key in the case where the secondary key is not unique.
+             * 
+             * Avoid the common pitfall of copy-assigning the T& reference returned 
+             * to a stack-allocated local variable and then passing that into modify of the multi-index.
+             * The most common mistake is when the local variable is defined as auto 
+             * typename, instead it should be of type auto& or decltype(auto).
+             */
             const T& get( const secondary_key_type& secondary, const char* error_msg = "unable to find secondary key" )const {
                auto result = find( secondary );
                eosio::check( result != cend(), error_msg );
@@ -1719,10 +1734,10 @@ class multi_index
        *  Retrieves an existing object from a table using its primary key.
        *  @ingroup multiindex
        *
-       *  @param primary - Primary key value of the object
-       *  @return A constant reference to the object containing the specified primary key.
+       *  @param primary - Primary key value of the object.
+       *  @return A constant reference to the object containing the specified primary key. 
        *
-       *  Exception - No object matches the given key
+       *  Exception - No object matches the given key. 
        *
        *  Example:
        *
@@ -1733,12 +1748,19 @@ class multi_index
        *        // create reference to address_index  - see emplace example
        *        // add dan account to table           - see emplace example
        *
-       *        auto user = addresses.get("dan"_n);
+       *        auto& user = addresses.get("dan"_n);
        *        eosio::check(user.first_name == "Daniel", "Couldn't get him.");
        *      }
        *  }
        *  EOSIO_DISPATCH( addressbook, (myaction) )
        *  @endcode
+       * 
+       *  Warning: 
+       * 
+       *  Avoid the common pitfall of copy-assigning the T& reference returned 
+       *  to a stack-allocated local variable and then passing that into modify of the multi-index.
+       *  The most common mistake is when the local variable is defined as auto 
+       *  typename, instead it should be of type auto& or decltype(auto).
        */
       const T& get( uint64_t primary, const char* error_msg = "unable to find key" )const {
          auto result = find( primary );

--- a/libraries/eosiolib/contracts/eosio/multi_index.hpp
+++ b/libraries/eosiolib/contracts/eosio/multi_index.hpp
@@ -695,7 +695,11 @@ class multi_index
 
                return {this, &mi};
             }
-
+            /**
+             *  Warning: the interator_to can have undefined behavior if the caller 
+             *  passes in a reference to a stack-allocated object rather than the 
+             *  reference returned by get or by dereferencing a const_iterator.
+             */
             const_iterator iterator_to( const T& obj ) {
                using namespace _multi_index_detail;
 
@@ -1498,6 +1502,10 @@ class multi_index
        *  }
        *  EOSIO_DISPATCH( addressbook, (myaction) )
        *  @endcode
+       * 
+       *  Warning: the interator_to can have undefined behavior if the caller 
+       *  passes in a reference to a stack-allocated object rather than the 
+       *  reference returned by get or by dereferencing a const_iterator.
        */
       const_iterator iterator_to( const T& obj )const {
          const auto& objitem = static_cast<const item&>(obj);


### PR DESCRIPTION
this is a sister PR for https://github.com/EOSIO/eosio.cdt/pull/1028

a few improvements:

- resolves #818, add warning for multi_index::get and multi_index::iterator_to
- correct the link to the built in types 
- and improve the kv_map example with a new action that demonstrates input param as user defined type