### PR TITLE
Wasm size artifact eosio.cdt/ release/1.8.x

### DIFF
--- a/.cicd/eosio-contracts-build.sh
+++ b/.cicd/eosio-contracts-build.sh
@@ -25,7 +25,7 @@ else #Linux
         # Generate Base Images
         $CICD_DIR/generate-base-images.sh
         if [[ "$IMAGE_TAG" == 'ubuntu-18.04' ]]; then
-            FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-develop'
+            FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-release_2.1.x'
             export CMAKE_FRAMEWORK_PATH="$MOUNTED_DIR/build:${CMAKE_FRAMEWORK_PATH}"
             BUILD_CONTRACTS_COMMAND="cmake -DBUILD_TESTS=true $MOUNTED_DIR/eosio.contracts && make -j$JOBS"
         fi

--- a/.cicd/eosio-contracts-build.sh
+++ b/.cicd/eosio-contracts-build.sh
@@ -25,7 +25,7 @@ else #Linux
         # Generate Base Images
         $CICD_DIR/generate-base-images.sh
         if [[ "$IMAGE_TAG" == 'ubuntu-18.04' ]]; then
-            FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-release_2.1.x'
+            FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-v2.1.0'
             export CMAKE_FRAMEWORK_PATH="$MOUNTED_DIR/build:${CMAKE_FRAMEWORK_PATH}"
             BUILD_CONTRACTS_COMMAND="cmake -DBUILD_TESTS=true $MOUNTED_DIR/eosio.contracts && make -j$JOBS"
         fi

--- a/.cicd/eosio-contracts-build.sh
+++ b/.cicd/eosio-contracts-build.sh
@@ -11,8 +11,13 @@ git clone -b "$CONTRACTS_VERSION" https://github.com/EOSIO/eosio.contracts.git
 if [[ $(uname) == 'Darwin' ]]; then
     export PATH=$CDT_DIR_HOST/build/bin:$PATH
     cd build_eosio_contracts
-    cmake $CDT_DIR_HOST/eosio.contracts
-    make -j$JOBS
+    CMAKE="cmake ../eosio.contracts"
+    echo "$ $CMAKE"
+    eval $CMAKE
+    MAKE="make -j $JOBS"
+    echo "$ $MAKE"
+    eval $MAKE
+    cd ..
 else #Linux
     ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}
     . $HELPERS_DIR/docker-hash.sh
@@ -21,15 +26,12 @@ else #Linux
     BUILD_CONTRACTS_COMMAND="cmake $MOUNTED_DIR/eosio.contracts && make -j$JOBS"
 
     # Docker Commands
-    if [[ $BUILDKITE == true ]]; then
-        # Generate Base Images
-        $CICD_DIR/generate-base-images.sh
-        if [[ "$IMAGE_TAG" == 'ubuntu-18.04' ]]; then
-            FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-v2.1.0'
-            export CMAKE_FRAMEWORK_PATH="$MOUNTED_DIR/build:${CMAKE_FRAMEWORK_PATH}"
-            BUILD_CONTRACTS_COMMAND="cmake -DBUILD_TESTS=true $MOUNTED_DIR/eosio.contracts && make -j$JOBS"
-        fi
-
+    # Generate Base Images
+    $CICD_DIR/generate-base-images.sh
+    if [[ "$IMAGE_TAG" == 'ubuntu-18.04' ]]; then
+        FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-v2.1.0'
+        export CMAKE_FRAMEWORK_PATH="$MOUNTED_DIR/build:${CMAKE_FRAMEWORK_PATH}"
+        BUILD_CONTRACTS_COMMAND="cmake -DBUILD_TESTS=true $MOUNTED_DIR/eosio.contracts && make -j$JOBS"
     fi
 
     COMMANDS_EOSIO_CONTRACTS="$PRE_CONTRACTS_COMMAND && $BUILD_CONTRACTS_COMMAND"
@@ -42,45 +44,46 @@ else #Linux
         done < "$BUILDKITE_ENV_FILE"
     fi
 
-    eval docker run $ARGS $evars $FULL_TAG bash -c \"$COMMANDS_EOSIO_CONTRACTS\"
+    DOCKER_RUN="docker run $ARGS $evars $FULL_TAG bash -c \"$COMMANDS_EOSIO_CONTRACTS\""
+    echo "$ $DOCKER_RUN"
+    eval $DOCKER_RUN
 
 fi
 
+touch wasm_abi_size.json
+cd build/tests/unit/test_contracts
+JSON=$(echo '{}' | jq -r '.')
+echo '--- :arrow_up: Generating wasm_abi_size.json file'
+for FILENAME in *.{wasm,abi}; do
+    FILESIZE=$(wc -c <"$FILENAME")
+    export value=$FILESIZE
+    export key="$FILENAME"
+    JSON="$(echo "$JSON" | jq -r '.[env.key] += (env.value | tonumber)')"
+done
+
+cd ../../../../build_eosio_contracts/contracts
+for dir in */; do
+    cd $dir
+    for FILENAME in *.{wasm,abi}; do
+        if [[ -f $FILENAME ]]; then
+            FILESIZE=$(wc -c <"$FILENAME")
+            export value=$FILESIZE
+            export key="$FILENAME"
+            JSON="$(echo "$JSON" | jq -r '.[env.key] += (env.value | tonumber)')"
+        fi
+    done
+    cd ..
+done
+
+echo '--- :arrow_up: Uploading wasm_abi_size.json'
+cd ../../
+echo $JSON >> wasm_abi_size.json
 if [[ $BUILDKITE == true ]]; then
-    cd $CDT_DIR_HOST/build/tests/unit/test_contracts
-    touch wasm_abi_size.json
-    PATH_WASM=$(pwd)
-    JSON=$(echo '{}' | jq -r '.')
-    echo '--- :arrow_up: Generating wasm_abi_size.log file'
-    for FILENAME in *.{abi,wasm}; do
-        FILESIZE=$(wc -c <"$FILENAME")
-        export value=$FILESIZE
-        export key="$FILENAME"
-        JSON=$(echo "$JSON" | jq -r "(.\"$key\") += (env.value | tonumber)")
-    done
 
-    cd $CDT_DIR_HOST/build_eosio_contracts/contracts
-    for dir in */; do
-        cd $dir
-        for FILENAME in *.{abi,wasm}; do
-            if [[ -f $FILENAME ]]; then
-                FILESIZE=$(wc -c <"$FILENAME")
-                export value=$FILESIZE
-                export key="$FILENAME"
-                JSON=$(echo "$JSON" | jq -r "(.\"$key\") += (env.value | tonumber)")
-            fi
-        done
-        cd ..
-    done
-
-    echo '--- :arrow_up: Uploading wasm_abi_size.json'
-    cd $PATH_WASM
-    echo $JSON >> wasm_abi_size.json
     buildkite-agent artifact upload wasm_abi_size.json
     echo 'Done uploading wasm_abi_size.json'
     echo '--- :arrow_up: Uploading eosio.contract build'
     echo 'Compressing eosio.contract build directory.'
