### PR TITLE
Add payer to kv_set and remove db_name to match 2.1.x of eosio/eos

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -48,6 +48,7 @@ steps:
 
   - label: ":darwin: macOS 10.14 - Build"
     command:
+      - "brew upgrade"
       - "brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3"
       - "git clone $BUILDKITE_REPO eosio.cdt"
       - "cd eosio.cdt && if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then git fetch -v --prune origin refs/pull/$(echo $BUILDKITE_BRANCH | cut -d/ -f2)/head; fi"
@@ -73,6 +74,7 @@ steps:
 
   - label: ":darwin: macOS 10.15 - Build"
     command:
+      - "brew upgrade"
       - "brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3"
       - "git clone $BUILDKITE_REPO eosio.cdt"
       - "cd eosio.cdt && if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then git fetch -v --prune origin refs/pull/$(echo $BUILDKITE_BRANCH | cut -d/ -f2)/head; fi"
@@ -143,6 +145,7 @@ steps:
 
   - label: ":darwin: macOS 10.14 - Unit Tests"
     command:
+      - "brew upgrade"
       - "brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3"
       - "git clone $BUILDKITE_REPO eosio.cdt"
       - "cd eosio.cdt && if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then git fetch -v --prune origin refs/pull/$(echo $BUILDKITE_BRANCH | cut -d/ -f2)/head; fi"
@@ -168,6 +171,7 @@ steps:
 
   - label: ":darwin: macOS 10.15 - Unit Tests"
     command:
+      - "brew upgrade"
       - "brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3"
       - "git clone $BUILDKITE_REPO eosio.cdt"
       - "cd eosio.cdt && if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then git fetch -v --prune origin refs/pull/$(echo $BUILDKITE_BRANCH | cut -d/ -f2)/head; fi"
@@ -235,6 +239,7 @@ steps:
 
   - label: ":darwin: macOS 10.14 - Toolchain Tests"
     command:
+      - "brew upgrade"
       - "brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3"
       - "git clone $BUILDKITE_REPO eosio.cdt"
       - "cd eosio.cdt && if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then git fetch -v --prune origin refs/pull/$(echo $BUILDKITE_BRANCH | cut -d/ -f2)/head; fi"
@@ -260,6 +265,7 @@ steps:
 
   - label: ":darwin: macOS 10.15 - Toolchain Tests"
     command:
+      - "brew upgrade"
       - "brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3"
       - "git clone $BUILDKITE_REPO eosio.cdt"
       - "cd eosio.cdt && if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then git fetch -v --prune origin refs/pull/$(echo $BUILDKITE_BRANCH | cut -d/ -f2)/head; fi"

--- a/docs/06_how-to-guides/06_key_value/01_key_value_examples.md
+++ b/docs/06_how-to-guides/06_key_value/01_key_value_examples.md
@@ -58,13 +58,6 @@ struct myramtable : kv_table<myrecord> {
         init(contract_name, "testtable"_n, "eosio.kvram"_n, ...)
     }
 }
