### PR TITLE
Fix the `-v` option of eosio-cpp and eosio-cc to use clang-9

### DIFF
--- a/tools/cc/eosio-cc.cpp.in
+++ b/tools/cc/eosio-cc.cpp.in
@@ -22,7 +22,7 @@ int main(int argc, const char **argv) {
    // fix to show version info without having to have any other arguments
    for (int i=0; i < argc; i++) {
      if (argv[i] == std::string("-v")) {
-       eosio::cdt::environment::exec_subprogram("clang-7", {"-v"});
+       eosio::cdt::environment::exec_subprogram("clang-9", {"-v"});
        return 0;
      }
    }

--- a/tools/cc/eosio-cpp.cpp.in
+++ b/tools/cc/eosio-cpp.cpp.in
@@ -110,7 +110,7 @@ int main(int argc, const char **argv) {
    // fix to show version info without having to have any other arguments
    for (int i=0; i < argc; i++) {
      if (argv[i] == std::string("-v")) {
-       eosio::cdt::environment::exec_subprogram("clang-7", {"-v"});
+       eosio::cdt::environment::exec_subprogram("clang-9", {"-v"});
        return 0;
      }
    }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->
Change `clang-7` to `clang-9` that is called by eosio-cpp and eosio-cc for option `-v`.
## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