-    cd $CDT_DIR_HOST
     tar -pczf 'build_eosio_contracts.tar.gz' build_eosio_contracts
     echo 'Uploading eosio.contract build directory.'
     buildkite-agent artifact upload 'build_eosio_contracts.tar.gz'

--- a/.cicd/eosio-contracts-build.sh
+++ b/.cicd/eosio-contracts-build.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -eo pipefail
+. ./.cicd/helpers/general.sh
+CDT_DIR_HOST=$(pwd)
+mkdir -p build_eosio_contracts 
+
+
+[[ ! -z "$CONTRACTS_VERSION" ]] || export CONTRACTS_VERSION="$(cat "$PIPELINE_CONFIG" | jq -r '.dependencies["eosio.contracts"]')"
+git clone -b "$CONTRACTS_VERSION" https://github.com/EOSIO/eosio.contracts.git 
+
+if [[ $(uname) == 'Darwin' ]]; then
+    export PATH=$CDT_DIR_HOST/build/bin:$PATH
+    cd build_eosio_contracts
+    cmake $CDT_DIR_HOST/eosio.contracts
+    make -j$JOBS
+else #Linux
+    ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}
+    . $HELPERS_DIR/docker-hash.sh
+
+    PRE_CONTRACTS_COMMAND="export PATH=$MOUNTED_DIR/build/bin:$PATH && cd $MOUNTED_DIR/build_eosio_contracts"
+    BUILD_CONTRACTS_COMMAND="cmake $MOUNTED_DIR/eosio.contracts && make -j$JOBS"
+
+    # Docker Commands
+    if [[ $BUILDKITE == true ]]; then
+        # Generate Base Images
+        $CICD_DIR/generate-base-images.sh
+        if [[ "$IMAGE_TAG" == 'ubuntu-18.04' ]]; then
+            FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-develop'
+            export CMAKE_FRAMEWORK_PATH="$MOUNTED_DIR/build:${CMAKE_FRAMEWORK_PATH}"
+            BUILD_CONTRACTS_COMMAND="cmake -DBUILD_TESTS=true $MOUNTED_DIR/eosio.contracts && make -j$JOBS"
+        fi
+
+    fi
+
+    COMMANDS_EOSIO_CONTRACTS="$PRE_CONTRACTS_COMMAND && $BUILD_CONTRACTS_COMMAND"
+
+    # Load BUILDKITE Environment Variables for use in docker run
+    if [[ -f $BUILDKITE_ENV_FILE ]]; then
+        evars=""
+        while read -r var; do
+            evars="$evars --env ${var%%=*}"
+        done < "$BUILDKITE_ENV_FILE"
+    fi
+
+    eval docker run $ARGS $evars $FULL_TAG bash -c \"$COMMANDS_EOSIO_CONTRACTS\"
+
+fi
+
+if [[ $BUILDKITE == true ]]; then
+    cd $CDT_DIR_HOST/build/tests/unit/test_contracts
+    touch wasm_abi_size.json
+    PATH_WASM=$(pwd)
+    JSON=$(echo '{}' | jq -r '.')
+    echo '--- :arrow_up: Generating wasm_abi_size.log file'
+    for FILENAME in *.{abi,wasm}; do
+        FILESIZE=$(wc -c <"$FILENAME")
+        export value=$FILESIZE
+        export key="$FILENAME"
+        JSON=$(echo "$JSON" | jq -r "(.\"$key\") += (env.value | tonumber)")
+    done
+
+    cd $CDT_DIR_HOST/build_eosio_contracts/contracts
+    for dir in */; do
+        cd $dir
+        for FILENAME in *.{abi,wasm}; do
+            if [[ -f $FILENAME ]]; then
+                FILESIZE=$(wc -c <"$FILENAME")
+                export value=$FILESIZE
+                export key="$FILENAME"
+                JSON=$(echo "$JSON" | jq -r "(.\"$key\") += (env.value | tonumber)")
+            fi
+        done
+        cd ..
+    done
+
+    echo '--- :arrow_up: Uploading wasm_abi_size.json'
+    cd $PATH_WASM
+    echo $JSON >> wasm_abi_size.json
+    buildkite-agent artifact upload wasm_abi_size.json
+    echo 'Done uploading wasm_abi_size.json'
+    echo '--- :arrow_up: Uploading eosio.contract build'
+    echo 'Compressing eosio.contract build directory.'
+    cd $CDT_DIR_HOST
+    tar -pczf 'build_eosio_contracts.tar.gz' build_eosio_contracts
+    echo 'Uploading eosio.contract build directory.'
+    buildkite-agent artifact upload 'build_eosio_contracts.tar.gz'
+    echo 'Done uploading artifacts.'
+
+fi

--- a/.cicd/eosio-contracts-unittest.sh
+++ b/.cicd/eosio-contracts-unittest.sh
@@ -12,7 +12,7 @@ ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}
 if [[ $BUILDKITE == true ]]; then
     # Generate Base Images
     $CICD_DIR/generate-base-images.sh
-    FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-release_2.1.x'
+    FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-release_2.1.x'
     TEST_CONTRACTS_COMMAND="cd $MOUNTED_DIR/build_eosio_contracts/tests && ctest -j $JOBS --output-on-failure -T Test"
     
     # Load BUILDKITE Environment Variables for use in docker run

--- a/.cicd/eosio-contracts-unittest.sh
+++ b/.cicd/eosio-contracts-unittest.sh
@@ -10,7 +10,9 @@ ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}
 . $HELPERS_DIR/docker-hash.sh
 
 FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-v2.1.0'
-TEST_CONTRACTS_COMMAND="cd $MOUNTED_DIR/build_eosio_contracts/tests && ctest -j $JOBS --output-on-failure -T Test"
+TEST_CONTRACTS_COMMAND="cd $MOUNTED_DIR/build_eosio_contracts/tests && CTEST='ctest -j $JOBS --output-on-failure -T Test' \
+&& echo \\\"$ \\\$CTEST\\\" && eval \\\$CTEST"
+
 
 # Load BUILDKITE Environment Variables for use in docker run
 if [[ -f $BUILDKITE_ENV_FILE ]]; then

--- a/.cicd/eosio-contracts-unittest.sh
+++ b/.cicd/eosio-contracts-unittest.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -eo pipefail
+. ./.cicd/helpers/general.sh
+
+[[ ! -z "$CONTRACTS_VERSION" ]] || export CONTRACTS_VERSION="$(cat "$PIPELINE_CONFIG" | jq -r '.dependencies["eosio.contracts"]')"
+git clone -b "$CONTRACTS_VERSION" https://github.com/EOSIO/eosio.contracts.git 
+
+# Docker Commands
+ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}
+. $HELPERS_DIR/docker-hash.sh
+
+if [[ $BUILDKITE == true ]]; then
+    # Generate Base Images
+    $CICD_DIR/generate-base-images.sh
+    FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-develop'
+    TEST_CONTRACTS_COMMAND="cd $MOUNTED_DIR/build_eosio_contracts/tests && ctest -j $JOBS --output-on-failure -T Test"
+    
+    # Load BUILDKITE Environment Variables for use in docker run
+    if [[ -f $BUILDKITE_ENV_FILE ]]; then
+        evars=""
+        while read -r var; do
+            evars="$evars --env ${var%%=*}"
+        done < "$BUILDKITE_ENV_FILE"
+    fi
+    
+    echo '--- :arrow_up: Sanity tests for eosio.contract wasm and abi files'
+    eval docker run $ARGS $evars $FULL_TAG bash -c \"$TEST_CONTRACTS_COMMAND\"
+    EXIT_STATUS=$?
+    
+    if [[ "$EXIT_STATUS" != 0 ]]; then
+        echo "Failing due to non-zero exit status from ctest: $EXIT_STATUS"
+        exit $EXIT_STATUS
+    fi
+fi
+

