### PR TITLE
Include recover_key into tester_intrinsics

### DIFF
--- a/libraries/eosiolib/tester/tester_intrinsics.cpp
+++ b/libraries/eosiolib/tester/tester_intrinsics.cpp
@@ -33,10 +33,9 @@ extern "C" {
    struct __attribute__((aligned (16))) capi_checksum256 { uint8_t hash[32]; };
    struct __attribute__((aligned (16))) capi_checksum512 { uint8_t hash[64]; };
 
-   int recover_key( capi_checksum256* digest, const char* sig, uint32_t sig_len, char* pub, uint32_t pub_len) {
-      eosio::check(false, "recover_key is not available");
-      __builtin_unreachable();
-   }
+   __attribute__((eosio_wasm_import))
+   int recover_key( capi_checksum256* digest, const char* sig, uint32_t sig_len, char* pub, uint32_t pub_len);
+
    void assert_recover_key( capi_checksum256* digest, const char* sig, uint32_t sig_len, const char* pub, uint32_t pub_len) {
       eosio::check(false, "assert_recover_key is not available");
       __builtin_unreachable();


### PR DESCRIPTION
## Change Description

Add `recover_key` host function to tester lib. A corresponding PR https://github.com/EOSIO/eos/pull/10598 to `EOSIO/eos` branch `develop-boxed` for `eosio-tester` will use this.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
