### PR TITLE
Add additional warnings to eosio_exit annotations

### DIFF
--- a/libraries/eosiolib/contracts/eosio/system.hpp
+++ b/libraries/eosiolib/contracts/eosio/system.hpp
@@ -37,11 +37,12 @@ namespace eosio {
     *  This is used to bypass all cleanup / destructors that would normally be
     *  called.
     *
-    *  WARNING: this method will immediately abort execution of wasm code that is on
-    *           the stack and would be executed as the method normally returned.
-    *           Problems can occur with write-caches, RAII, reference counting
-    *           when this method aborts execution of wasm code immediately.
-    *
+       <html><p><b>
+       WARNING: this method will immediately abort execution of wasm code that is on
+                the stack and would be executed as the method normally returned.
+                Problems can occur with write-caches, RAII, reference counting
+                when this method aborts execution of wasm code immediately.
+       </b></p></html>
     *  @ingroup system
     *
     *  @param code - the exit code

--- a/libraries/eosiolib/contracts/eosio/system.hpp
+++ b/libraries/eosiolib/contracts/eosio/system.hpp
@@ -37,7 +37,7 @@ namespace eosio {
     *  This is used to bypass all cleanup / destructors that would normally be
     *  called.
     *
-    *  WARNING: this method immediately abort execution of wasm code that is on
+    *  WARNING: this method will immediately abort execution of wasm code that is on
     *           the stack and would be executed as the method normally returned.
     *           Problems can occur with write-caches, RAII, reference counting
     *           when this method aborts execution of wasm code immediately.

--- a/libraries/eosiolib/contracts/eosio/system.hpp
+++ b/libraries/eosiolib/contracts/eosio/system.hpp
@@ -33,19 +33,27 @@ namespace eosio {
    */
 
    /**
-    *  This method will abort execution of wasm without failing the contract. This is used to bypass all cleanup / destructors that would normally be called.
+    *  This method will abort execution of wasm without failing the contract.
+    *  This is used to bypass all cleanup / destructors that would normally be
+    *  called.
+    *
+    *  WARNING: this method immediately abort execution of wasm code that is on
+    *           the stack and would be executed as the method normally returned.
+    *           Problems can occur with write-caches, RAII, reference counting
+    *           when this method aborts execution of wasm code immediately.
     *
     *  @ingroup system
-    *  @param code - the exit code
-    *  Example:
     *
-    *  @code
-    *  eosio_exit(0);
-    *  eosio_exit(1);
-    *  eosio_exit(2);
-    *  eosio_exit(3);
-    *  @endcode
-    */
+    *  @param code - the exit code
+    *    Example:
+    *
+    *      @code
+    *      eosio_exit(0);
+    *      eosio_exit(1);
+    *      eosio_exit(2);
+    *      eosio_exit(3);
+    *      @endcode
+   */
    inline void eosio_exit( int32_t code ) {
      internal_use_do_not_use::eosio_exit(code);
    }


### PR DESCRIPTION
## Change Description

At present, the documentations for `eosio_exit` accurately describes that the termination is immediate and that destructors etc will not be called however, given that this can lead to very strange error cases it would be better to explicitly mention scenarios where this goes wrong and why.  Ideally, this would be some sort of "big red warning" callout.  

The documentation are updated such that they render an obvious warning about the possible impacts of this intrinsics use describing problems that can occur with write-caches (as we had with the KV singleton), RAII, reference counting etc is attached to this ticket and reviewed for the troubleshooting section
https://blockone.atlassian.net/browse/EPE-382

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->