### PR TITLE
Fix imported CAPI function declarations

### DIFF
--- a/libraries/eosiolib/contracts/eosio/action.hpp
+++ b/libraries/eosiolib/contracts/eosio/action.hpp
@@ -42,10 +42,10 @@ namespace eosio {
          bool is_account( uint64_t name );
 
          __attribute__((eosio_wasm_import))
-         void send_inline(char *serialized_action, size_t size);
+         void send_inline(char* serialized_action, size_t size);
 
          __attribute__((eosio_wasm_import))
-         void send_context_free_inline(char *serialized_action, size_t size);
+         void send_context_free_inline(char* serialized_action, size_t size);
 
          __attribute__((eosio_wasm_import))
          uint64_t  publication_time();

--- a/libraries/eosiolib/contracts/eosio/privileged.hpp
+++ b/libraries/eosiolib/contracts/eosio/privileged.hpp
@@ -34,10 +34,10 @@ namespace eosio {
          int64_t set_proposed_producers( char*, uint32_t );
 
          __attribute__((eosio_wasm_import))
-         void preactivate_feature( const capi_checksum256* feature_digest );
+         void preactivate_feature( const struct capi_checksum256* feature_digest );
 
          __attribute__((eosio_wasm_import))
-         int64_t set_proposed_producers_ex( uint64_t producer_data_format, char *producer_data, uint32_t producer_data_size );
+         int64_t set_proposed_producers_ex( uint64_t producer_data_format, char* producer_data, uint32_t producer_data_size );
       }
    }
 

--- a/libraries/eosiolib/contracts/eosio/system.hpp
+++ b/libraries/eosiolib/contracts/eosio/system.hpp
@@ -19,7 +19,7 @@ namespace eosio {
       };
 
       __attribute__((eosio_wasm_import))
-      bool is_feature_activated( const capi_checksum256* feature_digest );
+      bool is_feature_activated( const struct capi_checksum256* feature_digest);
 
       __attribute__((eosio_wasm_import))
       uint64_t get_sender();

--- a/libraries/eosiolib/contracts/eosio/transaction.hpp
+++ b/libraries/eosiolib/contracts/eosio/transaction.hpp
@@ -14,10 +14,10 @@ namespace eosio {
    namespace internal_use_do_not_use {
       extern "C" {
          __attribute__((eosio_wasm_import))
-         void send_deferred(const uint128_t&, uint64_t, const char*, size_t, uint32_t);
+         void send_deferred(const uint128_t*, uint64_t, const char*, size_t, uint32_t);
 
          __attribute__((eosio_wasm_import))
-         int cancel_deferred(const uint128_t&);
+         int cancel_deferred(const uint128_t*);
 
          __attribute__((eosio_wasm_import))
          size_t read_transaction(char*, size_t);
@@ -124,7 +124,7 @@ namespace eosio {
        */
       void send(const uint128_t& sender_id, name payer, bool replace_existing = false) const {
          auto serialize = pack(*this);
-         internal_use_do_not_use::send_deferred(sender_id, payer.value, serialize.data(), serialize.size(), replace_existing);
+         internal_use_do_not_use::send_deferred(&sender_id, payer.value, serialize.data(), serialize.size(), replace_existing);
       }
 
       std::vector<action>  context_free_actions;
@@ -173,7 +173,7 @@ namespace eosio {
     *  @param replace - If true, will replace an existing transaction.
     */
    inline void send_deferred(const uint128_t& sender_id, name payer, const char* serialized_transaction, size_t size, bool replace = false) {
-     internal_use_do_not_use::send_deferred(sender_id, payer.value, serialized_transaction, size, replace);
+     internal_use_do_not_use::send_deferred(&sender_id, payer.value, serialized_transaction, size, replace);
    }
    /**
     *  Retrieve the indicated action from the active transaction.
@@ -224,7 +224,7 @@ namespace eosio {
      *  @endcode
      */
    inline int cancel_deferred(const uint128_t& sender_id) {
-      return internal_use_do_not_use::cancel_deferred(sender_id);
+      return internal_use_do_not_use::cancel_deferred(&sender_id);
    }
 
    /**


### PR DESCRIPTION
When including testing framework, some `eosio` C++ headers conflict with C headers and you get compiler error: `conflicting types for ...`. The issue is wrong declaration of some CAPI functions in C++ headers. Namely, declaration of `send_deferred` and `cancel_deferred` CAPI functions. This PR fixes those incorrect declaration. 

PR fix partially #811. 

*Note: The issue still persists for functions `preactivate_feature` and `is_feature_activated` due to struct `capi_checksum256` declared in [eosio/system.hpp#L17](https://github.com/EOSIO/eosio.cdt/blob/c4dd2d3b00496d86d3cea7b70a02514a9137d698/libraries/eosiolib/contracts/eosio/system.hpp#L17), although scoped in `extern "C"`, still defines different type than struct defined in [capi/types.h#L51](https://github.com/EOSIO/eosio.cdt/blob/c4dd2d3b00496d86d3cea7b70a02514a9137d698/libraries/eosiolib/capi/eosio/types.h#L51)*

