### PR TITLE
Add error output when ABI is not generated using "eosio-cpp"

### DIFF
--- a/tests/toolchain/abigen-fail/empty_contract.cpp
+++ b/tests/toolchain/abigen-fail/empty_contract.cpp
@@ -1,0 +1,4 @@
+#include <eosio/eosio.hpp>
+using namespace eosio;
+
+CONTRACT hello : public contract {};

--- a/tests/toolchain/abigen-fail/empty_contract.json
+++ b/tests/toolchain/abigen-fail/empty_contract.json
@@ -1,0 +1,22 @@
+{
+  "tests" : [
+    {
+      "compile_flags": ["--abigen", "--contract=hello"],
+      "expected" : {
+        "stderr": "wasm-ld: error"
+      }
+    },
+    {
+      "compile_flags": ["--abigen", "-o=hello.wasm"],
+      "expected" : {
+        "stderr": "wasm-ld: error"
+      }
+    },
+    {
+      "compile_flags": ["--abigen"],
+      "expected" : {
+        "stderr": "wasm-ld: error"
+      }
+    }
+  ]
+}

--- a/tests/toolchain/abigen-fail/empty_contract_with_other_contract.cpp
+++ b/tests/toolchain/abigen-fail/empty_contract_with_other_contract.cpp
@@ -1,0 +1,24 @@
+#include <eosio/eosio.hpp>
+using namespace eosio;
+
+CONTRACT hello : public contract {};
+
+CONTRACT another_hello : public contract {
+   public:
+      using contract::contract;
+
+      ACTION hi( name nm );
+      ACTION check( name nm );
+
+      using hi_action = action_wrapper<"hi"_n, &hello::hi>;
+      using check_action = action_wrapper<"check"_n, &hello::check>;
+};
+
+ACTION hello::hi( name nm ) {
+   print_f("Name : %\n", nm);
+}
+
+ACTION hello::check( name nm ) {
+   print_f("Name : %\n", nm);
+   eosio::check(nm == "hello"_n, "check name not equal to `hello`");
+}

--- a/tests/toolchain/abigen-fail/empty_contract_with_other_contract.cpp
+++ b/tests/toolchain/abigen-fail/empty_contract_with_other_contract.cpp
@@ -7,18 +7,7 @@ CONTRACT another_hello : public contract {
    public:
       using contract::contract;
 
-      ACTION hi( name nm );
-      ACTION check( name nm );
-
-      using hi_action = action_wrapper<"hi"_n, &hello::hi>;
-      using check_action = action_wrapper<"check"_n, &hello::check>;
+      ACTION hi( name nm ) {
+         print_f("Name : %\n", nm);
+      }
 };
-
-ACTION hello::hi( name nm ) {
-   print_f("Name : %\n", nm);
-}
-
-ACTION hello::check( name nm ) {
-   print_f("Name : %\n", nm);
-   eosio::check(nm == "hello"_n, "check name not equal to `hello`");
-}

--- a/tests/toolchain/abigen-fail/empty_contract_with_other_contract.json
+++ b/tests/toolchain/abigen-fail/empty_contract_with_other_contract.json
@@ -1,0 +1,22 @@
+{
+  "tests" : [
+    {
+      "compile_flags": ["--abigen", "--contract=hello"],
+      "expected" : {
+        "stderr": "abigen error"
+      }
+    },
+    {
+      "compile_flags": ["--abigen", "-o=hello.wasm"],
+      "expected" : {
+          "stderr": "abigen error"
+      }
+    },
+    {
+      "compile_flags": ["--abigen"],
+      "expected" : {
+        "stderr": "abigen error"
+      }
+    }
+  ]
+}

--- a/tests/toolchain/abigen-fail/wrong_contract_name.cpp
+++ b/tests/toolchain/abigen-fail/wrong_contract_name.cpp
@@ -1,0 +1,22 @@
+#include <eosio/eosio.hpp>
+using namespace eosio;
+
+CONTRACT hello : public contract {
+   public:
+      using contract::contract;
+
+      ACTION hi( name nm );
+      ACTION check( name nm );
+
+      using hi_action = action_wrapper<"hi"_n, &hello::hi>;
+      using check_action = action_wrapper<"check"_n, &hello::check>;
+};
+
+ACTION hello::hi( name nm ) {
+   print_f("Name : %\n", nm);
+}
+
+ACTION hello::check( name nm ) {
+   print_f("Name : %\n", nm);
+   eosio::check(nm == "hello"_n, "check name not equal to `hello`");
+}

