### PR TITLE
Passthrough return of main within start function of tester WASMs.

### DIFF
--- a/libraries/eosiolib/tester/crt0.cpp
+++ b/libraries/eosiolib/tester/crt0.cpp
@@ -4,7 +4,7 @@
 int main(int argc, char** argv);
 
 extern "C" __attribute__((eosio_wasm_entry)) void initialize() {}
-extern "C" __attribute__((eosio_wasm_entry)) void start(void (*f)()) {
+extern "C" __attribute__((eosio_wasm_entry)) int start(void (*f)()) {
   std::vector<std::string> args = eosio::get_args();
    char buf[] = "eosio-tester";
    std::vector<char*> argv;
@@ -12,5 +12,5 @@ extern "C" __attribute__((eosio_wasm_entry)) void start(void (*f)()) {
    for(std::string& s : args) {
       argv.push_back(const_cast<char*>(s.data()));
    }
-   main(argv.size(), argv.data());
+   return main(argv.size(), argv.data());
 }


### PR DESCRIPTION
## Change Description

In WASM files compiled with `-ftester` the `start` function returned void. This made it impossible to access the return value of the `main` function. Now the `start` function passes through the return of `main`.


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