--- a/.cicd/eosio-contracts-unittest.sh
+++ b/.cicd/eosio-contracts-unittest.sh
@@ -12,7 +12,7 @@ ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}
 if [[ $BUILDKITE == true ]]; then
     # Generate Base Images
     $CICD_DIR/generate-base-images.sh
-    FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-release_2.1.x'
+    FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-v2.1.0'
     TEST_CONTRACTS_COMMAND="cd $MOUNTED_DIR/build_eosio_contracts/tests && ctest -j $JOBS --output-on-failure -T Test"
     
     # Load BUILDKITE Environment Variables for use in docker run

--- a/.cicd/eosio-contracts-unittest.sh
+++ b/.cicd/eosio-contracts-unittest.sh
@@ -12,7 +12,7 @@ ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}
 if [[ $BUILDKITE == true ]]; then
     # Generate Base Images
     $CICD_DIR/generate-base-images.sh
-    FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-develop'
+    FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-release_2.1.x'
     TEST_CONTRACTS_COMMAND="cd $MOUNTED_DIR/build_eosio_contracts/tests && ctest -j $JOBS --output-on-failure -T Test"
     
     # Load BUILDKITE Environment Variables for use in docker run

--- a/.cicd/eosio-contracts-unittest.sh
+++ b/.cicd/eosio-contracts-unittest.sh
@@ -9,27 +9,26 @@ git clone -b "$CONTRACTS_VERSION" https://github.com/EOSIO/eosio.contracts.git
 ARGS=${ARGS:-"--rm --init -v $(pwd):$MOUNTED_DIR"}
 . $HELPERS_DIR/docker-hash.sh
 
-if [[ $BUILDKITE == true ]]; then
-    # Generate Base Images
-    $CICD_DIR/generate-base-images.sh
-    FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-v2.1.0'
-    TEST_CONTRACTS_COMMAND="cd $MOUNTED_DIR/build_eosio_contracts/tests && ctest -j $JOBS --output-on-failure -T Test"
-    
-    # Load BUILDKITE Environment Variables for use in docker run
-    if [[ -f $BUILDKITE_ENV_FILE ]]; then
-        evars=""
-        while read -r var; do
-            evars="$evars --env ${var%%=*}"
-        done < "$BUILDKITE_ENV_FILE"
-    fi
-    
-    echo '--- :arrow_up: Sanity tests for eosio.contract wasm and abi files'
-    eval docker run $ARGS $evars $FULL_TAG bash -c \"$TEST_CONTRACTS_COMMAND\"
-    EXIT_STATUS=$?
-    
-    if [[ "$EXIT_STATUS" != 0 ]]; then
-        echo "Failing due to non-zero exit status from ctest: $EXIT_STATUS"
-        exit $EXIT_STATUS
-    fi
+FULL_TAG='eosio/ci-contracts-builder:base-ubuntu-18.04-v2.1.0'
+TEST_CONTRACTS_COMMAND="cd $MOUNTED_DIR/build_eosio_contracts/tests && ctest -j $JOBS --output-on-failure -T Test"
+
+# Load BUILDKITE Environment Variables for use in docker run
+if [[ -f $BUILDKITE_ENV_FILE ]]; then
+    evars=""
+    while read -r var; do
+        evars="$evars --env ${var%%=*}"
+    done < "$BUILDKITE_ENV_FILE"
 fi
+
+echo '--- :arrow_up: Unit-tests for eosio.contract wasm and abi files'
+DOCKER_RUN="docker run $ARGS $evars $FULL_TAG bash -c \"$TEST_CONTRACTS_COMMAND\""
+echo "$ $DOCKER_RUN"
+eval $DOCKER_RUN
+EXIT_STATUS=$?
+
+if [[ "$EXIT_STATUS" != 0 ]]; then
+    echo "Failing due to non-zero exit status from ctest: $EXIT_STATUS"
+    exit $EXIT_STATUS
+fi
+
 

--- a/.cicd/helpers/general.sh
+++ b/.cicd/helpers/general.sh
@@ -4,3 +4,12 @@ export CICD_DIR=$ROOT_DIR/.cicd
 export HELPERS_DIR=$CICD_DIR/helpers
 export JOBS=${JOBS:-"$(getconf _NPROCESSORS_ONLN)"}
 export MOUNTED_DIR='/workdir'
+
+[[ -z $PIPELINE_CONFIG ]] && export PIPELINE_CONFIG='pipeline.json'
+[[ -z $RAW_PIPELINE_CONFIG ]] && export RAW_PIPELINE_CONFIG='pipeline.jsonc'
+if [[ -f "$RAW_PIPELINE_CONFIG" ]]; then
+    # parse pipeline config
+    cat "$RAW_PIPELINE_CONFIG" | grep -Po '^[^"/]*("((?<=\\).|[^"])*"[^"/]*)*' | jq -c '.[env.BUILDKITE_PIPELINE_SLUG]' > "$PIPELINE_CONFIG"
+elif [[ "$DEBUG" == 'true' ]]; then
+    echo "WARNING: No pipeline configuration file \"$RAW_PIPELINE_CONFIG\" found in \"$(pwd)\""'!'
+fi

--- a/.cicd/helpers/general.sh
+++ b/.cicd/helpers/general.sh
@@ -7,9 +7,11 @@ export MOUNTED_DIR='/workdir'
 
 [[ -z $PIPELINE_CONFIG ]] && export PIPELINE_CONFIG='pipeline.json'
 [[ -z $RAW_PIPELINE_CONFIG ]] && export RAW_PIPELINE_CONFIG='pipeline.jsonc'
