### PR TITLE
[docs] Clean up [[eosio::action]] use for structs

### DIFF
--- a/docs/05_best-practices/08_abi/01_abi-code-generator-attributes-explained.md
+++ b/docs/05_best-practices/08_abi/01_abi-code-generator-attributes-explained.md
@@ -6,7 +6,7 @@ link_text: ABI/Code generator attributes
 The new ABI generator tool uses C++11 or GNU style attributes to mark `actions` and `tables`.
 
 ## [[eosio::action]]
-This attribute marks either a struct or a method as an action.
+This attribute marks a method as an action.
 Example (four ways to declare an action for ABI generation):
 ```cpp
 // this is the C++11 and greater style attribute


### PR DESCRIPTION
Clean up `[[eosio::action]]` use for structs.
Larry was consulted on this one with DM and he confirmed.
sister PR: https://github.com/EOSIO/eosio.cdt/pull/1077