### PR TITLE
[docs] attempt to separate annotations from code into a dox file

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -11,7 +11,7 @@
 			"name": "doxygen_to_xml",
 			"options": {
 				"INPUT": "libraries/eosiolib",
-				"EXCLUDE_PATTERNS": "*.cpp *.c *.h"
+				"EXCLUDE_PATTERNS": "*.cpp *.c"
 			}
 		},
     	{

--- a/libraries/eosiolib/contracts/eosio/doxy/map_iterator.dox
+++ b/libraries/eosiolib/contracts/eosio/doxy/map_iterator.dox
@@ -1,102 +1,125 @@
-//  -*-c++-*-
+/**
+ * @defgroup keyvaluemap Key Value Map
+ *
+ * @ingroup contracts
+ */
 
 /**
- * @brief This class represents the iterator for the `eosio::kv::map` data type.
+ * @class map
+ *
+ * @ingroup keyvaluemap
+ *
+ * This class represents the 'eosio::kv::map' data type.
+ *
+ * @details TO DO add details here
+ */
+
+/**
+ * @class iterator
+ * @ingroup keyvaluemap
+ *
+ * This class represents the iterator for the 'eosio::kv::map' data type.
+ *
  * @details You will use the sets of functions and operations associated with this type to
  * iterate through values in the map and reference them.
  * 
- * Note that this iterator type in `eosio::kv::map` is defined as `eosio::kv::map::iterator_t`.
- * There is also a reverse iterator available, it is defined as `eosio::kv::map::reverse_iterator_t`.
+ * Note that this iterator type in 'eosio::kv::map' is defined as 'eosio::kv::map::iterator_t'.
+ * There is also a reverse iterator available, it is defined as 'eosio::kv::map::reverse_iterator_t'.
  * The only difference between iterator_t and reverse_iterator_t is the direction the ++ and -- operators go.
  */
-class iterator {
-   /**
-    * @defgroup keyvalue Key Value Map
-    * @ingroup contracts
-    *
-    * @brief Constructor for the iterator type.
-    * @param owner This is the owner of the table object.
-    */
-   iterator(name owner);
 
-   /**
-    * @defgroup keyvalue Key Value Map
-    * @ingroup contracts
-    *
-    * @brief Utility function to see if the iterator is valid or is pointing at `end` or one past the last or first element.
-    */
-   bool is_valid() const;
+/**
+ * @fn iterator::is_valid
+ *
+ * Utility function to see if the iterator is valid or is pointing at 'end' or one past the last or first element.
+ *
+ * @returns bool
+ */
 
-   /**
-    * @defgroup keyvalue Key Value Map
-    * @ingroup contracts
-    *
-    * @brief This will take a `key_type` key and find the value that is equal to or greater than that key.
-    * @details If no element is greater than or equal to the key the iterator will now hold `end`.
-    * @param key This is the key which you wish to query with.
-    */
-   iterator& lower_bound(const key_type& key);
+/**
+ * @fn iterator::lower_bound
+ *
+ * This will take a 'key_type' key and find the value that is equal to or greater than that key.
+ *
+ * @details If no element is greater than or equal to the key the iterator will now hold 'end'.
+ *
+ * @param key This is the key which you wish to query with.
+ * @returns iterator reference
+ */
 
-   /**
-    * @defgroup keyvalue Key Value Map
-    * @ingroup contracts
-    *
-    * @brief This will take a `key_type` key and find the value that is strictly greater than that key.
-    * @details If no element is strictly greater than the key the iterator will now hold `end`.
-    * @param key This is the key which you wish to query with.
-    */
-   iterator& upper_bound(const key_type& key);
+/**
+ * @fn iterator::upper_bound
+ *
+ * This will take a 'key_type' key and find the value that is strictly greater than that key.
+ *
+ * @details If no element is strictly greater than the key the iterator will now hold 'end'.
+ *
+ * @param key This is the key which you wish to query with.
+ * @returns iterator reference
+ */
 
-   /**
-    * @defgroup keyvalue Key Value Map
-    * @ingroup contracts
-    *
-    * @brief This will take a `key_type` key and find the value that exactly matches that key.
-    * @details If no element is equal to the key the iterator will now hold `end`.
-    * @param key This is the key which you wish to query with.
-    */
-   iterator& find(const key_type& key);
+/**
+ * @fn iterator::find
+ *
+ * This will take a 'key_type' key and find the value that exactly matches that key.
+ *
+ * @details If no element is equal to the key the iterator will now hold 'end'.
+ *
+ * @param key This is the key which you wish to query with.
+ *
+ * @returns iterator reference
+ */
 
-   /**
-    * @defgroup keyvalue Key Value Map
-    * @ingroup contracts
-    *
-    * @brief Function to advance the iterator to the beginning of the map's key value pairs.
-    */
-   iterator& seek_to_begin();
+/**
+ * @fn iterator::seek_to_begin
+ *
+ * Function to advance the iterator to the beginning of the map's key value pairs.
+ *
+ * @returns iterator reference
+ */
 
-   /**
-    * @defgroup keyvalue Key Value Map
-    * @ingroup contracts
-    *
-    * @brief Function to advance the iterator to the element past the last element of the map's key value pairs.
-    */
-   iterator& seek_to_end();
+/**
+ * @fn iterator::seek_to_end
+ *
+ * Function to advance the iterator to the element past the last element of the map's key value pairs.
+ *
+ * @returns iterator reference
+ */
 
-   /* @defgroup keyvalue Key Value Map
-    * @ingroup contracts
-    *
-    * @brief Function to advance the iterator to the last element of the map's key value pairs.
-    */
-   iterator& seek_to_last();
+/**
+ * @fn iterator::seek_to_last
+ *
+ * Function to advance the iterator to the last element of the map's key value pairs.
+ *
+ * @returns iterator reference
+ */
 
-   /**
-    * @defgroup keyvalue Key Value Map
-    * @ingroup contracts
-    *
-    * @brief Function to increment the iterator to the next element (sorted in lexicographic order).
-    * @details Note this is the prefix operator, i.e. `++it`, the `it++` operator is explicitly missing because
-    * of performance issues. If you increment past the last element this iterator will then be invalid and point to `end`.
-    */
-   iterator& operator++();
+/**
+ * @fn iterator::operator++
+ *
+ * Function to increment the iterator to the next element (sorted in lexicographic order).
+ *
+ * @details Note this is the prefix operator, i.e. '++it', the 'it++' operator is explicitly missing because
+ * of performance issues. If you increment past the last element this iterator will then be invalid and point to 'end'.
+ *
+ * @returns iterator reference
+ */
 
-   /**
-    * @defgroup keyvalue Key Value Map
-    * @ingroup contracts
-    *
-    * @brief Function to decrement the iterator to the next element (sorted in lexicographic order).
-    * @details Note this is the prefix operator, i.e. `--it`, the `it--` operator is explicitly missing because
-    * of performance issues. If you decrement past the first element this iterator will then be invalid and point to `end`.
-    */
-   iterator& operator--();
-};
+/**
+ * @fn iterator::operator--
+ *
+ * Function to decrement the iterator to the next element (sorted in lexicographic order).
+ *
+ * @details Note this is the prefix operator, i.e. '--it', the 'it--' operator is explicitly missing because
+ * of performance issues. If you decrement past the first element this iterator will then be invalid and point to 'end'.
+ *
+ * @returns iterator reference
+ */
+
+/**
+ * @fn iterator::iterator
+ *
+ * Constructor for the iterator type.
+ *
+ * @param owner This is the owner of the table object.
+ */

--- a/libraries/eosiolib/contracts/eosio/doxy/map_iterator.dox
+++ b/libraries/eosiolib/contracts/eosio/doxy/map_iterator.dox
@@ -15,7 +15,7 @@
  */
 
 /**
- * @class map::iterator
+ * @class iterator
  * @ingroup keyvaluemap
  *
  * @brief This class represents the iterator for the 'eosio::kv::map' data type.
@@ -29,7 +29,7 @@
  */
 
 /**
- * @fn map::iterator::iterator
+ * @fn iterator::iterator
  * @ingroup keyvaluemap
  *
  * Constructor for the iterator type.
@@ -38,7 +38,7 @@
  */
 
 /**
- * @fn map::iterator::is_valid
+ * @fn iterator::is_valid
  * @ingroup keyvaluemap
  *
  * Utility function to see if the iterator is valid or is pointing at 'end' or one past the last or first element.
@@ -47,7 +47,7 @@
  */
 
 /**
- * @fn map::iterator::lower_bound
+ * @fn iterator::lower_bound
  *
  * This will take a 'key_type' key and find the value that is equal to or greater than that key.
  *
@@ -58,7 +58,7 @@
  */
 
 /**
- * @fn map::iterator::upper_bound
+ * @fn iterator::upper_bound
  *
  * This will take a 'key_type' key and find the value that is strictly greater than that key.
  *
@@ -69,7 +69,7 @@
  */
 
 /**
- * @fn map::iterator::find
+ * @fn iterator::find
  *
  * This will take a 'key_type' key and find the value that exactly matches that key.
  *
@@ -81,7 +81,7 @@
  */
 
 /**
- * @fn map::iterator::seek_to_begin
+ * @fn iterator::seek_to_begin
  *
  * Function to advance the iterator to the beginning of the map's key value pairs.
  *
@@ -89,7 +89,7 @@
  */
 
 /**
- * @fn map::iterator::seek_to_end
+ * @fn iterator::seek_to_end
  *
  * Function to advance the iterator to the element past the last element of the map's key value pairs.
  *
@@ -97,7 +97,7 @@
  */
 
 /**
- * @fn map::iterator::seek_to_last
+ * @fn iterator::seek_to_last
  *
  * Function to advance the iterator to the last element of the map's key value pairs.
  *
@@ -105,7 +105,7 @@
  */
 
 /**
- * @fn map::iterator::operator++
+ * @fn iterator::operator++
  *
  * Function to increment the iterator to the next element (sorted in lexicographic order).
  *
@@ -116,7 +116,7 @@
  */
 
 /**
- * @fn map::iterator::operator--
+ * @fn iterator::operator--
  *
  * Function to decrement the iterator to the next element (sorted in lexicographic order).
  *

--- a/libraries/eosiolib/contracts/eosio/doxy/map_iterator.dox
+++ b/libraries/eosiolib/contracts/eosio/doxy/map_iterator.dox
@@ -9,16 +9,16 @@
  *
  * @ingroup keyvaluemap
  *
- * This class represents the 'eosio::kv::map' data type.
+ * @brief This class represents the 'eosio::kv::map' data type.
  *
  * @details TO DO add details here
  */
 
 /**
- * @class iterator
+ * @class map::iterator
  * @ingroup keyvaluemap
  *
- * This class represents the iterator for the 'eosio::kv::map' data type.
+ * @brief This class represents the iterator for the 'eosio::kv::map' data type.
  *
  * @details You will use the sets of functions and operations associated with this type to
  * iterate through values in the map and reference them.
@@ -29,7 +29,17 @@
  */
 
 /**
- * @fn iterator::is_valid
+ * @fn map::iterator::iterator
+ * @ingroup keyvaluemap
+ *
+ * Constructor for the iterator type.
+ *
+ * @param owner This is the owner of the table object.
+ */
+
+/**
+ * @fn map::iterator::is_valid
+ * @ingroup keyvaluemap
  *
  * Utility function to see if the iterator is valid or is pointing at 'end' or one past the last or first element.
  *
@@ -37,7 +47,7 @@
  */
 
 /**
- * @fn iterator::lower_bound
+ * @fn map::iterator::lower_bound
  *
  * This will take a 'key_type' key and find the value that is equal to or greater than that key.
  *
@@ -48,7 +58,7 @@
  */
 
 /**
- * @fn iterator::upper_bound
+ * @fn map::iterator::upper_bound
  *
  * This will take a 'key_type' key and find the value that is strictly greater than that key.
  *
@@ -59,7 +69,7 @@
  */
 
 /**
- * @fn iterator::find
+ * @fn map::iterator::find
  *
  * This will take a 'key_type' key and find the value that exactly matches that key.
  *
@@ -71,7 +81,7 @@
  */
 
 /**
- * @fn iterator::seek_to_begin
+ * @fn map::iterator::seek_to_begin
  *
  * Function to advance the iterator to the beginning of the map's key value pairs.
  *
@@ -79,7 +89,7 @@
  */
 
 /**
- * @fn iterator::seek_to_end
+ * @fn map::iterator::seek_to_end
  *
  * Function to advance the iterator to the element past the last element of the map's key value pairs.
  *
@@ -87,7 +97,7 @@
  */
 
 /**
- * @fn iterator::seek_to_last
+ * @fn map::iterator::seek_to_last
  *
  * Function to advance the iterator to the last element of the map's key value pairs.
  *
@@ -95,7 +105,7 @@
  */
 
 /**
- * @fn iterator::operator++
+ * @fn map::iterator::operator++
  *
  * Function to increment the iterator to the next element (sorted in lexicographic order).
  *
@@ -106,7 +116,7 @@
  */
 
 /**
- * @fn iterator::operator--
+ * @fn map::iterator::operator--
  *
  * Function to decrement the iterator to the next element (sorted in lexicographic order).
  *
@@ -114,12 +124,4 @@
  * of performance issues. If you decrement past the first element this iterator will then be invalid and point to 'end'.
  *
  * @returns iterator reference
- */
-
-/**
- * @fn iterator::iterator
- *
- * Constructor for the iterator type.
- *
- * @param owner This is the owner of the table object.
  */

--- a/libraries/eosiolib/contracts/eosio/table.hpp
+++ b/libraries/eosiolib/contracts/eosio/table.hpp
@@ -403,7 +403,7 @@ namespace internal {
  * Indexes must be a member variable or a member function.
  *
  * @tparam T         - the type of the data stored as the value of the table
-  */
+ */
 template<typename T, eosio::name::raw TableName>
 class table : internal::table_base {
 public:


### PR DESCRIPTION
this is how the dox file supposed to be built based on doxygen docs and other samples out there
however it is not generating documentation for the functions of the iterator class, for some reason which escapes me it ignores all of them... :(
it does generate the map and iterator class documentation though, but that's it no functions.