-if [[ -f "$RAW_PIPELINE_CONFIG" ]]; then
-    # parse pipeline config
-    cat "$RAW_PIPELINE_CONFIG" | grep -Po '^[^"/]*("((?<=\\).|[^"])*"[^"/]*)*' | jq -c '.[env.BUILDKITE_PIPELINE_SLUG]' > "$PIPELINE_CONFIG"
-elif [[ "$DEBUG" == 'true' ]]; then
-    echo "WARNING: No pipeline configuration file \"$RAW_PIPELINE_CONFIG\" found in \"$(pwd)\""'!'
+if [[ $BUILDKITE == true ]]; then
+    if [[ -f "$RAW_PIPELINE_CONFIG" ]]; then
+        # parse pipeline config
+        cat "$RAW_PIPELINE_CONFIG" | grep -Po '^[^"/]*("((?<=\\).|[^"])*"[^"/]*)*' | jq -c '.[env.BUILDKITE_PIPELINE_SLUG]' > "$PIPELINE_CONFIG"
+    elif [[ "$DEBUG" == 'true' ]]; then
+        echo "WARNING: No pipeline configuration file \"$RAW_PIPELINE_CONFIG\" found in \"$(pwd)\""'!'
+    fi
 fi

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -727,7 +727,7 @@ steps:
           no-volume: true
           inherit-environment-vars: true
           vm-name: 10.14.6_6C_14G_80G
-          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
+          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent::${MACOS_10_14_TAG}"
           always-pull: true
           debug: true
           wait-network: true
@@ -754,7 +754,7 @@ steps:
           no-volume: true
           inherit-environment-vars: true
           vm-name: 10.14.6_6C_14G_80G
-          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
+          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent::${MACOS_10_14_TAG}"
           always-pull: true
           debug: true
           wait-network: true
@@ -784,7 +784,7 @@ steps:
           no-volume: true
           inherit-environment-vars: true
           vm-name: 10.15.5_6C_14G_80G
-          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
+          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent::${MACOS_10_15_TAG}"
           always-pull: true
           debug: true
           wait-network: true
@@ -811,7 +811,7 @@ steps:
           no-volume: true
           inherit-environment-vars: true
           vm-name: 10.15.5_6C_14G_80G
-          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
+          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent::${MACOS_10_15_TAG}"
           always-pull: true
           debug: true
           wait-network: true

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -16,7 +16,7 @@ steps:
     command:
       - "./.cicd/build.sh"
       - "tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
-    env: 
+    env:
       IMAGE_TAG: "centos-7.7"
     agents:
       queue: "automation-eks-eos-builder-fleet"
@@ -27,7 +27,7 @@ steps:
     command:
       - "./.cicd/build.sh"
       - "tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
-    env: 
+    env:
       IMAGE_TAG: "centos-8"
     agents:
       queue: "automation-eks-eos-builder-fleet"
@@ -38,7 +38,7 @@ steps:
     command:
       - "./.cicd/build.sh"
       - "tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
-    env: 
+    env:
       IMAGE_TAG: "ubuntu-16.04"
     agents:
       queue: "automation-eks-eos-builder-fleet"
@@ -88,8 +88,8 @@ steps:
           pre-execute-sleep: 5
           pre-execute-ping-sleep: github.com
           failover-registries:
-            - 'registry-1'
-            - 'registry-2'
+            - "registry-1"
+            - "registry-2"
           pre-commands:
             - "rm -rf mac-anka-fleet; git clone git@github.com:EOSIO/mac-anka-fleet.git && cd mac-anka-fleet && . ./ensure-tag.bash -u 12 -r 25G -a '-n'"
       - EOSIO/skip-checkout#v0.1.1:
@@ -127,8 +127,8 @@ steps:
           pre-execute-sleep: 5
           pre-execute-ping-sleep: github.com
           failover-registries:
-            - 'registry-1'
-            - 'registry-2'
+            - "registry-1"
+            - "registry-2"
           pre-commands:
             - "rm -rf mac-anka-fleet; git clone git@github.com:EOSIO/mac-anka-fleet.git && cd mac-anka-fleet && . ./ensure-tag.bash -u 12 -r 25G -a '-n'"
       - EOSIO/skip-checkout#v0.1.1:
@@ -147,6 +147,139 @@ steps:
 
   - wait
 