--- a/tests/toolchain/abigen-fail/wrong_contract_name.cpp
+++ b/tests/toolchain/abigen-fail/wrong_contract_name.cpp
@@ -5,18 +5,7 @@ CONTRACT hello : public contract {
    public:
       using contract::contract;
 
-      ACTION hi( name nm );
-      ACTION check( name nm );
-
-      using hi_action = action_wrapper<"hi"_n, &hello::hi>;
-      using check_action = action_wrapper<"check"_n, &hello::check>;
+      ACTION hi( name nm ) {
+         print_f("Name : %\n", nm);
+      }
 };
-
-ACTION hello::hi( name nm ) {
-   print_f("Name : %\n", nm);
-}
-
-ACTION hello::check( name nm ) {
-   print_f("Name : %\n", nm);
-   eosio::check(nm == "hello"_n, "check name not equal to `hello`");
-}

--- a/tests/toolchain/abigen-fail/wrong_contract_name.json
+++ b/tests/toolchain/abigen-fail/wrong_contract_name.json
@@ -1,0 +1,22 @@
+{
+  "tests" : [
+    {
+      "compile_flags": ["--abigen", "--contract=nothello"],
+      "expected" : {
+        "stderr": "abigen error"
+      }
+    },
+    {
+      "compile_flags": ["--abigen", "-o=nothello.wasm"],
+      "expected" : {
+        "stderr": "abigen error"
+      }
+    },
+    {
+      "compile_flags": ["--abigen"],
+      "expected" : {
+        "stderr": "abigen error"
+      }
+    }
+  ]
+}

--- a/tools/cc/eosio-cpp.cpp.in
+++ b/tools/cc/eosio-cpp.cpp.in
@@ -77,7 +77,16 @@ void generate(const std::vector<std::string>& base_options, std::string input, s
       abigen::get().to_json().dump(abi_s);
       codegen::get().set_abi(abi_s);
    } else {
-      throw std::runtime_error("abigen error");
+      const std::string& name = abigen::get().get_internal_contract_name();
+      if (name.empty()) {
+         // there are no actions, tables or maps, so the actural contract name could not be retrieved
+         // a warning is output, and later `wasm-ld` will output an error
+         std::cout << "Warning, ABI is empty and will not be generated\n";
+      } else if (name != contract_name) {
+         throw std::runtime_error("abigen error: please check the specified WASM name or contract name is correct");
+      } else {
+         throw std::runtime_error("abigen error"); // unknown error
+      }
    }
 
    tool_run = ctool.run(newFrontendActionFactory<eosio_codegen_frontend_action>().get());

