### PR TITLE
Fix not working --no-missing-ricardian-clause

### DIFF
--- a/tests/toolchain/compile-pass/no-missing-ricardian-clause.cpp
+++ b/tests/toolchain/compile-pass/no-missing-ricardian-clause.cpp
@@ -1,0 +1,12 @@
+#include <eosio/eosio.hpp>
+
+using namespace eosio;
+
+class [[eosio::contract]] no_missing_ricardian_clause : public contract {
+public:
+   using contract::contract;
+
+   [[eosio::action]]
+   void test1( name user ) {
+   }
+};

--- a/tests/toolchain/compile-pass/no-missing-ricardian-clause.json
+++ b/tests/toolchain/compile-pass/no-missing-ricardian-clause.json
@@ -1,0 +1,11 @@
+{
+  "tests" : [
+    {
+      "compile_flags": ["--no-missing-ricardian-clause"],
+      "expected" : {
+        "exit-code": 0,
+        "stdout": ""
+      }
+    }
+  ]
+}

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -69,12 +69,8 @@ namespace eosio { namespace cdt {
          auto action_name = decl->getEosioActionAttr()->getName();
 
          if (!checked_actions.insert(get_action_name(decl)).second)
-            CDT_CHECK_WARN(!rcs[get_action_name(decl)].empty(), "abigen_warning", decl->getLocation(), "Action <"+get_action_name(decl)+"> does not have a ricardian contract");
-
-         if (!suppress_ricardian_warnings)
-            if (rcs[get_action_name(decl)].empty())
-               // TODO:
-               std::cout << "Warning, action <"+get_action_name(decl)+"> does not have a ricardian contract\n";
+            if (!suppress_ricardian_warnings)
+               CDT_CHECK_WARN(!rcs[get_action_name(decl)].empty(), "abigen_warning", decl->getLocation(), "Action <"+get_action_name(decl)+"> does not have a ricardian contract");
 
          ret.ricardian_contract = rcs[get_action_name(decl)];
 
@@ -96,12 +92,8 @@ namespace eosio { namespace cdt {
          auto action_name = decl->getEosioActionAttr()->getName();
 
          if (!checked_actions.insert(get_action_name(decl)).second)
-            CDT_CHECK_WARN(!rcs[get_action_name(decl)].empty(), "abigen_warning", decl->getLocation(), "Action <"+get_action_name(decl)+"> does not have a ricardian contract");
-
-         if (!suppress_ricardian_warnings)
-            if (rcs[get_action_name(decl)].empty())
-               // TODO
-               std::cout << "Warning, action <"+get_action_name(decl)+"> does not have a ricardian contract\n";
+            if (!suppress_ricardian_warnings)
+               CDT_CHECK_WARN(!rcs[get_action_name(decl)].empty(), "abigen_warning", decl->getLocation(), "Action <"+get_action_name(decl)+"> does not have a ricardian contract");
 
          ret.ricardian_contract = rcs[get_action_name(decl)];
 


### PR DESCRIPTION
## Change Description

This PR makes `--no-missing-ricardian-clause` compile option work correctly.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