+  - label: ":aws: Amazon_Linux 2 - EOSIO.CONTRACTS Build"
+    command:
+      - "buildkite-agent artifact download build.tar.gz . --step ':aws: Amazon_Linux 2 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
+      - "./.cicd/eosio-contracts-build.sh"
+    env:
+      IMAGE_TAG: "amazonlinux-2"
+    agents:
+      queue: "automation-eks-eos-tester-fleet"
+    timeout: ${TIMEOUT:-10}
+    skip: ${SKIP_AMAZON_LINUX_2}${SKIP_LINUX}${SKIP_WASM_METRICS}
+
+  - label: ":centos: CentOS 7.7 - EOSIO.CONTRACTS Build"
+    command:
+      - "buildkite-agent artifact download build.tar.gz . --step ':centos: CentOS 7.7 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
+      - "./.cicd/eosio-contracts-build.sh"
+    env:
+      IMAGE_TAG: "centos-7.7"
+    agents:
+      queue: "automation-eks-eos-tester-fleet"
+    timeout: ${TIMEOUT:-10}
+    skip: ${SKIP_CENTOS_7}${SKIP_LINUX}${SKIP_WASM_METRICS}
+
+  - label: ":centos: CentOS 8 - EOSIO.CONTRACTS Build"
+    command:
+      - "buildkite-agent artifact download build.tar.gz . --step ':centos: CentOS 8 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
+      - "./.cicd/eosio-contracts-build.sh"
+    env:
+      IMAGE_TAG: "centos-8"
+    agents:
+      queue: "automation-eks-eos-tester-fleet"
+    timeout: ${TIMEOUT:-10}
+    skip: ${SKIP_CENTOS_8}${SKIP_LINUX}${SKIP_WASM_METRICS}
+
+  - label: ":ubuntu: Ubuntu 16.04 - EOSIO.CONTRACTS Build"
+    command:
+      - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 16.04 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
+      - "./.cicd/eosio-contracts-build.sh"
+    env:
+      IMAGE_TAG: "ubuntu-16.04"
+    agents:
+      queue: "automation-eks-eos-tester-fleet"
+    timeout: ${TIMEOUT:-10}
+    skip: ${SKIP_UBUNTU_16}${SKIP_LINUX}${SKIP_WASM_METRICS}
+
+  - label: ":ubuntu: Ubuntu 18.04 - EOSIO.CONTRACTS Build"
+    command:
+      - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 18.04 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
+      - "./.cicd/eosio-contracts-build.sh"
+    env:
+      IMAGE_TAG: "ubuntu-18.04"
+    agents:
+      queue: "automation-eks-eos-tester-fleet"
+    key: "ubuntu1804contracts"
+    timeout: ${TIMEOUT:-10}
+    skip: ${SKIP_UBUNTU_18}${SKIP_LINUX}${SKIP_WASM_METRICS}
+
+  - label: ":ubuntu: Ubuntu 20.04 - EOSIO.CONTRACTS Build"
+    command:
+      - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 20.04 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
+      - "./.cicd/eosio-contracts-build.sh"
+    env:
+      IMAGE_TAG: "ubuntu-20.04"
+    agents:
+      queue: "automation-eks-eos-tester-fleet"
+    timeout: ${TIMEOUT:-10}
+    skip: ${SKIP_UBUNTU_20}${SKIP_LINUX}${SKIP_WASM_METRICS}
+
+  - label: ":darwin: macOS 10.14 - EOSIO.CONTRACTS Build"
+    command:
+      - "git clone $BUILDKITE_REPO eosio.cdt"
+      - "cd eosio.cdt && if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then git fetch -v --prune origin refs/pull/$(echo $BUILDKITE_BRANCH | cut -d/ -f2)/head; fi"
+      - "cd eosio.cdt && git checkout -f $BUILDKITE_COMMIT && git submodule update --init --recursive"
+      - "cd eosio.cdt && buildkite-agent artifact download build.tar.gz . --step ':darwin: macOS 10.14 - Build' && tar -xzf build.tar.gz"
+      - "cd eosio.cdt && ./.cicd/eosio-contracts-build.sh"
+    plugins:
+      - EOSIO/anka#v0.6.1:
+          no-volume: true
+          inherit-environment-vars: true
+          vm-name: 10.14.6_6C_14G_80G
+          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent::${MACOS_10_14_TAG}"
+          always-pull: true
+          debug: true
+          wait-network: true
+          pre-execute-sleep: 5
+          pre-execute-ping-sleep: github.com
+          failover-registries:
+            - "registry-1"
+            - "registry-2"
+      - EOSIO/skip-checkout#v0.1.1:
+          cd: ~
+    agents:
+      - "queue=mac-anka-node-fleet"
+    skip: ${SKIP_MACOS_10_14}${SKIP_MAC}${SKIP_WASM_METRICS}
+
+  - label: ":darwin: macOS 10.15 - EOSIO.CONTRACTS Build"
+    command:
+      - "git clone $BUILDKITE_REPO eosio.cdt"
+      - "cd eosio.cdt && if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then git fetch -v --prune origin refs/pull/$(echo $BUILDKITE_BRANCH | cut -d/ -f2)/head; fi"
+      - "cd eosio.cdt && git checkout -f $BUILDKITE_COMMIT && git submodule update --init --recursive"
+      - "cd eosio.cdt && buildkite-agent artifact download build.tar.gz . --step ':darwin: macOS 10.15 - Build' && tar -xzf build.tar.gz"
+      - "cd eosio.cdt && ./.cicd/eosio-contracts-build.sh"
+    plugins:
+      - EOSIO/anka#v0.6.1:
+          no-volume: true
+          inherit-environment-vars: true
+          vm-name: 10.15.5_6C_14G_80G
+          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent::${MACOS_10_15_TAG}"
+          always-pull: true
+          debug: true
+          wait-network: true
+          pre-execute-sleep: 5
+          pre-execute-ping-sleep: github.com
+          failover-registries:
+            - "registry-1"
+            - "registry-2"
+      - EOSIO/skip-checkout#v0.1.1:
+          cd: ~
+    agents:
+      - "queue=mac-anka-node-fleet"
+    skip: ${SKIP_MACOS_10_15}${SKIP_MAC}${SKIP_WASM_METRICS}
+
+  - label: ":ubuntu: Ubuntu 18.04 - EOSIO.CONTRACTS Unit Test"
+    command:
+      - "buildkite-agent artifact download build_eosio_contracts.tar.gz . --step ':ubuntu: Ubuntu 18.04 - EOSIO.CONTRACTS Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build_eosio_contracts.tar.gz"
+      - "./.cicd/eosio-contracts-unittest.sh"
+    env:
+      IMAGE_TAG: "ubuntu-18.04"
+    agents:
+      queue: "automation-eks-eos-tester-fleet"
+    timeout: ${TIMEOUT:-10}
+    depends_on: "ubuntu1804contracts"
+    skip: ${SKIP_UBUNTU_18}${SKIP_LINUX}${SKIP_WASM_METRICS}
+
   - label: ":aws: Amazon_Linux 2 - Unit Tests"
     command:
       - "buildkite-agent artifact download build.tar.gz . --step ':aws: Amazon_Linux 2 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
@@ -162,7 +295,7 @@ steps:
     command:
       - "buildkite-agent artifact download build.tar.gz . --step ':centos: CentOS 7.7 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
       - "./.cicd/tests.sh"
-    env: 
+    env:
       IMAGE_TAG: "centos-7.7"
     agents:
       queue: "automation-eks-eos-tester-fleet"
@@ -173,7 +306,7 @@ steps:
     command:
       - "buildkite-agent artifact download build.tar.gz . --step ':centos: CentOS 8 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
       - "./.cicd/tests.sh"
-    env: 
+    env:
       IMAGE_TAG: "centos-8"
     agents:
       queue: "automation-eks-eos-tester-fleet"
@@ -184,7 +317,7 @@ steps:
     command:
       - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 16.04 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
       - "./.cicd/tests.sh"
-    env: 
+    env:
       IMAGE_TAG: "ubuntu-16.04"
     agents:
       queue: "automation-eks-eos-tester-fleet"
@@ -232,8 +365,8 @@ steps:
           pre-execute-sleep: 5
           pre-execute-ping-sleep: github.com
           failover-registries:
-            - 'registry-1'
-            - 'registry-2'
+            - "registry-1"
+            - "registry-2"
       - EOSIO/skip-checkout#v0.1.1:
           cd: ~
     agents:
@@ -259,8 +392,8 @@ steps:
           pre-execute-sleep: 5
           pre-execute-ping-sleep: github.com
           failover-registries:
-            - 'registry-1'
-            - 'registry-2'
+            - "registry-1"
+            - "registry-2"
       - EOSIO/skip-checkout#v0.1.1:
           cd: ~
     agents:
@@ -282,7 +415,7 @@ steps:
     command:
       - "buildkite-agent artifact download build.tar.gz . --step ':centos: CentOS 7.7 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
       - "./.cicd/toolchain-tests.sh"
-    env: 
+    env:
       IMAGE_TAG: "centos-7.7"
     agents:
       queue: "automation-eks-eos-tester-fleet"
@@ -293,7 +426,7 @@ steps:
     command:
       - "buildkite-agent artifact download build.tar.gz . --step ':centos: CentOS 8 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
       - "./.cicd/toolchain-tests.sh"
-    env: 
+    env:
       IMAGE_TAG: "centos-8"
     agents:
       queue: "automation-eks-eos-tester-fleet"
@@ -304,7 +437,7 @@ steps:
     command:
       - "buildkite-agent artifact download build.tar.gz . --step ':ubuntu: Ubuntu 16.04 - Build' --agent-access-token $$BUILDKITE_AGENT_ACCESS_TOKEN && tar -xzf build.tar.gz"
       - "./.cicd/toolchain-tests.sh"
-    env: 
+    env:
       IMAGE_TAG: "ubuntu-16.04"
     agents:
       queue: "automation-eks-eos-tester-fleet"
@@ -352,8 +485,8 @@ steps:
           pre-execute-sleep: 5
           pre-execute-ping-sleep: github.com
           failover-registries:
-            - 'registry-1'
-            - 'registry-2'
+            - "registry-1"
+            - "registry-2"
       - EOSIO/skip-checkout#v0.1.1:
           cd: ~
     agents:
@@ -379,8 +512,8 @@ steps:
           pre-execute-sleep: 5
           pre-execute-ping-sleep: github.com
           failover-registries:
-            - 'registry-1'
-            - 'registry-2'
+            - "registry-1"
+            - "registry-2"
       - EOSIO/skip-checkout#v0.1.1:
           cd: ~
     agents:
@@ -601,8 +734,8 @@ steps:
           pre-execute-sleep: 5
           pre-execute-ping-sleep: github.com
           failover-registries:
-            - 'registry-1'
-            - 'registry-2'
+            - "registry-1"
+            - "registry-2"
       - EOSIO/skip-checkout#v0.1.1:
           cd: ~
     agents:
@@ -628,8 +761,8 @@ steps:
           pre-execute-sleep: 5
           pre-execute-ping-sleep: github.com
           failover-registries:
-            - 'registry_1'
-            - 'registry_2'
+            - "registry_1"
+            - "registry_2"
       - EOSIO/skip-checkout#v0.1.1:
           cd: ~
     agents:
@@ -658,8 +791,8 @@ steps:
           pre-execute-sleep: 5
           pre-execute-ping-sleep: github.com
           failover-registries:
-            - 'registry-1'
-            - 'registry-2'
+            - "registry-1"
+            - "registry-2"
       - EOSIO/skip-checkout#v0.1.1:
           cd: ~
     agents:
@@ -685,8 +818,8 @@ steps:
           pre-execute-sleep: 5
           pre-execute-ping-sleep: github.com
           failover-registries:
-            - 'registry_1'
-            - 'registry_2'
+            - "registry_1"
+            - "registry_2"
       - EOSIO/skip-checkout#v0.1.1:
           cd: ~
     agents:
@@ -697,7 +830,7 @@ steps:
     skip: ${SKIP_MACOS_10_15}${SKIP_PACKAGE_BUILDER}${SKIP_MAC}
 
   - wait
-  
+
   - label: ":docker::ubuntu: Docker - Build 18.04 Docker Image"
     command: "./.cicd/create-docker-from-binary.sh"
     agents:

--- a/.cicd/platforms/macos-10.14.sh
+++ b/.cicd/platforms/macos-10.14.sh
@@ -3,4 +3,11 @@ set -eou pipefail
 VERSION=1
 
 brew update && brew upgrade
-brew install automake cmake doxygen gettext git gmp graphviz lcov libtool python@3 wget
+brew unlink md5sha1sum
+brew install coreutils gnu-sed grep tree automake cmake doxygen gettext git gmp graphviz lcov libtool python@3 wget 
+
+echo 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"' >> ~/.bash_profile
+echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> ~/.bash_profile
+echo 'export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"' >> ~/.bash_profile
+echo '' >> ~/.bash_profile
+source ~/.bash_profile

--- a/.cicd/platforms/macos-10.15.sh
+++ b/.cicd/platforms/macos-10.15.sh
@@ -3,4 +3,11 @@ set -eou pipefail
 VERSION=1
 
 brew update && brew upgrade
-brew install automake cmake doxygen gettext git gmp graphviz lcov libtool python@3 wget
+brew unlink md5sha1sum
+brew install coreutils gnu-sed grep tree automake cmake doxygen gettext git gmp graphviz lcov libtool python@3 wget 
+
+echo 'export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"' >> ~/.bash_profile
+echo 'export PATH="/usr/local/opt/grep/libexec/gnubin:$PATH"' >> ~/.bash_profile
+echo 'export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"' >> ~/.bash_profile
+echo '' >> ~/.bash_profile
+source ~/.bash_profile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,28 +65,6 @@ jobs:
           ./.cicd/tests.sh
         env:
           IMAGE_TAG: amazonlinux-2
-  amazon_linux-2-eosio-contracts-build:
-    name: Amazon_Linux 2 | EOSIO.CONTRACTS Build
-    runs-on: ubuntu-latest
-    needs: amazon_linux-2-build
-    steps:
-      - name: Checkout
-        run: |
-          git clone https://github.com/${GITHUB_REPOSITORY} .
-          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
-          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
-          git submodule sync --recursive
-          git submodule update --init --force --recursive
-      - name: Download Build Artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: amazon_linux-2-build
-      - name: EOSIO.CONTRACTS Build
-        run: |
-          tar -xzf amazon_linux-2-build/build.tar.gz
-          ./.cicd/eosio-contracts-build.sh
-        env:
-          IMAGE_TAG: amazonlinux-2
   amazon_linux-2-toolchain-test:
     name: Amazon_Linux 2 | Toolchain Test
     runs-on: ubuntu-latest
@@ -153,28 +131,6 @@ jobs:
         run: |
           tar -xzf centos-77-build/build.tar.gz
           ./.cicd/tests.sh
-        env:
-          IMAGE_TAG: centos-7.7
-  centos-77-eosio-contracts-build:
-    name: CentOS 7.7 | EOSIO.CONTRACTS Build
-    runs-on: ubuntu-latest
-    needs: centos-77-build
-    steps:
-      - name: Checkout
-        run: |
-          git clone https://github.com/${GITHUB_REPOSITORY} .
-          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
-          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
-          git submodule sync --recursive
-          git submodule update --init --force --recursive
-      - name: Download Build Artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: centos-77-build
-      - name: EOSIO.CONTRACTS Build
-        run: |
-          tar -xzf centos-77-build/build.tar.gz
-          ./.cicd/eosio-contracts-build.sh
         env:
           IMAGE_TAG: centos-7.7
   centos-77-toolchain-test:
@@ -245,28 +201,6 @@ jobs:
           ./.cicd/tests.sh
         env:
           IMAGE_TAG: ubuntu-16.04
-  ubuntu-1604-eosio-contracts-build:
-    name: Ubuntu 16.04 | EOSIO.CONTRACTS Build
-    runs-on: ubuntu-latest
-    needs: ubuntu-1604-build
-    steps:
-      - name: Checkout
-        run: |
-          git clone https://github.com/${GITHUB_REPOSITORY} .
-          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
-          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
-          git submodule sync --recursive
-          git submodule update --init --force --recursive
-      - name: Download Build Artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: ubuntu-1604-build
-      - name: EOSIO.CONTRACTS Build
-        run: |
-          tar -xzf ubuntu-1604-build/build.tar.gz
-          ./.cicd/eosio-contracts-build.sh
-        env:
-          IMAGE_TAG: ubuntu-16.04
   ubuntu-1604-toolchain-test:
     name: Ubuntu 16.04 | Toolchain Test
     runs-on: ubuntu-latest
@@ -335,50 +269,6 @@ jobs:
           ./.cicd/tests.sh
         env:
           IMAGE_TAG: ubuntu-18.04