--- a/tools/cc/eosio-cpp.cpp.in
+++ b/tools/cc/eosio-cpp.cpp.in
@@ -75,14 +75,15 @@ void generate(const std::vector<std::string>& base_options, std::string input, s
    if (!abigen::get().is_empty()) {
       std::string abi_s;
       abigen::get().to_json().dump(abi_s);
+      codegen::get().set_abi(abi_s);
    } else if (abigen) {
       const std::string& real_contract_name = abigen::get().get_real_contract_name();
       if (real_contract_name.empty()) {
          // if the contract is empty, the real contract name could not be obtained by parsing methods or records
-         // a warning is output, and later `wasm-ld` will output an error
+         // a warning is output here, and `wasm-ld` will output an error later
          std::cout << "Warning, contract is empty and ABI file is not generated\n";
       } else if (contract_name != real_contract_name) {
-         throw std::runtime_error("abigen error: the contract name from -o or --contract doesn't match the real contract name");
+         throw std::runtime_error("abigen error: the specified contract name by WASM name or --contract doesn't match the real contract name");
       } else {
          throw std::runtime_error("abigen error"); // unknown error
       }

--- a/tools/cc/eosio-cpp.cpp.in
+++ b/tools/cc/eosio-cpp.cpp.in
@@ -39,6 +39,8 @@ using namespace llvm;
 using namespace eosio;
 using namespace eosio::cdt;
 
+void handle_empty_abigen(const std::string& contract_name, bool has_o_opt, bool has_contract_opt);
+
 void generate(const std::vector<std::string>& base_options, std::string input, std::string contract_name, const std::vector<std::string>& resource_paths, const std::pair<int, int>& abi_version, bool abigen, bool suppress_ricardian_warning, bool has_o_opt, bool has_contract_opt) {
    std::vector<std::string> options;
    options.push_back("eosio-cpp");
@@ -77,27 +79,29 @@ void generate(const std::vector<std::string>& base_options, std::string input, s
       abigen::get().to_json().dump(abi_s);
       codegen::get().set_abi(abi_s);
    } else if (abigen) {
-      const std::string& parsed_contract_name = abigen::get().get_parsed_contract_name();
-      if (parsed_contract_name.empty()) {
-         // if the contract is empty, the contract name could not be obtained by parsing methods or records
-         // a warning is output here, and `wasm-ld` will output an error later
-         std::cout << "Warning, contract is empty and ABI is not generated\n";
-      } else if (contract_name != parsed_contract_name) {
-         if (has_contract_opt) {
-            throw std::runtime_error("abigen error: '--contract' specified name doesn't match the real contract name");
-         } else if (has_o_opt) {
-            throw std::runtime_error("abigen error: '-o' specified WASM name doesn't match the real contract name");
-         } else {
-            throw std::runtime_error("abigen error: contract filename doesn't match the real contract name");
-         }
-      } else {
-         throw std::runtime_error("abigen error"); // unknown error
-      }
+      handle_empty_abigen(contract_name, has_o_opt, has_contract_opt);
    }
 
    tool_run = ctool.run(newFrontendActionFactory<eosio_codegen_frontend_action>().get());
    if (tool_run != 0) {
       throw std::runtime_error("codegen error");
+   }
+}
+
+void handle_empty_abigen(const std::string& contract_name, bool has_o_opt, bool has_contract_opt) {
+   const std::string& parsed_contract_name = abigen::get().get_parsed_contract_name();
+   if (parsed_contract_name.empty()) {
+      // if no contract name could be obtained by parsing methods/records, it means the contract is empty
+      std::cout << "Warning, contract is empty and ABI is not generated\n";
+   } else if (contract_name != parsed_contract_name) {
+      // if contract is empty but the contract file contains other contracts, the parsed contract name could be wrong
+      std::string err = "abigen error: contract is empty, or ";
+      // or, the contract is not empty but the specified or inferred contract name is wrong
+      err += has_contract_opt ? "'--contract' specified name" : (has_o_opt ? "'-o' specified name" : "contract filename");
+      err += " doesn't match the real contract name";
+      throw std::runtime_error(err);
+   } else {
+      throw std::runtime_error("abigen error"); // unknown error
    }
 }
 

--- a/tools/cc/eosio-cpp.cpp.in
+++ b/tools/cc/eosio-cpp.cpp.in
@@ -39,7 +39,7 @@ using namespace llvm;
 using namespace eosio;
 using namespace eosio::cdt;
 
-void generate(const std::vector<std::string>& base_options, std::string input, std::string contract_name, const std::vector<std::string>& resource_paths, const std::pair<int, int>& abi_version, bool abigen, bool suppress_ricardian_warning) {
+void generate(const std::vector<std::string>& base_options, std::string input, std::string contract_name, const std::vector<std::string>& resource_paths, const std::pair<int, int>& abi_version, bool abigen, bool suppress_ricardian_warning, bool has_o_opt, bool has_contract_opt) {
    std::vector<std::string> options;
    options.push_back("eosio-cpp");
    options.push_back(input); // don't remove oddity of CommonOptionsParser?
@@ -77,13 +77,19 @@ void generate(const std::vector<std::string>& base_options, std::string input, s
       abigen::get().to_json().dump(abi_s);
       codegen::get().set_abi(abi_s);
    } else if (abigen) {
-      const std::string& real_contract_name = abigen::get().get_real_contract_name();
-      if (real_contract_name.empty()) {
-         // if the contract is empty, the real contract name could not be obtained by parsing methods or records
+      const std::string& parsed_contract_name = abigen::get().get_parsed_contract_name();
+      if (parsed_contract_name.empty()) {
+         // if the contract is empty, the contract name could not be obtained by parsing methods or records
          // a warning is output here, and `wasm-ld` will output an error later
-         std::cout << "Warning, contract is empty and ABI file is not generated\n";
-      } else if (contract_name != real_contract_name) {
-         throw std::runtime_error("abigen error: the specified contract name by WASM name or --contract doesn't match the real contract name");
+         std::cout << "Warning, contract is empty and ABI is not generated\n";
+      } else if (contract_name != parsed_contract_name) {
+         if (has_contract_opt) {
+            throw std::runtime_error("abigen error: '--contract' specified name doesn't match the real contract name");
+         } else if (has_o_opt) {
+            throw std::runtime_error("abigen error: '-o' specified WASM name doesn't match the real contract name");
+         } else {
+            throw std::runtime_error("abigen error: contract filename doesn't match the real contract name");
+         }
       } else {
          throw std::runtime_error("abigen error"); // unknown error
       }
@@ -126,7 +132,7 @@ int main(int argc, const char **argv) {
             tool_opts.erase(std::remove_if(tool_opts.begin(), tool_opts.end(),
                                            [&](const auto& opt){ return non_tool_opts.count(opt); }),
                             tool_opts.end());
-            generate(tool_opts, input, opts.abigen_contract, opts.abigen_resources, opts.abi_version, opts.abigen, opts.suppress_ricardian_warning);
+            generate(tool_opts, input, opts.abigen_contract, opts.abigen_resources, opts.abi_version, opts.abigen, opts.suppress_ricardian_warning, opts.has_o_opt, opts.has_contract_opt);
 
             auto src = SmallString<64>(input);
             llvm::sys::path::remove_filename(src);
@@ -137,7 +143,7 @@ int main(int argc, const char **argv) {
                input = tmp_file;
             }
             output = tmp_file+".o";
-     
+
             if (!opts.link) {
                output = opts.output_fn.empty() ? "a.out" : opts.output_fn;
             }

--- a/tools/cc/eosio-cpp.cpp.in
+++ b/tools/cc/eosio-cpp.cpp.in
@@ -75,15 +75,14 @@ void generate(const std::vector<std::string>& base_options, std::string input, s
    if (!abigen::get().is_empty()) {
       std::string abi_s;
       abigen::get().to_json().dump(abi_s);
-      codegen::get().set_abi(abi_s);
-   } else {
-      const std::string& name = abigen::get().get_internal_contract_name();
-      if (name.empty()) {
-         // there are no actions, tables or maps, so the actural contract name could not be retrieved
+   } else if (abigen) {
+      const std::string& real_contract_name = abigen::get().get_real_contract_name();
+      if (real_contract_name.empty()) {
+         // if the contract is empty, the real contract name could not be obtained by parsing methods or records
          // a warning is output, and later `wasm-ld` will output an error
-         std::cout << "Warning, ABI is empty and will not be generated\n";
-      } else if (name != contract_name) {
-         throw std::runtime_error("abigen error: please check the specified WASM name or contract name is correct");
+         std::cout << "Warning, contract is empty and ABI file is not generated\n";
+      } else if (contract_name != real_contract_name) {
+         throw std::runtime_error("abigen error: the contract name from -o or --contract doesn't match the real contract name");
       } else {
          throw std::runtime_error("abigen error"); // unknown error
       }
@@ -137,7 +136,7 @@ int main(int argc, const char **argv) {
                input = tmp_file;
             }
             output = tmp_file+".o";
-
+     
             if (!opts.link) {
                output = opts.output_fn.empty() ? "a.out" : opts.output_fn;
             }

--- a/tools/cc/eosio-cpp.cpp.in
+++ b/tools/cc/eosio-cpp.cpp.in
@@ -76,6 +76,8 @@ void generate(const std::vector<std::string>& base_options, std::string input, s
       std::string abi_s;
       abigen::get().to_json().dump(abi_s);
       codegen::get().set_abi(abi_s);
+   } else {
+      throw std::runtime_error("abigen error");
    }
 
    tool_run = ctool.run(newFrontendActionFactory<eosio_codegen_frontend_action>().get());

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -891,8 +891,7 @@ static Options CreateOptions(bool add_defaults=true) {
    if (!contract_name.empty()) {
       abigen_contract = contract_name;
       has_contract_opt = true;
-   }
-   else {
+   } else {
       llvm::SmallString<256> fn = llvm::sys::path::filename(output_fn);
       llvm::sys::path::replace_extension(fn, "");
       abigen_contract = fn.str();

--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -385,6 +385,8 @@ struct Options {
    bool debug;
    bool native;
    std::pair<int, int> abi_version;
+   bool has_o_opt;
+   bool has_contract_opt;
 };
 
 static void GetCompDefaults(std::vector<std::string>& copts) {
@@ -544,6 +546,8 @@ static Options CreateOptions(bool add_defaults=true) {
    std::string pp_dir;
    std::string abigen_output;
    std::string abigen_contract;
+   bool has_o_opt;
+   bool has_contract_opt;
 
 #ifdef ONLY_LD
    bool abigen = false;
@@ -833,11 +837,13 @@ static Options CreateOptions(bool add_defaults=true) {
          ldopts.emplace_back("-o"+output_fn);
       }
 #endif
+      has_o_opt = false;
    }
    else {
       ldopts.emplace_back("-o");
       ldopts.emplace_back(o_opt);
       output_fn = o_opt;
+      has_o_opt = true;
    }
 
    if (!fnative_opt) {
@@ -882,12 +888,15 @@ static Options CreateOptions(bool add_defaults=true) {
       agopts.emplace_back("-fstrict-vtable-pointers");
    }
 #endif
-   if (!contract_name.empty())
+   if (!contract_name.empty()) {
       abigen_contract = contract_name;
+      has_contract_opt = true;
+   }
    else {
       llvm::SmallString<256> fn = llvm::sys::path::filename(output_fn);
       llvm::sys::path::replace_extension(fn, "");
       abigen_contract = fn.str();
+      has_contract_opt = false;
    }
 
    for ( auto resource : resources ) {
@@ -910,8 +919,8 @@ static Options CreateOptions(bool add_defaults=true) {
    }
 
 #ifndef ONLY_LD
-   return {output_fn, inputs, link, abigen, no_missing_ricardian_clause_opt, pp_only, pp_dir, abigen_output, abigen_contract, copts, ldopts, agopts, agresources, debug, fnative_opt, {abi_version_major, abi_version_minor}};
+   return {output_fn, inputs, link, abigen, no_missing_ricardian_clause_opt, pp_only, pp_dir, abigen_output, abigen_contract, copts, ldopts, agopts, agresources, debug, fnative_opt, {abi_version_major, abi_version_minor}, has_o_opt, has_contract_opt};
 #else
-   return {output_fn, {}, link, abigen, no_missing_ricardian_clause_opt, pp_only, pp_dir, abigen_output, abigen_contract, copts, ldopts, agopts, agresources, debug, fnative_opt, {abi_version_major, abi_version_minor}};
+   return {output_fn, {}, link, abigen, no_missing_ricardian_clause_opt, pp_only, pp_dir, abigen_output, abigen_contract, copts, ldopts, agopts, agresources, debug, fnative_opt, {abi_version_major, abi_version_minor}, has_o_opt, has_contract_opt};
 #endif
 }

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -105,6 +105,7 @@ struct simple_ricardian_tokenizer {
 struct generation_utils {
    std::vector<std::string> resource_dirs;
    std::string contract_name;
+   inline static std::string name = ""; // internal contract name
    bool suppress_ricardian_warnings;
 
    generation_utils() : resource_dirs({"./"}) {}
@@ -154,6 +155,7 @@ struct generation_utils {
 
    inline void set_contract_name( const std::string& cn ) { contract_name = cn; }
    inline std::string get_contract_name()const { return contract_name; }
+   static inline std::string get_internal_contract_name() { return name; }
    inline void set_resource_dirs( const std::vector<std::string>& rd ) {
       llvm::SmallString<128> cwd;
       auto has_real_path = llvm::sys::fs::real_path("./", cwd, true);
@@ -271,7 +273,9 @@ struct generation_utils {
    }
 
    static inline bool is_eosio_contract( const clang::CXXMethodDecl* decl, const std::string& cn ) {
-      std::string name = "";
+      if (!name.empty()) {
+         return name == cn;
+      }
       if (decl->isEosioContract())
          name = decl->getEosioContractAttr()->getName();
       else if (decl->getParent()->isEosioContract())
@@ -283,7 +287,9 @@ struct generation_utils {
    }
 
    static inline bool is_eosio_contract( const clang::CXXRecordDecl* decl, const std::string& cn ) {
-      std::string name = "";
+      if (!name.empty()) {
+         return name == cn;
+      }
       auto pd = llvm::dyn_cast<clang::CXXRecordDecl>(decl->getParent());
       if (decl->isEosioContract()) {
          auto nm = decl->getEosioContractAttr()->getName().str();

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -105,7 +105,7 @@ struct simple_ricardian_tokenizer {
 struct generation_utils {
    std::vector<std::string> resource_dirs;
    std::string contract_name;
-   inline static std::string name = ""; // internal contract name
+   inline static std::string real_contract_name = ""; // obtained by parsing methods/records
    bool suppress_ricardian_warnings;
 
    generation_utils() : resource_dirs({"./"}) {}
@@ -155,7 +155,7 @@ struct generation_utils {
 
    inline void set_contract_name( const std::string& cn ) { contract_name = cn; }
    inline std::string get_contract_name()const { return contract_name; }
-   static inline std::string get_internal_contract_name() { return name; }
+   static inline std::string get_real_contract_name() { return real_contract_name; }
    inline void set_resource_dirs( const std::vector<std::string>& rd ) {
       llvm::SmallString<128> cwd;
       auto has_real_path = llvm::sys::fs::real_path("./", cwd, true);
@@ -273,33 +273,31 @@ struct generation_utils {
    }
 
    static inline bool is_eosio_contract( const clang::CXXMethodDecl* decl, const std::string& cn ) {
-      if (!name.empty()) {
-         return name == cn;
+      if (real_contract_name.empty()) {
+         if (decl->isEosioContract())
+            real_contract_name = decl->getEosioContractAttr()->getName();
+         else if (decl->getParent()->isEosioContract())
+            real_contract_name = decl->getParent()->getEosioContractAttr()->getName();
+         if (real_contract_name.empty()) {
+            real_contract_name = decl->getParent()->getName().str();
+         }
       }
-      if (decl->isEosioContract())
-         name = decl->getEosioContractAttr()->getName();
-      else if (decl->getParent()->isEosioContract())
-         name = decl->getParent()->getEosioContractAttr()->getName();
-      if (name.empty()) {
-         name = decl->getParent()->getName().str();
-      }
-      return name == cn;
+      return cn == real_contract_name;
    }
 
    static inline bool is_eosio_contract( const clang::CXXRecordDecl* decl, const std::string& cn ) {
-      if (!name.empty()) {
-         return name == cn;
+      if (real_contract_name.empty()) {
+         auto pd = llvm::dyn_cast<clang::CXXRecordDecl>(decl->getParent());
+         if (decl->isEosioContract()) {
+            auto nm = decl->getEosioContractAttr()->getName().str();
+            real_contract_name = nm.empty() ? decl->getName().str() : nm;
+         }
+         else if (pd && pd->isEosioContract()) {
+            auto nm = pd->getEosioContractAttr()->getName().str();
+            real_contract_name = nm.empty() ? pd->getName().str() : nm;
+         }
       }
-      auto pd = llvm::dyn_cast<clang::CXXRecordDecl>(decl->getParent());
-      if (decl->isEosioContract()) {
-         auto nm = decl->getEosioContractAttr()->getName().str();
-         name = nm.empty() ? decl->getName().str() : nm;
-      }
-      else if (pd && pd->isEosioContract()) {
-         auto nm = pd->getEosioContractAttr()->getName().str();
-         name = nm.empty() ? pd->getName().str() : nm;
-      }
-      return cn == name;
+      return cn == real_contract_name;
    }
 
    inline bool is_template_specialization( const clang::QualType& type, const std::vector<std::string>& names ) {

--- a/tools/toolchain-tester/tests.py
+++ b/tools/toolchain-tester/tests.py
@@ -194,3 +194,12 @@ class CompileFailTest(Test):
         self.handle_test_result(res, expected_pass=False)
 
         return res
+
+class AbigenFailTest(Test):
+    def _run(self, eosio_cpp, args):
+        command = [eosio_cpp, self.cpp_file, "-abigen_output=''"]
+        command.extend(args)
+        res = subprocess.run(command, capture_output=True)
+        self.handle_test_result(res, expected_pass=False)
+        
+        return res

--- a/tools/toolchain-tester/testsuite.py
+++ b/tools/toolchain-tester/testsuite.py
@@ -73,6 +73,8 @@ class TestSuite:
                     self.tests.append(tests.CompileFailTest(*args))
                 elif self.test_type == TestType.ABIGEN_PASS:
                     self.tests.append(tests.AbigenPassTest(*args))
+                elif self.test_type == TestType.ABIGEN_FAIL:
+                    self.tests.append(tests.AbigenFailTest(*args))
 
     def _get_test_type(self) -> TestType:
         return TestType.from_str(self.directory.split("/")[-1])


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
When using `eosio-cpp` to generate WASM and ABI, if the contract is empty, or if the specified contract name doesn't match the real contract name, the ABI will silently not be generated. This fix adds warning output, or throws exception with error messages, for this situation.

Notes: 
- **Only when `--abigen` option is set, the warning or error is output. This is to avoid incompatibility with some previous code (e.g. some contracts in the unit test code have different names for contract and filename). This decision can be further discussed**.
- The `specified` contract name is either explicitly specified by `--contract`, or inferred from output name by `-o`, or the same as the contract filename if neither '--contract' or '-o' is set.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
