### PR TITLE
Let wasm-ld support --no-abigen which is passed from eosio-cpp.

### DIFF
--- a/tests/toolchain/build-pass/no_abigen_test.cpp
+++ b/tests/toolchain/build-pass/no_abigen_test.cpp
@@ -1,0 +1,12 @@
+#include <eosio/eosio.hpp>
+
+using namespace eosio;
+
+class [[eosio::contract]] no_abigen_test : public contract {
+  public:
+      using contract::contract;
+      
+      [[eosio::action]]
+      void test() {
+      }
+};

--- a/tests/toolchain/build-pass/no_abigen_test.json
+++ b/tests/toolchain/build-pass/no_abigen_test.json
@@ -1,0 +1,10 @@
+{
+   "tests" : [
+     {
+       "compile_flags": ["--no-abigen"],
+       "expected" : {
+         "exit-code": 0,
+       }
+     }
+   ]
+}

--- a/tests/toolchain/build-pass/no_abigen_test.json
+++ b/tests/toolchain/build-pass/no_abigen_test.json
@@ -3,7 +3,7 @@
      {
        "compile_flags": ["--no-abigen"],
        "expected" : {
-         "exit-code": 0,
+         "exit-code": 0
        }
      }
    ]


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Let wasm-ld support --no-abigen which is passed from eosio-cpp
when using eosio-cpp --no-abigen xxxcontract.cpp, then wasm-ld pop error says -no-abigen is not unknown option, after this change, user can use eosio-cpp --no-abigen to compile xxxcontract.cpp without generating xxxcontract.abi, only get xxxcontract.wasm.

See also EPE 953

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