-  ubuntu-1804-eosio-contracts-build:
-    name: Ubuntu 18.04 | EOSIO.CONTRACTS Build
-    runs-on: ubuntu-latest
-    needs: ubuntu-1804-build
-    steps:
-      - name: Checkout
-        run: |
-          git clone https://github.com/${GITHUB_REPOSITORY} .
-          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
-          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
-          git submodule sync --recursive
-          git submodule update --init --force --recursive
-      - name: Download Build Artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: ubuntu-1804-build
-      - name: EOSIO.CONTRACTS Build
-        run: |
-          tar -xzf ubuntu-1804-build/build.tar.gz
-          ./.cicd/eosio-contracts-build.sh
-        env:
-          IMAGE_TAG: ubuntu-18.04
-  ubuntu-1804-eosio-contracts-unit-test:
-    name: Ubuntu 18.04 | EOSIO.CONTRACTS Unit Test
-    runs-on: ubuntu-latest
-    needs: ubuntu-1804-eosio-contracts-build
-    steps:
-      - name: Checkout
-        run: |
-          git clone https://github.com/${GITHUB_REPOSITORY} .
-          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
-          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
-          git submodule sync --recursive
-          git submodule update --init --force --recursive
-      - name: Download Build Artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: ubuntu-1804-eosio-contracts-build
-      - name: Wasm Sanity Test
-        run: |
-          tar -xzf ubuntu-1804-eosio-contracts-build/build_eosio_contracts.tar.gz
-          ./.cicd/eosio-contracts-unittest.sh
-        env:
-          IMAGE_TAG: ubuntu-18.04
   ubuntu-1804-toolchain-test:
     name: Ubuntu 18.04 | Toolchain Test
     runs-on: ubuntu-latest
@@ -445,27 +335,6 @@ jobs:
           brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3
           tar -xzf macos-1015-build/build.tar.gz
           ./.cicd/tests.sh
-  macos-1015-eosio-contracts-build:
-    name: MacOS 10.15 | EOSIO.CONTRACTS Build
-    runs-on: macos-latest
-    needs: macos-1015-build
-    steps:
-      - name: Checkout
-        run: |
-          git clone https://github.com/${GITHUB_REPOSITORY} .
-          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
-          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
-          git submodule sync --recursive
-          git submodule update --init --force --recursive
-      - name: Download Build Artifact
-        uses: actions/download-artifact@v1
-        with:
-          name: macos-1015-build
-      - name: EOSIO.CONTRACTS Build
-        run: |
-          brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3
-          tar -xzf macos-1015-build/build.tar.gz
-          ./.cicd/eosio-contracts-build.sh
   macos-1015-toolchain-test:
     name: MacOS 10.15 | Toolchain Test
     runs-on: macos-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -357,7 +357,7 @@ jobs:
           ./.cicd/eosio-contracts-build.sh
         env:
           IMAGE_TAG: ubuntu-18.04
-  ubuntu-1804-wasm-sanity-test:
+  ubuntu-1804-eosio-contracts-unit-test:
     name: Ubuntu 18.04 | EOSIO.CONTRACTS Unit Test
     runs-on: ubuntu-latest
     needs: ubuntu-1804-eosio-contracts-build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -358,7 +358,7 @@ jobs:
         env:
           IMAGE_TAG: ubuntu-18.04
   ubuntu-1804-wasm-sanity-test:
-    name: Ubuntu 18.04 | Wasm Sanity Test
+    name: Ubuntu 18.04 | EOSIO.CONTRACTS Unit Test
     runs-on: ubuntu-latest
     needs: ubuntu-1804-eosio-contracts-build
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Submodule Regression Check
         run: ./.cicd/submodule-regression-checker.sh
 
-
   amazon_linux-2-build:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Amazon_Linux 2 | Build
@@ -34,7 +33,7 @@ jobs:
           git submodule sync --recursive
           git submodule update --init --force --recursive
       - name: Build
-        run: | 
+        run: |
           ./.cicd/build.sh
           tar -pczf build.tar.gz build
         env:
@@ -61,9 +60,31 @@ jobs:
         with:
           name: amazon_linux-2-build
       - name: Unit Test
-        run: | 
+        run: |
           tar -xzf amazon_linux-2-build/build.tar.gz
           ./.cicd/tests.sh
+        env:
+          IMAGE_TAG: amazonlinux-2
+  amazon_linux-2-eosio-contracts-build:
+    name: Amazon_Linux 2 | EOSIO.CONTRACTS Build
+    runs-on: ubuntu-latest
+    needs: amazon_linux-2-build
+    steps:
+      - name: Checkout
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: amazon_linux-2-build
+      - name: EOSIO.CONTRACTS Build
+        run: |
+          tar -xzf amazon_linux-2-build/build.tar.gz
+          ./.cicd/eosio-contracts-build.sh
         env:
           IMAGE_TAG: amazonlinux-2
   amazon_linux-2-toolchain-test:
@@ -83,12 +104,11 @@ jobs:
         with:
           name: amazon_linux-2-build
       - name: Toolchain Test
-        run: | 
+        run: |
           tar -xzf amazon_linux-2-build/build.tar.gz
           ./.cicd/toolchain-tests.sh
         env:
           IMAGE_TAG: amazonlinux-2
-
 
   centos-77-build:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
@@ -103,7 +123,7 @@ jobs:
           git submodule sync --recursive
           git submodule update --init --force --recursive
       - name: Build
-        run: | 
+        run: |
           ./.cicd/build.sh
           tar -pczf build.tar.gz build
         env:
@@ -130,9 +150,31 @@ jobs:
         with:
           name: centos-77-build
       - name: Unit Test
-        run: | 
+        run: |
           tar -xzf centos-77-build/build.tar.gz
           ./.cicd/tests.sh
+        env:
+          IMAGE_TAG: centos-7.7
+  centos-77-eosio-contracts-build:
+    name: CentOS 7.7 | EOSIO.CONTRACTS Build
+    runs-on: ubuntu-latest
+    needs: centos-77-build
+    steps:
+      - name: Checkout
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: centos-77-build
+      - name: EOSIO.CONTRACTS Build
+        run: |
+          tar -xzf centos-77-build/build.tar.gz
+          ./.cicd/eosio-contracts-build.sh
         env:
           IMAGE_TAG: centos-7.7
   centos-77-toolchain-test:
@@ -152,15 +194,14 @@ jobs:
         with:
           name: centos-77-build
       - name: Toolchain Test
-        run: | 
+        run: |
           tar -xzf centos-77-build/build.tar.gz
           ./.cicd/toolchain-tests.sh
         env:
           IMAGE_TAG: centos-7.7
 
-
   ubuntu-1604-build:
-    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id  
+    if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
     name: Ubuntu 16.04 | Build
     runs-on: ubuntu-latest
     steps:
@@ -172,7 +213,7 @@ jobs:
           git submodule sync --recursive
           git submodule update --init --force --recursive
       - name: Build
-        run: | 
+        run: |
           ./.cicd/build.sh
           tar -pczf build.tar.gz build
         env:
@@ -199,9 +240,31 @@ jobs:
         with:
           name: ubuntu-1604-build
       - name: Unit Test
-        run: | 
+        run: |
           tar -xzf ubuntu-1604-build/build.tar.gz
           ./.cicd/tests.sh
