### PR TITLE
add security group support

### DIFF
--- a/libraries/eosiolib/capi/eosio/security_group.h
+++ b/libraries/eosiolib/capi/eosio/security_group.h
@@ -1,0 +1,56 @@
+#pragma once
+#include "types.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Propose new participants to the security group.
+ *
+ * @param data - the buffer containing the packed participants.
+ * @param datalen - size of the packed participants
+ * @pre `data` is a valid pointer to a range of memory at least `datalen` bytes long that contains packed participants data
+ * 
+ * @return -1 if proposing a new security group was unsuccessful, otherwise returns 0.
+*/
+__attribute__((eosio_wasm_import))
+int64_t add_security_group_participants(const char* data, uint32_t datalen);
+
+/**
+ * Propose to remove participants from the security group.
+ *
+ * @param data - the buffer containing the packed participants.
+ * @param datalen - size of the packed participants
+ * @pre `data` is a valid pointer to a range of memory at least `datalen` bytes long that contains packed participants data
+ *  
+ * @return -1 if proposing a new security group was unsuccessful, otherwise returns 0.
+*/
+__attribute__((eosio_wasm_import))
+int64_t remove_security_group_participants(const char* data, uint32_t datalen);
+
+/**
+ * Check if the specified accounts are all in the active security group.
+ *
+ * @param data - the buffer containing the packed participants.
+ * @param datalen - size of the packed participants
+ *  
+ * @return Returns true if the specified accounts are all in the active security group. 
+*/
+__attribute__((eosio_wasm_import))
+bool in_active_security_group(const char* data, uint32_t datalen);
+
+/**
+ * Gets the active security group
+ *
+ * @param[out] data - the output buffer containing the packed security group.
+ * @param datalen - size of the `data` buffer
+ *  
+ * @return Returns the size required in the buffer (if the buffer is too small, nothing is written).
+ *
+*/
+__attribute__((eosio_wasm_import))
+uint32_t get_active_security_group(char* data, uint32_t datalen);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libraries/eosiolib/contracts/eosio/security_group.hpp
+++ b/libraries/eosiolib/contracts/eosio/security_group.hpp
@@ -9,15 +9,13 @@ namespace internal_use_do_not_use {
 extern "C" {
 __attribute__((eosio_wasm_import)) int64_t add_security_group_participants(const char* data, uint32_t datalen);
 
-__attribute__((eosio_wasm_import)) int64_t remove_security_group_participants(const char* data,
-                                                                                      uint32_t    datalen);
+__attribute__((eosio_wasm_import)) int64_t remove_security_group_participants(const char* data, uint32_t datalen);
 
 __attribute__((eosio_wasm_import)) bool in_active_security_group(const char* data, uint32_t datalen);
 
 __attribute__((eosio_wasm_import)) uint32_t get_active_security_group(char* data, uint32_t datalen);
 }
 } // namespace internal_use_do_not_use