-
-struct mydisktable : kv_table<myrecord> {
-    // Assume some indexes
-    mydisktable(eosio::name contract_name) {
-        init(contract_name, "testtable"_n, "eosio.kvdisk"_n, ...)
-    }
-}
 ```
 
 ### kv_table::put Example:

--- a/libraries/eosiolib/contracts/eosio/key_value.hpp
+++ b/libraries/eosiolib/contracts/eosio/key_value.hpp
@@ -200,7 +200,6 @@ inline partial_key make_key(T val) {
 #endif
 
 static constexpr eosio::name kv_ram = "eosio.kvram"_n;
-static constexpr eosio::name kv_disk = "eosio.kvdisk"_n;
 
 template<typename T>
 class kv_table;
@@ -571,7 +570,7 @@ class kv_table : kv_detail::kv_table_base {
 
       iterator& operator--() {
          if (!itr) {
-            itr = internal_use_do_not_use::kv_it_create(static_cast<kv_table*>(index->tbl)->db_name, index->contract_name.value, index->prefix.data(), index->prefix.size());
+            itr = internal_use_do_not_use::kv_it_create(index->contract_name.value, index->prefix.data(), index->prefix.size());
          }
          itr_stat = static_cast<status>(internal_use_do_not_use::kv_it_prev(itr));
          eosio::check(itr_stat != status::iterator_end, "decremented past the beginning");
@@ -643,7 +642,7 @@ class kv_table : kv_detail::kv_table_base {
 
       reverse_iterator& operator--() {
          if (!itr) {
-            itr = internal_use_do_not_use::kv_it_create(static_cast<kv_table*>(index->tbl)->db_name, index->contract_name.value, index->prefix.data(), index->prefix.size());
+            itr = internal_use_do_not_use::kv_it_create(index->contract_name.value, index->prefix.data(), index->prefix.size());
             itr_stat = static_cast<status>(internal_use_do_not_use::kv_it_lower_bound(itr, "", 0));
          }
          itr_stat = static_cast<status>(internal_use_do_not_use::kv_it_next(itr));
@@ -734,7 +733,7 @@ public:
       }
 
       iterator find(const full_key& key) const {
-         uint32_t itr = internal_use_do_not_use::kv_it_create(static_cast<kv_table*>(tbl)->db_name, contract_name.value, prefix.data(), prefix.size());
+         uint32_t itr = internal_use_do_not_use::kv_it_create(contract_name.value, prefix.data(), prefix.size());
          int32_t itr_stat = internal_use_do_not_use::kv_it_lower_bound(itr, key.data(), key.size());
 
          auto cmp = internal_use_do_not_use::kv_it_key_compare(itr, key.data(), key.size());

--- a/libraries/eosiolib/contracts/eosio/key_value.hpp
+++ b/libraries/eosiolib/contracts/eosio/key_value.hpp
@@ -28,19 +28,19 @@ namespace eosio {
    namespace internal_use_do_not_use {
       extern "C" {
          __attribute__((eosio_wasm_import))
-         int64_t kv_erase(uint64_t db, uint64_t contract, const char* key, uint32_t key_size);
+         int64_t kv_erase(uint64_t contract, const char* key, uint32_t key_size);
 
          __attribute__((eosio_wasm_import))
-         int64_t kv_set(uint64_t db, uint64_t contract, const char* key, uint32_t key_size, const char* value, uint32_t value_size);
+         int64_t kv_set(uint64_t contract, const char* key, uint32_t key_size, const char* value, uint32_t value_size, uint64_t payer);
 
          __attribute__((eosio_wasm_import))
-         bool kv_get(uint64_t db, uint64_t contract, const char* key, uint32_t key_size, uint32_t& value_size);
+         bool kv_get(uint64_t contract, const char* key, uint32_t key_size, uint32_t& value_size);
 
          __attribute__((eosio_wasm_import))
-         uint32_t kv_get_data(uint64_t db, uint32_t offset, char* data, uint32_t data_size);
+         uint32_t kv_get_data(uint32_t offset, char* data, uint32_t data_size);
 
          __attribute__((eosio_wasm_import))
-         uint32_t kv_it_create(uint64_t db, uint64_t contract, const char* prefix, uint32_t size);
+         uint32_t kv_it_create(uint64_t contract, const char* prefix, uint32_t size);
 
          __attribute__((eosio_wasm_import))
          void kv_it_destroy(uint32_t itr);
@@ -271,11 +271,11 @@ namespace kv_detail {
          auto primary_key = primary_index->get_key_void(value);
          auto tbl_key = full_key(make_prefix(table_name, primary_index->index_name), primary_key);
 
-         auto primary_key_found = internal_use_do_not_use::kv_get(db_name, contract_name.value, tbl_key.data(), tbl_key.size(), value_size);
+         auto primary_key_found = internal_use_do_not_use::kv_get(contract_name.value, tbl_key.data(), tbl_key.size(), value_size);
 
          if (primary_key_found) {
             void* buffer = value_size > detail::max_stack_buffer_size ? malloc(value_size) : alloca(value_size);
-            auto copy_size = internal_use_do_not_use::kv_get_data(db_name, 0, (char*)buffer, value_size);
+            auto copy_size = internal_use_do_not_use::kv_get_data(0, (char*)buffer, value_size);
 
             deserialize(old_value, buffer, copy_size);
 
@@ -284,18 +284,19 @@ namespace kv_detail {
             }
          }
 
+         eosio::name payer = contract_name;
          for (const auto& idx : secondary_indices) {
             uint32_t value_size;
             auto sec_tbl_key = full_key(make_prefix(table_name, idx->index_name), idx->get_key_void(value));
-            auto sec_found = internal_use_do_not_use::kv_get(db_name, contract_name.value, sec_tbl_key.data(), sec_tbl_key.size(), value_size);
+            auto sec_found = internal_use_do_not_use::kv_get(contract_name.value, sec_tbl_key.data(), sec_tbl_key.size(), value_size);
 
             if (!primary_key_found) {
                eosio::check(!sec_found, "Attempted to store an existing secondary index.");
-               internal_use_do_not_use::kv_set(db_name, contract_name.value, sec_tbl_key.data(), sec_tbl_key.size(), tbl_key.data(), tbl_key.size());
+               internal_use_do_not_use::kv_set(contract_name.value, sec_tbl_key.data(), sec_tbl_key.size(), tbl_key.data(), tbl_key.size(), payer.value);
             } else {
                if (sec_found) {
                   void* buffer = value_size > detail::max_stack_buffer_size ? malloc(value_size) : alloca(value_size);
-                  auto copy_size = internal_use_do_not_use::kv_get_data(db_name, 0, (char*)buffer, value_size);
+                  auto copy_size = internal_use_do_not_use::kv_get_data(0, (char*)buffer, value_size);
 
                   auto res = memcmp(buffer, tbl_key.data(), copy_size);
                   eosio::check(copy_size == tbl_key.size() && res == 0, "Attempted to update an existing secondary index.");
@@ -305,8 +306,8 @@ namespace kv_detail {
                   }
                } else {
                   auto old_sec_key = full_key(make_prefix(table_name, idx->index_name), idx->get_key_void(old_value));
-                  internal_use_do_not_use::kv_erase(db_name, contract_name.value, old_sec_key.data(), old_sec_key.size());
-                  internal_use_do_not_use::kv_set(db_name, contract_name.value, sec_tbl_key.data(), sec_tbl_key.size(), tbl_key.data(), tbl_key.size());
+                  internal_use_do_not_use::kv_erase(contract_name.value, old_sec_key.data(), old_sec_key.size());
+                  internal_use_do_not_use::kv_set(contract_name.value, sec_tbl_key.data(), sec_tbl_key.size(), tbl_key.data(), tbl_key.size(), payer.value);
                }
             }
          }
@@ -316,7 +317,7 @@ namespace kv_detail {
 
          serialize(value, data_buffer, data_size);
 
-         internal_use_do_not_use::kv_set(db_name, contract_name.value, tbl_key.data(), tbl_key.size(), (const char*)data_buffer, data_size);
+         internal_use_do_not_use::kv_set(contract_name.value, tbl_key.data(), tbl_key.size(), (const char*)data_buffer, data_size, payer.value);
 
          if (data_size > detail::max_stack_buffer_size) {
             free(data_buffer);
@@ -328,7 +329,7 @@ namespace kv_detail {
 
          auto primary_key = primary_index->get_key_void(value);
          auto tbl_key = full_key(make_prefix(table_name, primary_index->index_name), primary_key);
-         auto primary_key_found = internal_use_do_not_use::kv_get(db_name, contract_name.value, tbl_key.data(), tbl_key.size(), value_size);
+         auto primary_key_found = internal_use_do_not_use::kv_get(contract_name.value, tbl_key.data(), tbl_key.size(), value_size);
 
          if (!primary_key_found) {
             return;
@@ -336,10 +337,10 @@ namespace kv_detail {
 
          for (const auto& idx : secondary_indices) {
             auto sec_tbl_key = full_key(make_prefix(table_name, idx->index_name), idx->get_key_void(value));
-            internal_use_do_not_use::kv_erase(db_name, contract_name.value, sec_tbl_key.data(), sec_tbl_key.size());
+            internal_use_do_not_use::kv_erase(contract_name.value, sec_tbl_key.data(), sec_tbl_key.size());
          }
 
-         internal_use_do_not_use::kv_erase(db_name, contract_name.value, tbl_key.data(), tbl_key.size());
+         internal_use_do_not_use::kv_erase(contract_name.value, tbl_key.data(), tbl_key.size());
       }
    };
 
@@ -347,24 +348,24 @@ namespace kv_detail {
       uint32_t value_size;
       uint32_t actual_data_size;
 
-      auto success = internal_use_do_not_use::kv_get(tbl->db_name, contract_name.value, key.data(), key.size(), value_size);
+      auto success = internal_use_do_not_use::kv_get(contract_name.value, key.data(), key.size(), value_size);
       if (!success) {
          return;
       }
 
       void* buffer = value_size > detail::max_stack_buffer_size ? malloc(value_size) : alloca(value_size);
-      auto copy_size = internal_use_do_not_use::kv_get_data(tbl->db_name, 0, (char*)buffer, value_size);
+      auto copy_size = internal_use_do_not_use::kv_get_data(0, (char*)buffer, value_size);
 
       void* deserialize_buffer = buffer;
       size_t deserialize_size = copy_size;
 
       bool is_primary = index_name == tbl->primary_index_name;
       if (!is_primary) {
-         auto success = internal_use_do_not_use::kv_get(tbl->db_name, contract_name.value, (char*)buffer, copy_size, actual_data_size);
+         auto success = internal_use_do_not_use::kv_get(contract_name.value, (char*)buffer, copy_size, actual_data_size);
          eosio::check(success, "failure getting primary key");
 
          void* pk_buffer = actual_data_size > detail::max_stack_buffer_size ? malloc(actual_data_size) : alloca(actual_data_size);
-         auto pk_copy_size = internal_use_do_not_use::kv_get_data(tbl->db_name, 0, (char*)pk_buffer, actual_data_size);
+         auto pk_copy_size = internal_use_do_not_use::kv_get_data(0, (char*)pk_buffer, actual_data_size);
 
          deserialize_buffer = pk_buffer;
          deserialize_size = pk_copy_size;
@@ -446,11 +447,11 @@ namespace kv_detail {
 
          bool is_primary = index->index_name == index->tbl->primary_index_name;
          if (!is_primary) {
-            auto success = internal_use_do_not_use::kv_get(index->tbl->db_name, index->contract_name.value, (char*)buffer, actual_value_size, actual_data_size);
+            auto success = internal_use_do_not_use::kv_get(index->contract_name.value, (char*)buffer, actual_value_size, actual_data_size);
             eosio::check(success, "failure getting primary key in `value()`");
 
             void* pk_buffer = actual_data_size > detail::max_stack_buffer_size ? malloc(actual_data_size) : alloca(actual_data_size);
-            internal_use_do_not_use::kv_get_data(index->tbl->db_name, 0, (char*)pk_buffer, actual_data_size);
+            internal_use_do_not_use::kv_get_data(0, (char*)pk_buffer, actual_data_size);
 
             deserialize_buffer = pk_buffer;
             deserialize_size = actual_data_size;
@@ -760,7 +761,7 @@ public:
 
       bool exists(const full_key& key) const {
          uint32_t value_size;
-         return internal_use_do_not_use::kv_get(static_cast<kv_table*>(tbl)->db_name, contract_name.value, key.data(), key.size(), value_size);
+         return internal_use_do_not_use::kv_get(contract_name.value, key.data(), key.size(), value_size);
       }
 
       /**
@@ -812,7 +813,7 @@ public:
        * @return An iterator to the object with the lowest key (by this index) in the table.
        */
       iterator begin() const {
-         uint32_t itr = internal_use_do_not_use::kv_it_create(static_cast<kv_table*>(tbl)->db_name, contract_name.value, prefix.data(), prefix.size());
+         uint32_t itr = internal_use_do_not_use::kv_it_create(contract_name.value, prefix.data(), prefix.size());
          int32_t itr_stat = internal_use_do_not_use::kv_it_lower_bound(itr, "", 0);
 
          return {itr, static_cast<typename iterator::status>(itr_stat), this};
@@ -835,7 +836,7 @@ public:
        * @return A reverse iterator to the object with the highest key (by this index) in the table.
        */
       reverse_iterator rbegin() const {
-         uint32_t itr = internal_use_do_not_use::kv_it_create(static_cast<kv_table*>(tbl)->db_name, contract_name.value, prefix.data(), prefix.size());
+         uint32_t itr = internal_use_do_not_use::kv_it_create(contract_name.value, prefix.data(), prefix.size());
          int32_t itr_stat = internal_use_do_not_use::kv_it_prev(itr);
 
          return {itr, static_cast<typename iterator::status>(itr_stat), this};
@@ -867,7 +868,7 @@ public:
       }
 
       iterator lower_bound(const full_key& key ) const {
-         uint32_t itr = internal_use_do_not_use::kv_it_create(static_cast<kv_table*>(tbl)->db_name, contract_name.value, prefix.data(), prefix.size());
+         uint32_t itr = internal_use_do_not_use::kv_it_create(contract_name.value, prefix.data(), prefix.size());
          int32_t itr_stat = internal_use_do_not_use::kv_it_lower_bound(itr, key.data(), key.size());
 
          return {itr, static_cast<typename iterator::status>(itr_stat), this};

--- a/libraries/eosiolib/contracts/eosio/key_value.hpp
+++ b/libraries/eosiolib/contracts/eosio/key_value.hpp
@@ -199,7 +199,9 @@ inline partial_key make_key(T val) {
 }
 #endif
 
+// Ignored by kv_table, maintained for now so contracts do not have to change
 static constexpr eosio::name kv_ram = "eosio.kvram"_n;
+static constexpr eosio::name kv_disk = "eosio.kvdisk"_n;
 
 template<typename T>
 class kv_table;

--- a/libraries/eosiolib/contracts/eosio/key_value_singleton.hpp
+++ b/libraries/eosiolib/contracts/eosio/key_value_singleton.hpp
@@ -24,7 +24,7 @@ namespace eosio {
       }
    }
 
-   template <typename T, eosio::name::raw SingletonName, eosio::name::raw DbName = "eosio.kvram"_n>
+   template <typename T, eosio::name::raw SingletonName>
    class kv_singleton {
       struct state {
          T value;
@@ -154,7 +154,6 @@ namespace eosio {
       }
 
    private:
-      constexpr static uint64_t db_name = static_cast<uint64_t>(DbName);
       constexpr static uint64_t singleton_name = static_cast<uint64_t>(SingletonName);
 
       eosio::name contract_name;

--- a/libraries/eosiolib/contracts/eosio/key_value_singleton.hpp
+++ b/libraries/eosiolib/contracts/eosio/key_value_singleton.hpp
@@ -11,16 +11,16 @@ namespace eosio {
    namespace internal_use_do_not_use {
       extern "C" {
          __attribute__((eosio_wasm_import))
-         int64_t kv_erase(uint64_t db, uint64_t contract, const char* key, uint32_t key_size);
+         int64_t kv_erase(uint64_t contract, const char* key, uint32_t key_size);
 
          __attribute__((eosio_wasm_import))
-         int64_t kv_set(uint64_t db, uint64_t contract, const char* key, uint32_t key_size, const char* value, uint32_t value_size);
+         int64_t kv_set(uint64_t contract, const char* key, uint32_t key_size, const char* value, uint32_t value_size, uint64_t payer);
 
          __attribute__((eosio_wasm_import))
-         bool kv_get(uint64_t db, uint64_t contract, const char* key, uint32_t key_size, uint32_t& value_size);
+         bool kv_get(uint64_t contract, const char* key, uint32_t key_size, uint32_t& value_size);
 
          __attribute__((eosio_wasm_import))
-         uint32_t kv_get_data(uint64_t db, uint32_t offset, char* data, uint32_t data_size);
+         uint32_t kv_get_data(uint32_t offset, char* data, uint32_t data_size);
       }
    }
 
@@ -75,7 +75,7 @@ namespace eosio {
             uint32_t copy_size;
             uint32_t value_size;
 
-            auto success = internal_use_do_not_use::kv_get(db_name, contract_name.value, key.data(), key.size(), value_size);
+            auto success = internal_use_do_not_use::kv_get(contract_name.value, key.data(), key.size(), value_size);
 
             if( !success ) {
                 eosio::check(success, "tried to get the singleton '" + std::string(contract_name) + "'/'"+ std::string(name(SingletonName)) + "' that does not exist");
@@ -83,7 +83,7 @@ namespace eosio {
 
             ste.raw_original = (char*)malloc(value_size);
             ste.raw_original_size = value_size;
-            copy_size = internal_use_do_not_use::kv_get_data(db_name, 0, ste.raw_original, value_size);
+            copy_size = internal_use_do_not_use::kv_get_data(0, ste.raw_original, value_size);
 
             deserialize(ste.value, ste.raw_original, copy_size);
             ste.is_cached = true;
@@ -98,7 +98,7 @@ namespace eosio {
             uint32_t copy_size;
             uint32_t value_size;
 
-            auto success = internal_use_do_not_use::kv_get(db_name, contract_name.value, key.data(), key.size(), value_size);
+            auto success = internal_use_do_not_use::kv_get(contract_name.value, key.data(), key.size(), value_size);
 
             if( !success ) {
                 eosio::check(success, "tried to get the singleton '" + std::string(contract_name) + "'/'"+ std::string(name(SingletonName)) + "' that does not exist");
@@ -106,7 +106,7 @@ namespace eosio {
 
             ste.raw_original = (char*)malloc(value_size);
             ste.raw_original_size = value_size;
-            copy_size = internal_use_do_not_use::kv_get_data(db_name, 0, ste.raw_original, value_size);
+            copy_size = internal_use_do_not_use::kv_get_data(0, ste.raw_original, value_size);
 
             deserialize(ste.value, ste.raw_original, copy_size);
             ste.is_cached = true;
@@ -127,11 +127,11 @@ namespace eosio {
       bool exists() const {
          uint32_t value_size;
 
-         return internal_use_do_not_use::kv_get(db_name, contract_name.value, key.data(), key.size(), value_size);
+         return internal_use_do_not_use::kv_get(contract_name.value, key.data(), key.size(), value_size);
       }
 
       void erase() {
-         internal_use_do_not_use::kv_erase(db_name, contract_name.value, key.data(), key.size());
+         internal_use_do_not_use::kv_erase(contract_name.value, key.data(), key.size());
          auto& ste = get_state();
          ste.is_cached = false;
          ste.is_dirty = false;
@@ -148,7 +148,7 @@ namespace eosio {
             serialize(ste.value, data_buffer, data_size);
 
             if (ste.raw_original_size != data_size || memcmp(ste.raw_original, data_buffer, data_size) != 0) {
-               internal_use_do_not_use::kv_set(db_name, contract_name.value, key.data(), key.size(), (const char*)data_buffer, data_size);
+               internal_use_do_not_use::kv_set(contract_name.value, key.data(), key.size(), (const char*)data_buffer, data_size, contract_name.value);
             }
          }
       }

--- a/tests/unit/test_contracts/kv_bios/kv_bios.cpp
+++ b/tests/unit/test_contracts/kv_bios/kv_bios.cpp
@@ -3,8 +3,8 @@
 #include <eosio/privileged.hpp>
 
 extern "C" __attribute__((eosio_wasm_import)) void set_resource_limit(int64_t, int64_t, int64_t);
-extern "C" __attribute__((eosio_wasm_import)) uint32_t get_kv_parameters_packed(uint64_t db, void* params, uint32_t size, uint32_t max_version);
-extern "C" __attribute__((eosio_wasm_import)) void set_kv_parameters_packed(uint64_t db, const void* params, uint32_t size);
+extern "C" __attribute__((eosio_wasm_import)) uint32_t get_kv_parameters_packed(void* params, uint32_t size, uint32_t max_version);
+extern "C" __attribute__((eosio_wasm_import)) void set_kv_parameters_packed(const void* params, uint32_t size);
 
 using namespace eosio;
 
@@ -19,22 +19,22 @@ class [[eosio::contract]] kv_bios : eosio::contract {
       set_resource_limit(account.value, "ram"_n.value, limit);
    }
    [[eosio::action]] void ramkvlimits(uint32_t k, uint32_t v, uint32_t i) {
-      kvlimits_impl("eosio.kvram"_n, k, v, i);
+      kvlimits_impl(k, v, i);
    }
    [[eosio::action]] void diskkvlimits(uint32_t k, uint32_t v, uint32_t i) {
-      kvlimits_impl("eosio.kvdisk"_n, k, v, i);
+      kvlimits_impl(k, v, i);
    }
-   void kvlimits_impl(name db, uint32_t k, uint32_t v, uint32_t i) {
+   void kvlimits_impl(uint32_t k, uint32_t v, uint32_t i) {
       uint32_t limits[4];
       limits[0] = 0;
       limits[1] = k;
       limits[2] = v;
       limits[3] = i;
-      set_kv_parameters_packed(db.value, limits, sizeof(limits));
-      int sz = get_kv_parameters_packed(db.value, nullptr, 0, 0);
+      set_kv_parameters_packed(limits, sizeof(limits));
+      int sz = get_kv_parameters_packed(nullptr, 0, 0);
       std::fill_n(limits, sizeof(limits)/sizeof(limits[0]), 0xFFFFFFFFu);
       check(sz == 16, "wrong kv parameters size");
-      sz = get_kv_parameters_packed(db.value, limits, sizeof(limits), 0);
+      sz = get_kv_parameters_packed(limits, sizeof(limits), 0);
       check(sz == 16, "wrong kv parameters result");
       check(limits[0] == 0, "wrong version");
       check(limits[1] == k, "wrong key");


### PR DESCRIPTION
## Change Description

- Match intrinsics of release/2.1.x of EOSIO/eos
- Add `payer` to `kv_set`
- Remove db_name from: `kv_erase, kv_set, kv_get, kv_get_data, kv_it_create`
- The kv_singleton and kv_table interfaces have not changed. `contract_name` is passed for `payer`.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