+        env:
+          IMAGE_TAG: ubuntu-16.04
+  ubuntu-1604-eosio-contracts-build:
+    name: Ubuntu 16.04 | EOSIO.CONTRACTS Build
+    runs-on: ubuntu-latest
+    needs: ubuntu-1604-build
+    steps:
+      - name: Checkout
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: ubuntu-1604-build
+      - name: EOSIO.CONTRACTS Build
+        run: |
+          tar -xzf ubuntu-1604-build/build.tar.gz
+          ./.cicd/eosio-contracts-build.sh
         env:
           IMAGE_TAG: ubuntu-16.04
   ubuntu-1604-toolchain-test:
@@ -221,12 +284,11 @@ jobs:
         with:
           name: ubuntu-1604-build
       - name: Toolchain Test
-        run: | 
+        run: |
           tar -xzf ubuntu-1604-build/build.tar.gz
           ./.cicd/toolchain-tests.sh
         env:
           IMAGE_TAG: ubuntu-16.04
-
 
   ubuntu-1804-build:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
@@ -241,7 +303,7 @@ jobs:
           git submodule sync --recursive
           git submodule update --init --force --recursive
       - name: Build
-        run: | 
+        run: |
           ./.cicd/build.sh
           tar -pczf build.tar.gz build
         env:
@@ -268,9 +330,53 @@ jobs:
         with:
           name: ubuntu-1804-build
       - name: Unit Test
-        run: | 
+        run: |
           tar -xzf ubuntu-1804-build/build.tar.gz
           ./.cicd/tests.sh
+        env:
+          IMAGE_TAG: ubuntu-18.04
+  ubuntu-1804-eosio-contracts-build:
+    name: Ubuntu 18.04 | EOSIO.CONTRACTS Build
+    runs-on: ubuntu-latest
+    needs: ubuntu-1804-build
+    steps:
+      - name: Checkout
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: ubuntu-1804-build
+      - name: EOSIO.CONTRACTS Build
+        run: |
+          tar -xzf ubuntu-1804-build/build.tar.gz
+          ./.cicd/eosio-contracts-build.sh
+        env:
+          IMAGE_TAG: ubuntu-18.04
+  ubuntu-1804-wasm-sanity-test:
+    name: Ubuntu 18.04 | Wasm Sanity Test
+    runs-on: ubuntu-latest
+    needs: ubuntu-1804-eosio-contracts-build
+    steps:
+      - name: Checkout
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: ubuntu-1804-eosio-contracts-build
+      - name: Wasm Sanity Test
+        run: |
+          tar -xzf ubuntu-1804-eosio-contracts-build/build_eosio_contracts.tar.gz
+          ./.cicd/eosio-contracts-unittest.sh
         env:
           IMAGE_TAG: ubuntu-18.04
   ubuntu-1804-toolchain-test:
@@ -290,12 +396,11 @@ jobs:
         with:
           name: ubuntu-1804-build
       - name: Toolchain Test
-        run: | 
+        run: |
           tar -xzf ubuntu-1804-build/build.tar.gz
           ./.cicd/toolchain-tests.sh
         env:
           IMAGE_TAG: ubuntu-18.04
-
 
   macos-1015-build:
     if: github.event.pull_request.base.repo.id != github.event.pull_request.head.repo.id
@@ -310,7 +415,7 @@ jobs:
           git submodule sync --recursive
           git submodule update --init --force --recursive
       - name: Build
-        run: | 
+        run: |
           brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3
           ./.cicd/build.sh
           tar -pczf build.tar.gz build
@@ -336,10 +441,31 @@ jobs:
         with:
           name: macos-1015-build
       - name: Unit Test
-        run: | 
+        run: |
           brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3
           tar -xzf macos-1015-build/build.tar.gz
           ./.cicd/tests.sh
+  macos-1015-eosio-contracts-build:
+    name: MacOS 10.15 | EOSIO.CONTRACTS Build
+    runs-on: macos-latest
+    needs: macos-1015-build
+    steps:
+      - name: Checkout
+        run: |
+          git clone https://github.com/${GITHUB_REPOSITORY} .
+          git fetch -v --prune origin +refs/pull/${PR_NUMBER}/merge:refs/remotes/pull/${PR_NUMBER}/merge
+          git checkout --force --progress refs/remotes/pull/${PR_NUMBER}/merge
+          git submodule sync --recursive
+          git submodule update --init --force --recursive
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: macos-1015-build
+      - name: EOSIO.CONTRACTS Build
+        run: |
+          brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3
+          tar -xzf macos-1015-build/build.tar.gz
+          ./.cicd/eosio-contracts-build.sh
   macos-1015-toolchain-test:
     name: MacOS 10.15 | Toolchain Test
     runs-on: macos-latest
@@ -357,7 +483,7 @@ jobs:
         with:
           name: macos-1015-build
       - name: Toolchain Test
-        run: | 
+        run: |
           brew install git automake libtool wget cmake gmp gettext doxygen graphviz lcov python@3
           tar -xzf macos-1015-build/build.tar.gz
           ./.cicd/toolchain-tests.sh

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -1,6 +1,5 @@
 {
   "eosio-dot-cdt": {
-    "pipeline-branch": "master",
     // dependencies to pull for cdt integration tests, by branch, tag, or commit hash
     "dependencies": {
       "eosio": "v2.1.0",

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -3,7 +3,7 @@
     "pipeline-branch": "master",
     // dependencies to pull for cdt integration tests, by branch, tag, or commit hash
     "dependencies": {
-      "eosio": "develop",
+      "eosio": "release/2.1.x",
       "eosio.contracts": "develop"
     }
   }

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -1,10 +1,10 @@
 {
-    "eosio-dot-cdt":
-    {
-        "pipeline-branch": "master",
-        "dependencies": // dependencies to pull for cdt integration tests, by branch, tag, or commit hash
-        {
-            "eosio": "develop"
-        }
+  "eosio-dot-cdt": {
+    "pipeline-branch": "master",
+    // dependencies to pull for cdt integration tests, by branch, tag, or commit hash
+    "dependencies": {
+      "eosio": "develop",
+      "eosio.contracts": "develop"
     }
+  }
 }

--- a/pipeline.jsonc
+++ b/pipeline.jsonc
@@ -3,7 +3,7 @@
     "pipeline-branch": "master",
     // dependencies to pull for cdt integration tests, by branch, tag, or commit hash
     "dependencies": {
-      "eosio": "release/2.1.x",
+      "eosio": "v2.1.0",
       "eosio.contracts": "develop"
     }
   }


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
This pull request is similar to PR https://github.com/EOSIO/eosio.cdt/pull/1176 to create a Json file artifact to track the wasm and abi files sizes in EOSIO.CDT cicd pipeline. The pipeline is modified such that it builds eosio.contracts to monitor wasm and abi file sizes for system contracts. For Ubuntu 18.04, unit-test step for eosio.contract is included to make sure generated  wasm and abi files are working properly. This is the PR link to EOSIO.CDT release/1.8.x #1191


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