-
 
 /**
  *  @defgroup security_group Security Group

--- a/libraries/eosiolib/contracts/eosio/security_group.hpp
+++ b/libraries/eosiolib/contracts/eosio/security_group.hpp
@@ -1,0 +1,88 @@
+#pragma once
+#include <set>
+#include "../../core/eosio/name.hpp"
+#include "../../core/eosio/serialize.hpp"
+
+namespace eosio {
+
+namespace internal_use_do_not_use {
+extern "C" {
+__attribute__((eosio_wasm_import)) int64_t add_security_group_participants(const char* data, uint32_t datalen);
+
+__attribute__((eosio_wasm_import)) int64_t remove_security_group_participants(const char* data,
+                                                                                      uint32_t    datalen);
+
+__attribute__((eosio_wasm_import)) bool in_active_security_group(const char* data, uint32_t datalen);
+
+__attribute__((eosio_wasm_import)) uint32_t get_active_security_group(char* data, uint32_t datalen);
+}
+} // namespace internal_use_do_not_use
+
+
+/**
+ *  @defgroup security_group Security Group
+ *  @ingroup contracts
+ *  @brief Defines C++ security group API
+ */
+
+struct security_group {
+   uint32_t version;
+   std::set<name> participants;
+   CDT_REFLECT(version, participants);
+};
+
+/**
+ * Propose new participants to the security group.
+ *
+ * @ingroup security_group
+ * @param participants - the participants.
+ *
+ * @return -1 if proposing a new security group was unsuccessful, otherwise returns 0.
+ */
+inline int64_t add_security_group_participants(const std::set<name>& participants) {
+   auto packed_participants = eosio::pack( participants );
+   return internal_use_do_not_use::add_security_group_participants( packed_participants.data(), packed_participants.size() );
+}
+
+/**
+ * Propose to remove participants from the security group.
+ *å
+ * @ingroup security_group
+ * @param participants - the participants.
+ *å
+ * @return -1 if proposing a new security group was unsuccessful, otherwise returns 0.
+ */
+inline int64_t remove_security_group_participants(const std::set<name>& participants){
+   auto packed_participants = eosio::pack( participants );
+   return internal_use_do_not_use::remove_security_group_participants( packed_participants.data(), packed_participants.size() );
+}
+
+/**
+ * Check if the specified accounts are all in the active security group.
+ *
+ * @ingroup security_group
+ * @param participants - the participants.
+ *
+ * @return Returns true if the specified accounts are all in the active security group.
+ */
+inline bool in_active_security_group(const std::set<name>& participants){
+   auto packed_participants = eosio::pack( participants );
+   return internal_use_do_not_use::in_active_security_group( packed_participants.data(), packed_participants.size() );
+}
+
+/**
+ * Gets the active security group
+ *
+ * @ingroup security_group
+ * @param[out] packed_security_group - the buffer containing the packed security_group.
+ *
+ * @return Returns the size required in the buffer (if the buffer is too small, nothing is written).
+ *
+ */
+inline security_group get_active_security_group() {
+   size_t buffer_size = internal_use_do_not_use::get_active_security_group(0, 0);
+   std::vector<char> buffer(buffer_size);
+   internal_use_do_not_use::get_active_security_group(buffer.data(), buffer_size);
+   return eosio::unpack<security_group>(buffer);
+}
+} // namespace eosio

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -892,4 +892,21 @@ extern "C" {
       eosio_assert(false, "abort");
    }
 #pragma clang diagnostic pop
+
+   int64_t add_security_group_participants(const char* data, uint32_t datalen) {
+      return intrinsics::get().call<intrinsics::add_security_group_participants>(data, datalen);
+   }
+
+   int64_t remove_security_group_participants(const char* data, uint32_t datalen){
+      return intrinsics::get().call<intrinsics::remove_security_group_participants>(data, datalen);
+   }
+
+   bool in_active_security_group(const char* data, uint32_t datalen){
+      return intrinsics::get().call<intrinsics::in_active_security_group>(data, datalen);
+   }
+
+   uint32_t get_active_security_group(char* data, uint32_t datalen){
+      return intrinsics::get().call<intrinsics::get_active_security_group>(data, datalen);
+   }
+
 }

--- a/libraries/native/native/eosio/intrinsics_def.hpp
+++ b/libraries/native/native/eosio/intrinsics_def.hpp
@@ -10,6 +10,7 @@
 #include <eosio/system.h>
 #include <eosio/transaction.h>
 #include <eosio/types.h>
+#include <eosio/security_group.h>
 
 #include <type_traits>
 
@@ -159,7 +160,12 @@ intrinsic_macro(send_deferred) \
 intrinsic_macro(cancel_deferred) \
 intrinsic_macro(get_context_free_data) \
 intrinsic_macro(get_sender) \
-intrinsic_macro(set_action_return_value)
+intrinsic_macro(set_action_return_value) \
+intrinsic_macro(add_security_group_participants) \
+intrinsic_macro(remove_security_group_participants) \
+intrinsic_macro(in_active_security_group) \
+intrinsic_macro(get_active_security_group)
+
 
 #define CREATE_ENUM(name) \
    name,


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description

This PR adds 4 new APIs for security groups.

add_security_group_participants
remove_security_group_participants
in_active_security_group
get_active_security_group

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions

Please refer to the comments of `security_group.hpp` for the detail of the added APIs. 