### PR TITLE
Add  new intrinsic register_transaction_hook

### DIFF
--- a/libraries/eosiolib/capi/eosio/privileged.h
+++ b/libraries/eosiolib/capi/eosio/privileged.h
@@ -84,6 +84,16 @@ __attribute__((eosio_wasm_import))
 void set_privileged( capi_name account, bool is_priv );
 
 /**
+ * Register a transaction hook (actions that execute at certain points on the lifetime of the execution of a transaction)
+ *
+ * @param hook_type - type of the hook to register
+ * @param callback_contract - name of the contract associated with the hook
+ * @param callback_action - name of the action associated with the hook
+ */
+__attribute__((eosio_wasm_import))
+bool register_transaction_hook( uint32_t hook_type, capi_name callback_contract, capi_name callback_action );
+
+/**
  * Set the blockchain parameters
  *
  * @param data - pointer to blockchain parameters packed as bytes

--- a/libraries/eosiolib/contracts/eosio/privileged.hpp
+++ b/libraries/eosiolib/contracts/eosio/privileged.hpp
@@ -22,6 +22,9 @@ namespace eosio {
          void set_privileged( uint64_t account, bool is_priv );
 
          __attribute__((eosio_wasm_import))
+         bool register_transaction_hook( uint32_t hook, uint64_t callback_contract, uint64_t callback_action );
+
+         __attribute__((eosio_wasm_import))
          void set_blockchain_parameters_packed( char* data, uint32_t datalen );
 
          __attribute__((eosio_wasm_import))
@@ -308,6 +311,24 @@ namespace eosio {
     */
    inline void set_privileged( name account, bool is_priv ) {
       internal_use_do_not_use::set_privileged( account.value, is_priv );
+   }
+
+   enum transaction_hook {
+      preexecution
+   };
+
+   /**
+    *  Register a transaction hook (actions that execute at certain points on the lifetime of the execution of a transaction)
+    *
+    *  @ingroup privileged
+    *  @param hook_type - type of the hook to register
+    *  @param callback_contract - name of the contract associated with the hook
+    *  @param callback_action - name of the action associated with the hook
+    *  @return false if the account does not exist or does not contain any code
+    *  @return true otherwise
+    */
+   inline bool register_transaction_hook( transaction_hook hook_type, name callback_contract, name callback_action ) {
+      return internal_use_do_not_use::register_transaction_hook( hook_type, callback_contract.value, callback_action.value );
    }
 
    /**

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -43,6 +43,9 @@ extern "C" {
    void set_privileged( capi_name account, bool is_priv ) {
       return intrinsics::get().call<intrinsics::set_privileged>(account, is_priv);
    }
+   bool register_transaction_hook( uint32_t hook_type, uint64_t callback_contract, uint64_t callback_action ) {
+      return intrinsics::get().call<intrinsics::register_transaction_hook>(hook_type, callback_contract, callback_action);
+   }
    bool is_feature_activated( const capi_checksum256* feature_digest ) {
       return intrinsics::get().call<intrinsics::is_feature_activated>(feature_digest);
    }

--- a/libraries/native/native/eosio/intrinsics_def.hpp
+++ b/libraries/native/native/eosio/intrinsics_def.hpp
@@ -49,6 +49,7 @@ intrinsic_macro(set_blockchain_parameters_packed) \
 intrinsic_macro(set_kv_parameters_packed) \
 intrinsic_macro(is_privileged) \
 intrinsic_macro(set_privileged) \
+intrinsic_macro(register_transaction_hook) \
 intrinsic_macro(is_feature_activated) \
 intrinsic_macro(preactivate_feature) \
 intrinsic_macro(get_active_producers) \

--- a/tests/unit/test_contracts/capi/privileged.c
+++ b/tests/unit/test_contracts/capi/privileged.c
@@ -8,6 +8,7 @@ void test_privileged( void ) {
    set_proposed_producers_ex(0, NULL, 0);
    is_privileged(0);
    set_privileged(0, 0);
+   register_transaction_hook(0, 0, 0);
    set_blockchain_parameters_packed(NULL, 0);
    get_blockchain_parameters_packed(NULL, 0);
    preactivate_feature(NULL);


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
A new privileged intrinsic with name register_transaction_hook is defined to register a contract callback at the transaction pre-execution phase for all transactions on the chain. 

This will give the system contract the ability to inspect / make modifications to the transaction prior to its execution.  
It is possible that in the future other hook types will be defined.

The interface for the intrinsic is:

`bool register_transaction_hook(transaction_hook hook_type, name callback_contract, name callback_action);`  

where
hook_type, is the type of hook we want to register (currently only one type - preexecution)
callback_contract, is the name of the contract containing the action for the callback
callback_action, is the name of the action inside the contract containing the code for the callback

## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->
The register_transaction_hook intrinsic is added.


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
