### PR TITLE
EPE-972:Add support for std::tuple in eosio.cdt

### DIFF
--- a/tests/toolchain/abigen-pass/nested_container.abi
+++ b/tests/toolchain/abigen-pass/nested_container.abi
@@ -1,0 +1,80 @@
+{
+    "____comment": "This file was generated with eosio-abigen. DO NOT EDIT ",
+    "version": "eosio::abi/1.2",
+    "types": [],
+    "structs": [
+        {
+            "name": "map2map",
+            "base": "",
+            "fields": [
+                {
+                    "name": "m",
+                    "type": "pair_string_string[]"
+                },
+                {
+                    "name": "m2m",
+                    "type": "pair_string_pair_string_string[][]"
+                }
+            ]
+        },
+        {
+            "name": "pair_string_pair_string_string",
+            "base": "",
+            "fields": [
+                {
+                    "name": "key",
+                    "type": "string"
+                },
+                {
+                    "name": "value",
+                    "type": "pair_string_string[]"
+                }
+            ]
+        },
+        {
+            "name": "pair_string_string",
+            "base": "",
+            "fields": [
+                {
+                    "name": "key",
+                    "type": "string"
+                },
+                {
+                    "name": "value",
+                    "type": "string"
+                }
+            ]
+        },
+        {
+            "name": "settuple2",
+            "base": "",
+            "fields": [
+                {
+                    "name": "user",
+                    "type": "name"
+                },
+                {
+                    "name": "tp2",
+                    "type": "tuple_int32_float64_string_int32[]"
+                }
+            ]
+        }
+    ],
+    "actions": [
+        {
+            "name": "map2map",
+            "type": "map2map",
+            "ricardian_contract": ""
+        },
+        {
+            "name": "settuple2",
+            "type": "settuple2",
+            "ricardian_contract": ""
+        }
+    ],
+    "tables": [],
+    "kv_tables": {},
+    "ricardian_clauses": [],
+    "variants": [],
+    "action_results": []
+}

--- a/tests/toolchain/abigen-pass/nested_container.cpp
+++ b/tests/toolchain/abigen-pass/nested_container.cpp
@@ -1,0 +1,20 @@
+#include <eosio/eosio.hpp>
+#include <tuple>
+#include <vector>
+
+using namespace eosio;
+using std::map;
+using std::string;
+using std::tuple;
+using std::vector;
+
+class [[eosio::contract]] nested_container : public contract {
+public:
+   using contract::contract;
+
+    [[eosio::action]] 
+    void map2map(map<string, string> m, map<string, map<string, string>> m2m) {}
+
+    [[eosio::action]]
+    void settuple2(name user, const tuple  <int, double, string, vector<int> >& tp2) {}
+};

--- a/tests/toolchain/abigen-pass/nested_container.json
+++ b/tests/toolchain/abigen-pass/nested_container.json
@@ -1,0 +1,9 @@
+{
+    "tests" : [
+       {
+          "expected" : {
+             "abi-file" : "nested_container.abi"
+          }
+       }
+    ]
+}

--- a/tests/toolchain/build-pass/nestcontn2a.cpp
+++ b/tests/toolchain/build-pass/nestcontn2a.cpp
@@ -1,0 +1,1182 @@
+/* Verify the support of nested containers in eosio multi-index table
+ * For each action, an example regarding how to use the action with the cleos command line is given.
+ *
+ * std:pair<T1,T2> is a struct with 2 fields first and second,
+ * std::map<K,V> is handled as an array/vector of pairs/structs by EOSIO with implicit fields key, value,
+ * the cases of combined use of key/value and first/second involving map,pair in the cleos are documented here.
+ * so handling of std::pair is NOT the same as the handling of a general struct such as struct mystruct!
+ *
+ * When assigning data input with cleos:
+ *      [] represents an empty vector<T>/set<T> or empty map<T1,T2> where T, T1, T2 can be any composite types
+ *      null represents an uninitialized std::optional<T> where T can be any composite type
+ *      BUT [] or null can NOT be used to represent an empty struct or empty std::pair
+ *
+ * Expected printout:
+ *      For each setx action, the printed result on the cleos console is given in its corresponding prntx action.
+ */
+
+#include <eosio/eosio.hpp>
+
+#include <vector>
+#include <set>
+#include <optional>
+#include <map>
+#include <tuple>
+
+using namespace eosio;
+using namespace std;
+
+#define  SETCONTAINERVAL(x) do { \
+        require_auth(user); \
+        psninfoindex2 tblIndex(get_self(), get_first_receiver().value); \
+        auto iter = tblIndex.find(user.value); \
+        if (iter == tblIndex.end()) \
+        { \
+            tblIndex.emplace(user, [&](auto &row) { \
+                        row.key = user; \
+                        row.x = x; \
+                    }); \
+        } \
+        else \
+        { \
+            tblIndex.modify(iter, user, [&]( auto& row ) { \
+                        row.x = x; \
+                    }); \
+        } \
+    }while(0)
+
+#define PRNTCHECK() require_auth(user); \
+        psninfoindex2 tblIndex(get_self(), get_first_receiver().value); \
+        auto iter = tblIndex.find(user.value); \
+        check(iter != tblIndex.end(), "Record does not exist");
+
+struct mystruct
+{
+    uint64_t   _count;
+    string     _strID;
+};
+
+//mystruct2 has embeded mystruct
+struct mystruct2
+{
+    mystruct   _structfld;
+    string     _strID2;
+};
+
+// use typedefs to make multi-layer nested containers work!
+typedef vector<uint16_t> vec_uint16;
+typedef set<uint16_t> set_uint16;
+typedef optional<uint16_t> op_uint16;
+typedef map<uint16_t, uint16_t> mp_uint16;
+typedef pair<uint16_t, uint16_t> pr_unit16;
+
+typedef vector<uint32_t> vec_uint32;
+typedef vector<vec_uint32> vecvec_uint32;
+
+
+class [[eosio::contract("nestcontn2a")]] nestcontn2a : public eosio::contract {
+    private:
+        struct [[eosio::table]] person2 {
+            name key;
+
+            //  Each container/object is represented by one letter: v-vector, m-map, s-mystruct,o-optional, p-pair,
+            //  with exceptions:     s2 - mystruct2,    st - set
+
+            vector<uint16_t> v;
+            map<string,string> m;
+            mystruct s;
+            mystruct2 s2;
+            set<uint16_t> st;
+            optional<string> o;
+            pair<uint16_t, uint16_t> p;
+            vector<mystruct> vs;
+
+            //The following are 2-layer nested containers involving vector/optional/map
+            vector<vec_uint16> vv;
+            optional<op_uint16> oo;
+            map<uint16_t, mp_uint16> mm;
+            set<set_uint16> stst;
+
+            vector<set_uint16> vst;
+            set<vec_uint16> stv;
+
+            vector<op_uint16> vo;
+            optional<vec_uint16> ov;
+            set<op_uint16> sto;
+            optional<set_uint16> ost;
+
+            vector<mp_uint16> vm;
+            map<uint16_t, vec_uint16> mv;
+
+            set<mp_uint16> stm;
+            map<uint16_t, set_uint16> mst;
+
+            optional<mp_uint16> om;
+            map<uint16_t, op_uint16> mo;
+
+            //The following are composite types involving pair and containers
+            vector<pair<uint32_t, uint32_t> > vp;
+            pair<uint32_t, vec_uint16> pv;
+
+            set<pair<uint32_t, uint32_t> > stp;
+            pair<uint32_t, set_uint16> pst;
+
+            optional<pr_unit16> op;
+            pair<uint32_t, op_uint16> po;
+
+            map<uint16_t, pr_unit16> mp;
+            pair<uint16_t, mp_uint16> pm;
+
+            pair<uint16_t, pr_unit16>  pp;
+
+            //The following is a 3-layer nested containers for motivation
+            optional<vecvec_uint32> ovv;
+
+            uint64_t primary_key() const { return key.value; }
+        };
+        using psninfoindex2 = eosio::multi_index<"people2"_n, person2>;
+
+
+    public:
+        using contract::contract;
+
+        nestcontn2a(name receiver, name code,  datastream<const char*> ds): contract(receiver, code, ds) {}
+
+
+        //[[eosio::action]] void settuple(name user, const tuple<uint16_t>& tp) {}
+        //  eosio-cpp compile error for std::tuple: Tried to get a nested template type of a template not containing one
+
+         /*Examples:
+          * cleos --verbose push action nestcontn2a setv '["alice", [100,200,300,600]]' -p alice@active
+          * cleos --verbose push action nestcontn2a setv '["bob", []]' -p bob@active
+          */
+        [[eosio::action]]
+        void setv(name user, const vector<uint16_t>& v)
+        {
+            SETCONTAINERVAL(v);
+            eosio::print("vector<uint16_t> stored successfully");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a prntv '["alice"]' -p alice@active
+         *      output: >> size of stored v:4 vals of v:100,200,300,600,
+         *
+         *  cleos --verbose push action nestcontn2a prntv '["bob"]' -p bob@active
+         *      output: >> size of stored v:0 vals of v:
+         */
+        [[eosio::action]]
+        void prntv(name user)
+        {
+            PRNTCHECK();
+            eosio::print("size of stored v:", iter->v.size()," vals of v:");
+            for (const auto & ele : iter->v)
+                eosio::print(ele, ",");
+
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a setst '["alice", [101,201,301]]' -p alice@active
+         *  cleos --verbose push action nestcontn2a setst '["bob", []]' -p bob@active
+         */
+        [[eosio::action]]
+        void setst(name user, const set<uint16_t> & st)
+        {
+            SETCONTAINERVAL(st);
+            eosio::print("set<uint16_t> stored successfully");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a prntst '["alice"]' -p alice@active
+         *      output: >> size of stored st:3 vals:101,201,301,
+         *
+         *  cleos --verbose push action nestcontn2a prntst '["bob"]' -p bob@active
+         *      output: >> size of stored st:0 vals:
+         */
+        [[eosio::action]]
+        void prntst(name user)
+        {
+            PRNTCHECK();
+            eosio::print("size of stored st:", iter->st.size()," vals:");
+            for (const auto & ele : iter->st)
+                eosio::print(ele, ",");
+
+        }
+
+        /*Examples:
+         * To use shortcut notation:
+         *   cleos --verbose push action nestcontn2a setm '["alice", [{"key":"str1","value":"str1val"}, {"key":"str3","value":"str3val"}]]' -p alice@active
+         *
+         * To use full JSON notation:
+         *   cleos --verbose push action nestcontn2a setm '{"user":"jane", "m":[{"key":"str4", "value":"str4val"}, {"key":"str6", "value":"str6val"}]}' -p jane@active
+         *
+         * To pass an empty map:
+         *   cleos --verbose push action nestcontn2a setm '["bob", []]' -p bob@active
+         */
+        [[eosio::action]]
+        void setm(name user, const map<string,string>  & m)
+        {
+            SETCONTAINERVAL(m);
+            eosio::print("map<string,string> stored successfully");
+        }
+
+        /* Examples:
+         *  cleos --verbose push action nestcontn2a prntm '["alice"]' -p alice@active
+         *      output: >> size of stored m:2 vals of m:str1:str1val  str3:str3val
+         *
+         *  cleos --verbose push action nestcontn2a prntm '["jane"]' -p jane@active
+         *      output: >> size of stored m:2 vals of m:str4:str4val  str6:str6val
+         *
+         *  cleos --verbose push action nestcontn2a prntm '["bob"]' -p bob@active
+         *      output: >> size of stored m:0 vals of m:
+        */
+        [[eosio::action]]
+        void prntm(name user)
+        {
+            PRNTCHECK();
+            eosio::print("size of stored m:", iter->m.size()," vals of m:");
+            for (auto it2 = iter->m.begin(); it2 != iter->m.end(); ++it2)
+                eosio::print(it2->first, ":", it2->second, "  ");
+
+        }
+
+        //Example: cleos --verbose push action nestcontn2a sets '["alice", {"_count":18, "_strID":"dumstr"}]' -p alice@active
+        [[eosio::action]]
+        void sets(name user, const mystruct& s)
+        {
+            SETCONTAINERVAL(s);
+            eosio::print("mystruct stored successfully");
+        }
+
+        /*Example:
+         * cleos --verbose push action nestcontn2a  prnts '["alice"]' -p alice@active
+         *      output: >> stored mystruct val:18,dumstr
+         */
+        [[eosio::action]]
+        void prnts(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored mystruct val:", iter->s._count,",", iter->s._strID);
+        }
+
+        //Example: cleos --verbose push action nestcontn2a sets2 '["alice", {"_structfld":{"_count":18, "_strID":"dumstr"}, "_strID2":"dumstr2"}]' -p alice@active
+        [[eosio::action]]
+        void sets2(name user, const mystruct2& s2)
+        {
+            SETCONTAINERVAL(s2);
+            eosio::print("complex mystruct2 stored successfully");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prnts2 '["alice"]' -p alice@active
+         *      output: >> stored mystruct2 val:18,dumstr,dumstr2
+         */
+        [[eosio::action]]
+        void prnts2(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored mystruct2 val:", iter->s2._structfld._count,",", iter->s2._structfld._strID, ",", iter->s2._strID2);
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setvs '["alice", [{"_count":18, "_strID":"dumstr"},{"_count":19, "_strID":"dumstr2"}]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setvs(name user, const vector<mystruct>& vs)
+        {
+            SETCONTAINERVAL(vs);
+            eosio::print("vector<mystruct> stored successfully");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntvs '["alice"]' -p alice@active
+         *      output: >> stored vector<mystruct>  size=2:
+         *              >> 18,dumstr
+         *              >> 19,dumstr2
+         */
+        [[eosio::action]]
+        void prntvs(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored vector<mystruct>  size=",iter->vs.size(), ":\n");
+            for (const auto& ele: iter->vs)
+            {
+                eosio::print(ele._count,",", ele._strID,"\n");
+            }
+        }
+
+        /*Examples
+         *  To pass a null value:
+         *      cleos --verbose push action nestcontn2a seto '["bob", null]' -p bob@active
+         *
+         *  To pass a non-null value:
+         *      cleos --verbose push action nestcontn2a seto '["alice","hello strval22"]' -p alice@active
+         *
+         */
+        [[eosio::action]]
+        void seto(name user, const optional<string>& o)
+        {
+            SETCONTAINERVAL(o);
+            eosio::print("optional<string> stored successfully");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a  prnto '["bob"]' -p bob@active
+         *      output: >> stored optional<string>  has null value!
+         *
+         *  cleos --verbose push action nestcontn2a  prnto '["alice"]' -p alice@active
+         *      output: >> stored optional<string> =hello strval22
+         */
+        [[eosio::action]]
+        void prnto(name user)
+        {
+            PRNTCHECK();
+            if (iter->o)
+                eosio::print("stored optional<string> =", iter->o.value());
+            else
+                eosio::print("stored optional<string>  has null value!");
+        }
+
+        //Example: cleos --verbose push action nestcontn2a setp '["alice", {"first":183, "second":269}]' -p alice@active
+        [[eosio::action]]
+        void setp(name user, const pair<uint16_t, uint16_t>& p)
+        {
+            SETCONTAINERVAL(p);
+            eosio::print("pair<uint16_t, uint16_t> stored successfully");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntp '["alice"]' -p alice@active
+         *      output: tored pair<uint16_t,uint16_t> val:183,269
+         */
+        [[eosio::action]]
+        void prntp(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored pair<uint16_t,uint16_t> val:", iter->p.first,",", iter->p.second);
+        }
+
+        //============Two-layer nest containers start here===========
+        //=== 1. Try vector - set,vector,optional,map,pair
+
+        //Example: cleos --verbose push action nestcontn2a setvst '["alice", [[10,20],[3], [400,500,600]]]' -p alice@active
+        [[eosio::action]]
+        void setvst(name user, const vector<set_uint16>& vst)
+        {
+            SETCONTAINERVAL(vst);
+            eosio::print("type defined vector<set_uint16> stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntvst '["alice"]' -p alice@active
+         *      output: >> stored vector<set<T>>:size=3 vals:
+         *              >> 10 20
+         *              >> 3
+         *              >> 400 500 600
+         */
+        [[eosio::action]]
+        void prntvst(name user)
+        {
+
+            PRNTCHECK();
+            eosio::print("stored vector<set<T>>:size=", iter->vst.size(), " vals:\n");
+            for (auto it1=iter->vst.begin(); it1!= iter->vst.end(); it1++)
+            {
+                for (auto it2=it1->begin(); it2!= it1->end(); it2++)
+                    eosio::print(*it2, " ");
+                eosio::print("\n");
+            }
+        }
+
+
+        //Example: cleos --verbose push action nestcontn2a setvv '["alice", [[1,2],[30], [40,50,60]]]' -p alice@active
+        [[eosio::action]]
+        void setvv(name user, const vector<vec_uint16>& vv)
+        {
+            SETCONTAINERVAL(vv);
+            eosio::print("type defined vector<vec_uint16> stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntvv '["alice"]' -p alice@active
+         *      output: >> stored vector<vector<T>> vals:
+         *              >> 1 2
+         *              >> 30
+         *              >> 40 50 60
+         */
+        [[eosio::action]]
+        void prntvv(name user)
+        {
+
+            PRNTCHECK();
+            eosio::print("stored vector<vector<T>> vals:\n");
+            for (int i=0 ; i < iter->vv.size(); i++)
+            {
+                for (int j=0; j < iter->vv[i].size(); j++)
+                    eosio::print(iter->vv[i][j], " ");
+                eosio::print("\n"); //--- use cleos --verbose to show new lines !!!
+            }
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setvo '["alice", [100, null, 200, null, 300]]' -p alice@active
+         *        ******user data can NOT be pushed into the chain, cleos get table will not work if using setvo
+         *  vector<optional<T> > is  NOT supported currently!
+         */
+        [[eosio::action]]
+        void setvo(name user, const vector<op_uint16>& vo)
+        {
+            SETCONTAINERVAL(vo);
+            eosio::print("type defined vector<optional<T> > stored successfully!");
+        }
+
+        //Example: cleos --verbose push action nestcontn2a  prntvo '["alice"]' -p alice@active
+        //          NOT supported
+        [[eosio::action]]
+        void prntvo(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored vector<op_uint16> vals:\n");
+            for (const auto& ele : iter->vo)
+            {
+                if (ele)
+                    eosio::print(ele.value(), " ");
+                else
+                    eosio::print("NULL", " ");
+            }
+        }
+
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setvm '["alice", [ [{"first":10,"second":100},{"first":11,"second":101}], [{"first":80,"second":800},{"first":81,"second":9009}] ]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setvm(name user, const vector<mp_uint16>& vm)
+        {
+            SETCONTAINERVAL(vm);
+            eosio::print("type defined vector<map<K, V> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntvm '["alice"]' -p alice@active
+         *      output: >> stored vector<mp_uint16>: size=2 content:
+         *              >>
+         *              >> Element 0--->
+         *              >> 	10:100  11:101
+         *              >> Element 1--->
+         *              >> 	80:800  81:9009
+         */
+        [[eosio::action]]
+        void prntvm(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored vector<mp_uint16>: size=", iter->vm.size()," content:\n");
+            int count=0;
+            for (const auto& mpval : iter->vm)
+            {
+                eosio::print("\nElement ", count++, "--->\n\t");
+                for (auto it2 = mpval.begin(); it2 != mpval.end(); ++it2)
+                    eosio::print(it2->first, ":", it2->second, "  ");
+            }
+
+        }
+
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setvp '["alice", [{"first":18, "second":28}, {"first":19, "second":29}]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setvp(name user, const vector<pair<uint32_t, uint32_t> >& vp)
+        {
+            SETCONTAINERVAL(vp);
+            eosio::print("vector<pair<uint32_t, uint32_t> > stored successfully");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntvp '["alice"]' -p alice@active
+         *      output: >> stored vector<pair<uint32_t, uint32_t> >  size=2:
+         *              >> 18,28
+         *              >> 19,29
+         */
+        [[eosio::action]]
+        void prntvp(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored vector<pair<uint32_t, uint32_t> >  size=",iter->vp.size(), ":\n");
+            for (const auto& ele: iter->vp)
+            {
+                eosio::print(ele.first,",", ele.second,"\n");
+            }
+        }
+
+        //=== 2. Try set - set,vector,optional,map,pair
+
+        //Example: cleos --verbose push action nestcontn2a setstst '["alice", [[10,20],[3], [400,500,600]]]' -p alice@active
+        [[eosio::action]]
+        void setstst(name user, const set<set_uint16>& stst)
+        {
+            SETCONTAINERVAL(stst);
+            eosio::print("type defined set<set_uint16> stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntstst '["alice"]' -p alice@active
+         *      output: >> stored set<set<T>>:size=3 vals:
+         *              >> 3
+         *              >> 10 20
+         *              >> 400 500 600
+         */
+        [[eosio::action]]
+        void prntstst(name user)
+        {
+
+            PRNTCHECK();
+            eosio::print("stored set<set<T>>:size=", iter->stst.size(), " vals:\n");
+            for (auto it1=iter->stst.begin(); it1!= iter->stst.end(); it1++)
+            {
+                for (auto it2=it1->begin(); it2!= it1->end(); it2++)
+                    eosio::print(*it2, " ");
+                eosio::print("\n");
+            }
+        }
+
+         //Example: cleos --verbose push action nestcontn2a setstv '["alice", [[16,26],[36], [46,506,606]]]' -p alice@active
+        [[eosio::action]]
+        void setstv(name user, const set<vec_uint16>& stv)
+        {
+            SETCONTAINERVAL(stv);
+            eosio::print("type defined set<vec_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntstv '["alice"]' -p alice@active
+         *      output: >> stored set<vector<T>>:size=3 vals:
+         *              >> 16 26
+         *              >> 36
+         *              >> 46 506 606
+         */
+        [[eosio::action]]
+        void prntstv(name user)
+        {
+
+            PRNTCHECK();
+            eosio::print("stored set<vector<T>>:size=", iter->stv.size(), " vals:\n");
+            for (auto it1=iter->stv.begin(); it1!= iter->stv.end(); it1++)
+            {
+                for (auto it2=it1->begin(); it2!= it1->end(); it2++)
+                    eosio::print(*it2, " ");
+                eosio::print("\n");
+            }
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setsto '["alice", [101, null, 201, 301]]' -p alice@active
+         *        ***user data can NOT be pushed into the chain, cleos get table will not work if using setsto
+         *  set<optional<T> > is  NOT supported currently!
+         */
+        [[eosio::action]]
+        void setsto(name user, const set<op_uint16>& sto)
+        {
+            SETCONTAINERVAL(sto);
+            eosio::print("type defined set<optional<T> > stored successfully!");
+        }
+
+        //Example: cleos --verbose push action nestcontn2a  prntsto '["alice"]' -p alice@active
+        //          NOT supported
+        [[eosio::action]]
+        void prntsto(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored vector<op_uint16> vals:\n");
+            for (const auto& ele : iter->sto)
+            {
+                if (ele)
+                    eosio::print(ele.value(), " ");
+                else
+                    eosio::print("NULL", " ");
+            }
+        }
+
+        /*Example:
+         * cleos --verbose push action nestcontn2a setstm '["alice", [ [{"first":30,"second":300},{"first":31,"second":301}], [{"first":60,"second":600},{"first":61,"second":601}] ]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setstm(name user, const set<mp_uint16>& stm)
+        {
+            SETCONTAINERVAL(stm);
+            eosio::print("type defined set<map<K, V> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntstm '["alice"]' -p alice@active
+         *      output: >> stored set<mp_uint16>: size=2 content:
+         *              >>
+         *              >> Element 0--->
+         *              >> 	30:300  31:301
+         *              >> Element 1--->
+         *              >> 	60:600  61:601
+         */
+        [[eosio::action]]
+        void prntstm(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored set<mp_uint16>: size=", iter->stm.size()," content:\n");
+            int count=0;
+            for (const auto& mpval : iter->stm)
+            {
+                eosio::print("\nElement ", count++, "--->\n\t");
+                for (auto it2 = mpval.begin(); it2 != mpval.end(); ++it2)
+                    eosio::print(it2->first, ":", it2->second, "  ");
+            }
+        }
+
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setstp '["alice", [{"first":68, "second":128}, {"first":69, "second":129}]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setstp(name user, const set<pair<uint32_t, uint32_t> >& stp)
+        {
+            SETCONTAINERVAL(stp);
+            eosio::print("set<pair<T1,T2 >> stored successfully");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntstp '["alice"]' -p alice@active
+         *      output: >> stored set<pair<uint32_t, uint32_t> >  size=2:
+         *              >> 68,128
+         *              >> 69,129
+         */
+        [[eosio::action]]
+        void prntstp(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored set<pair<uint32_t, uint32_t> >  size=",iter->stp.size(), ":\n");
+            for (const auto& ele: iter->stp)
+            {
+                eosio::print(ele.first,",", ele.second,"\n");
+            }
+        }
+
+        //=== 3. Try optional - set,vector,optional,map,pair
+
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a setost '["bob", null]' -p bob@active
+         *  cleos --verbose push action nestcontn2a setost '["alice", [1006,2006, 3006]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setost(name user, const optional<set_uint16>& ost)
+        {
+            SETCONTAINERVAL(ost);
+            eosio::print("type defined optional<set<T> > stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a  prntost '["bob"]' -p bob@active
+         *      output: >> stored optional<set_uint16>  vals:
+         *              >> NULL or no value
+         *
+         *  cleos --verbose push action nestcontn2a  prntost '["alice"]' -p alice@active
+         *      output: >> stored optional<set_uint16>  vals:
+         *              >> 1006 2006 3006
+         */
+        [[eosio::action]]
+        void prntost(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored optional<set_uint16>  vals:\n");
+            if (iter->ost)
+            {
+                for (const auto& ele : iter->ost.value())
+                    eosio::print(ele, " ");
+            }
+            else
+                eosio::print("NULL or no value");
+        }
+
+
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a setov '["bob", null]' -p bob@active
+         *
+         *  cleos --verbose push action nestcontn2a setov '["alice", [1001,2001, 3001]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setov(name user, const optional<vec_uint16>& ov)
+        {
+            SETCONTAINERVAL(ov);
+            eosio::print("type defined optional<vector<T> > stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a  prntov '["bob"]' -p bob@active
+         *      output: >> stored optional<vec_uint16>  vals:
+         *              >> NULL or no value
+         *
+         *  cleos --verbose push action nestcontn2a  prntov '["alice"]' -p alice@active
+         *      output: >> stored optional<vec_uint16>  vals:
+         *              >> 1001 2001 3001
+         */
+        [[eosio::action]]
+        void prntov(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored optional<vec_uint16>  vals:\n");
+            if (iter->ov)
+            {
+                for (const auto& ele : iter->ov.value())
+                    eosio::print(ele, " ");
+            }
+            else
+                eosio::print("NULL or no value");
+        }
+
+
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a setoo '["bob", null]' -p bob@active
+         *
+         *  cleos --verbose push action nestcontn2a setoo '["alice",123]' -p alice@active
+         */
+        [[eosio::action]]
+        void setoo(name user, const optional<op_uint16>& oo)
+        {
+            SETCONTAINERVAL(oo);
+            eosio::print("type defined optional<op_uint16> stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a  prntoo '["bob"]' -p bob@active
+         *      ouput: >> stored optional<optional<T>> val:null or no real value stored
+         *
+         *  cleos --verbose push action nestcontn2a  prntoo '["alice"]' -p alice@active
+         *      output: >> stored optional<optional<T>> val:123
+         */
+        [[eosio::action]]
+        void prntoo(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored optional<optional<T>> val:");
+            if (iter->oo && iter->oo.value())
+                eosio::print(iter->oo.value().value(),"\n");
+            else
+                eosio::print("null or no real value stored");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a  setom '["alice",[{"first":10,"second":1000},{"first":11,"second":1001}] ]' -p alice@active
+         *
+         *  cleos --verbose push action nestcontn2a  setom '["bob", null ]' -p bob@active
+         */
+        [[eosio::action]]
+        void setom(name user, const optional<mp_uint16>& om)
+        {
+            SETCONTAINERVAL(om);
+            eosio::print("type defined optional<map<K, V> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntom '["alice"]' -p alice@active
+         *      output: >> size of stored om:2 vals:10:1000  11:1001
+         *
+         *  cleos --verbose push action nestcontn2a  prntom '["bob"]' -p bob@active
+         *      output: >> optional<mp_uint16> has NULL value
+         */
+        [[eosio::action]]
+        void prntom(name user)
+        {
+            PRNTCHECK();
+            if (iter->om)
+            {
+                auto mpval = iter->om.value();
+                eosio::print("size of stored om:", mpval.size()," vals:");
+                for (auto it2 = mpval.begin(); it2 != mpval.end(); ++it2)
+                    eosio::print(it2->first, ":", it2->second, "  ");
+
+            }
+            else
+                eosio::print("optional<mp_uint16> has NULL value\n");
+        }
+
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a setop '["alice", {"first":60, "second":61}]' -p alice@active
+         *
+         *  cleos --verbose push action nestcontn2a setop '["bob", null]' -p bob@active
+         */
+        [[eosio::action]]
+        void setop(name user, const optional<pr_unit16> & op)
+        {
+            SETCONTAINERVAL(op);
+            eosio::print("type-defined optional-pair optional<pr_unit16> stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a  prntop '["alice"]' -p alice@active
+         *      output: >> stored optional<pr_unit16> data:60 61
+         *
+         *  cleos --verbose push action nestcontn2a  prntop '["bob"]' -p bob@active
+         *      output: >> optional<pr_unit16> has NULL value
+         */
+        [[eosio::action]]
+        void prntop(name user)
+        {
+            PRNTCHECK();
+            if (iter->op)
+                eosio::print("stored optional<pr_unit16> data:", iter->op.value().first, " ", iter->op.value().second);
+            else
+                eosio::print("optional<pr_unit16> has NULL value\n");
+        }
+
+
+        //=== 4. Try map - set,vector,optional,map,pair
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setmst '["alice", [{"key":1,"value":[10,11,12,16]},  {"key":2,"value":[200,300]} ]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setmst(name user, const map<uint16_t, set_uint16> & mst)
+        {
+            SETCONTAINERVAL(mst);
+            eosio::print("type-defined map<K, set<T> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntmst '["alice"]' -p alice@active
+         *      output: >> stored map<uint16_t, set_uint16>: size=2 content:
+         *              >> 1:vals 10 11 12 16
+         *              >> 2:vals 200 300
+         */
+        [[eosio::action]]
+        void prntmst(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored map<uint16_t, set_uint16>: size=", iter->mst.size()," content:\n");
+            for (auto it2 = iter->mst.begin(); it2 != iter->mst.end(); ++it2)
+            {
+                    eosio::print(it2->first, ":", "vals ");
+                    for (const auto& ele: it2->second)
+                    {
+                        eosio::print(ele," ");
+                    }
+                    eosio::print("\n");
+            }
+        }
+
+
+
+        /*Example:
+         * cleos --verbose push action nestcontn2a setmv '["alice", [{"key":1,"value":[10,11,12,16]},  {"key":2,"value":[200,300]} ]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setmv(name user, const map<uint16_t, vec_uint16>& mv)
+        {
+            SETCONTAINERVAL(mv);
+            eosio::print("type defined map<K, vector<T> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntmv '["alice"]' -p alice@active
+         *      output: >> stored map<uint16_t, vec_uint16>: size=2 content:
+         *              >> 1:vals 10 11 12 16
+         *              >> 2:vals 200 300
+         */
+        [[eosio::action]]
+        void prntmv(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored map<uint16_t, vec_uint16>: size=", iter->mv.size()," content:\n");
+            for (auto it2 = iter->mv.begin(); it2 != iter->mv.end(); ++it2)
+            {
+                    eosio::print(it2->first, ":", "vals ");
+                    for (const auto& ele: it2->second)
+                    {
+                        eosio::print(ele," ");
+                    }
+                    eosio::print("\n");
+            }
+        }
+
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setmo '["alice", [{"key":10,"value":1000},{"key":11,"value":null}]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setmo(name user, const map<uint16_t, op_uint16>& mo)
+        {
+            SETCONTAINERVAL(mo);
+            eosio::print("type defined map<K, optional<T> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntmo '["alice"]' -p alice@active
+         *      output: >> size of stored mo:2 vals
+         *              >> 10:1000 11:NULL
+         */
+        [[eosio::action]]
+        void prntmo(name user)
+        {
+            PRNTCHECK();
+            eosio::print("size of stored mo:", iter->mo.size()," vals\n");
+            for (auto it2 = iter->mo.begin(); it2 != iter->mo.end(); ++it2)
+            {
+                eosio::print(it2->first, ":");
+                if (it2->second)
+                    eosio::print(it2->second.value()," ");
+                else
+                    eosio::print("NULL ");
+            }
+        }
+
+        /*Example:
+         *  cleos push action nestcontn2a setmm '["alice", [{"key":10,"value":[{"first":200,"second":2000}, {"first":201,"second":2001}] }, {"key":11,"value":[{"first":300,"second":3000}, {"first":301,"second":3001}] } ]]' -p alice@active
+         *       Attention: please note the cleos input of mm or map<K1, map<K2, V> > is a combination of strings key/value and first/second !
+         *       i.e the "value" part of mm is an array of <first,second> pairs!
+         */
+        [[eosio::action]]
+        void setmm(name user, const map<uint16_t, mp_uint16>& mm)
+        {
+            SETCONTAINERVAL(mm);
+            eosio::print("type defined map<K1,map<K2, V> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntmm '["alice"]' -p alice@active
+         *      output: >> stored map<uint16_t, mp_uint16> val:size=2 vals are the following:
+         *              >> 10--->
+         *              >> 	200:2000
+         *              >> 	201:2001
+         *              >> 11--->
+         *              >> 	300:3000
+         *              >> 	301:3001
+         */
+        [[eosio::action]]
+        void prntmm(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored map<uint16_t, mp_uint16> val:");
+            eosio::print("size=", iter->mm.size()," vals are the following:\n");
+            for (auto it2 = iter->mm.begin(); it2 != iter->mm.end(); ++it2)
+            {
+                eosio::print(it2->first,"--->\n");
+                const auto& temp = it2->second;
+                for (auto it3 = temp.begin(); it3 != temp.end(); ++it3)
+                    eosio::print("\t",it3->first, ":", it3->second, "\n");
+            }
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setmp '["alice", [{"key":36,"value":{"first":300, "second":301}}, {"key":37,"value":{"first":600, "second":601}} ]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setmp(name user, const map<uint16_t, pr_unit16> & mp)
+        {
+            SETCONTAINERVAL(mp);
+            eosio::print("type-defined map-pair map<uint16_t, pr_unit16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntmp '["alice"]' -p alice@active
+         *      output: >> size of stored mp:2 vals:
+         *              >> 36:300 301
+         *              >> 37:600 601
+         */
+        [[eosio::action]]
+        void prntmp(name user)
+        {
+            PRNTCHECK();
+            eosio::print("size of stored mp:", iter->mp.size()," vals:\n");
+            for (auto it2 = iter->mp.begin(); it2 != iter->mp.end(); ++it2)
+                eosio::print(it2->first, ":", it2->second.first, " ", it2->second.second, "\n");
+        }
+
+        //=== 5. Try pair - set,vector,optional,map,pair
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setpst '["alice", {"first":20, "second":[200,201,202]}]' -p alice@active
+         */
+        [[eosio::action]]
+        void setpst(name user, const pair<uint32_t, set_uint16>& pst)
+        {
+            SETCONTAINERVAL(pst);
+            eosio::print("type-defined pair-set pair<uint32_t, set_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntpst '["alice"]' -p alice@active
+         *      output: >> content of stored pair<uint32_t, set_uint16>: first=20
+         *              >> second=200 201 202
+         */
+        [[eosio::action]]
+        void prntpst(name user)
+        {
+            PRNTCHECK();
+            eosio::print("content of stored pair<uint32_t, set_uint16>: first=", iter->pst.first, "\nsecond=");
+            for (const auto& ele: iter->pst.second)
+                eosio::print(ele, " ");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setpv '["alice", {"first":10, "second":[100,101,102]}]' -p alice@active
+         */
+        [[eosio::action]]
+        void setpv(name user, const pair<uint32_t, vec_uint16>& pv)
+        {
+            SETCONTAINERVAL(pv);
+            eosio::print("type-defined pair-vector pair<uint32_t, vec_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntpv '["alice"]' -p alice@active
+         *      output: >> content of stored pair<uint32_t, vec_uint16>: first=10
+         *              >> second=100 101 102
+         */
+        [[eosio::action]]
+        void prntpv(name user)
+        {
+            PRNTCHECK();
+            eosio::print("content of stored pair<uint32_t, vec_uint16>: first=", iter->pv.first, "\nsecond=");
+            for (const auto& ele: iter->pv.second)
+                eosio::print(ele, " ");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a setpo '["alice", {"first":70, "second":71}]' -p alice@active
+         *
+         *  cleos --verbose push action nestcontn2a setpo '["bob", {"first":70, "second":null}]' -p bob@active
+         */
+        [[eosio::action]]
+        void setpo(name user, const pair<uint32_t, op_uint16> & po)
+        {
+            SETCONTAINERVAL(po);
+            eosio::print("type-defined pair-optional pair<uint32_t, op_uint16> stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a  prntpo '["alice"]' -p alice@active
+         *      output: >> content of stored pair<uint16_t, op_unit16>: first=70
+         *              >> second=71
+         *
+         *  cleos --verbose push action nestcontn2a  prntpo '["bob"]' -p bob@active
+         *      output: >> content of stored pair<uint16_t, op_unit16>: first=70
+         *              >> second=NULL
+         */
+        [[eosio::action]]
+        void prntpo(name user)
+        {
+            PRNTCHECK();
+            eosio::print("content of stored pair<uint16_t, op_unit16>: first=", iter->po.first, "\nsecond=");
+            if (iter->po.second)
+                eosio::print(iter->po.second.value(), " ");
+            else
+                eosio::print("NULL ");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setpm '["alice", {"key":6, "value":[{"first":20,"second":300}, {"first":21,"second":301}] }]' -p alice@active
+         *      Remark: the data input for pm uses a combination of key/vale and first/second
+         */
+        [[eosio::action]]
+        void setpm(name user, const pair<uint16_t, mp_uint16> & pm)
+        {
+            SETCONTAINERVAL(pm);
+            eosio::print("type-defined pair-map pair<uint16_t, mp_uint16> stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2a  prntpm '["alice"]' -p alice@active
+         *      output: >> content of stored pair<uint16_t, mp_uint16>: first=6
+         *              >> second=20:300  21:301
+         */
+        [[eosio::action]]
+        void prntpm(name user)
+        {
+            PRNTCHECK();
+            eosio::print("content of stored pair<uint16_t, mp_uint16>: first=", iter->pm.first, "\nsecond=");
+            for (auto it2 = iter->pm.second.begin(); it2 != iter->pm.second.end(); ++it2)
+                eosio::print(it2->first, ":", it2->second, "  ");
+        }
+
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setpp '["alice", {"key":30, "value":{"first":301, "second":302} }]' -p alice@active
+         *      Remark: input data for pp or pair-pair is a combination of key/value and first/second
+         */
+        [[eosio::action]]
+        void setpp(name user, const pair<uint16_t, pr_unit16> & pp)
+        {
+            SETCONTAINERVAL(pp);
+            eosio::print("type-defined pair-pair pair<uint16_t, pr_unit16> stored successfully!");
+        }
+
+        /*Example:
+         * cleos --verbose push action nestcontn2a  prntpp '["alice"]' -p alice@active
+         *      output: >> content of stored pair<uint16_t, pr_unit16>: first=30
+         *              >> second=301 302
+         */
+        [[eosio::action]]
+        void prntpp(name user)
+        {
+            PRNTCHECK();
+            eosio::print("content of stored pair<uint16_t, pr_unit16>: first=", iter->pp.first, "\nsecond=");
+            eosio::print(iter->pp.second.first, " ", iter->pp.second.second);
+        }
+
+
+        //Try an example of 3-layer nested container
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a setovv '["alice", [[21,22],[230], [240,250,260,280]]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setovv(name user, const optional<vecvec_uint32>& ovv)
+        {
+            // try type-defined 3-layer nested container optional<vector<vector<T> > > here
+            SETCONTAINERVAL(ovv);
+            eosio::print("type-defined optional<vecvec_uint32> stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2a  prntovv '["alice"]' -p alice@active
+         *      output: >> stored optional<vector<vector<T> > > vals:
+         *              >> 21 22
+         *              >> 230
+         *              >> 240 250 260 280
+         */
+        [[eosio::action]]
+        void prntovv(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored optional<vector<vector<T> > > vals:\n");
+            if (iter->ovv)
+            {
+              auto v2 = iter->ovv.value();
+              for (int i=0 ; i < v2.size(); i++)
+              {
+                for (int j=0; j < v2[i].size(); j++)
+                    eosio::print(v2[i][j], " ");
+                eosio::print("\n");
+              }
+            }
+            else
+                eosio::print("stored optional<vector<vector<T> > >  has null value!");
+        }
+
+        //Example: cleos --verbose push action nestcontn2a erase '["alice"]' -p alice@active
+        [[eosio::action]]
+        void erase(name user)
+        {
+            require_auth(user);
+            psninfoindex2 tblIndex( get_self(), get_first_receiver().value);
+
+            auto iter = tblIndex.find(user.value);
+            check(iter != tblIndex.end(), "Record does not exist");
+            tblIndex.erase(iter);
+            eosio::print("record erased successfully");
+        }
+
+};

--- a/tests/toolchain/build-pass/nestcontn2a.json
+++ b/tests/toolchain/build-pass/nestcontn2a.json
@@ -1,0 +1,10 @@
+{
+    "tests": [
+        {
+            "expected": {
+                "exit-code": 0
+            }
+        }
+    ]
+}
+

--- a/tests/toolchain/build-pass/nestcontn2kv.cpp
+++ b/tests/toolchain/build-pass/nestcontn2kv.cpp
@@ -1,0 +1,1426 @@
+/* Verify the support of nested containers for the new Key-value table eosio::kv::map
+ * For each action, an example regarding how to use the action with the cleos command line is given.
+ *
+ * std:pair<T1,T2> is a struct with 2 fields first and second,
+ * std::map<K,V> is handled as an array/vector of pairs/structs by EOSIO with implicit fields key, value,
+ * the cases of combined use of key/value and first/second involving map,pair in the cleos are documented here,
+ * so handling of std::pair is NOT the same as the handling of a general struct such as struct mystruct!
+ *
+ * When assigning data input with cleos:
+ *      [] represents an empty vector<T>/set<T> or empty map<T1,T2> where T, T1, T2 can be any composite types
+ *      null represents an uninitialized std::optional<T> where T can be any composite type
+ *      BUT [] or null can NOT be used to represent an empty struct or empty std::pair
+ *
+ * Attention:
+ *   1) Please follow https://github.com/EOSIO/eos/tree/develop/contracts/enable-kv to enable key-value support of nodeos first
+ *   2) To get to the point right away, here authentication/permission checking is skipped for each action in this contract,
+ *      however in practice, suitable permission checking such as require_auth(user) has to be used!
+ *
+ * Expected printout:
+ *      For each setx action, the printed result on the cleos console is given in its corresponding prntx action.
+ */
+
+#include <eosio/eosio.hpp>
+#include <eosio/map.hpp>
+
+#include <vector>
+#include <set>
+#include <optional>
+#include <map>
+#include <tuple>
+
+using namespace eosio;
+using namespace std;
+
+
+#define SETCONTAINERVAL(x) do { \
+        person2kv obj = mymap[id]; \
+        obj.x = x; \
+        mymap[id] =  obj; \
+    }while(0)
+
+//when the keys of kv::map are of different types, the following sets values of mymap2, mymap3, mymap4
+#define SETCONTAINERVALN(num, x) do { \
+        person2kv obj = mymap ## num[id]; \
+        obj.x = x; \
+        mymap ## num[id] =  obj; \
+    }while(0)
+
+
+struct mystruct
+{
+    uint64_t   _count;
+    string     _strID;
+};
+
+//mystruct2 has embeded mystruct
+struct mystruct2
+{
+    mystruct   _structfld;
+    string     _strID2;
+};
+
+//mystructrefl has CDT_REFLECT wrapper over above mystruct, it is the key of following my_map_t4,
+//if the key of an kv::map is a self-defined struct, the struct has to be self-reflective
+struct mystructrefl
+{
+    uint64_t   _count;
+    string     _strID;
+    CDT_REFLECT(_count, _strID);
+};
+
+// use typedefs to make multi-layer nested containers work!
+typedef vector<uint16_t> vec_uint16;
+typedef set<uint16_t> set_uint16;
+typedef optional<uint16_t> op_uint16;
+typedef map<uint16_t, uint16_t> mp_uint16;
+typedef pair<uint16_t, uint16_t> pr_unit16;
+
+typedef vector<uint32_t> vec_uint32;
+typedef vector<vec_uint32> vecvec_uint32;
+
+//using dummy_kvmap = eosio::kv::map<"dumkv"_n, int, int>;
+
+struct person2kv {
+    //  Each container/object is represented by one letter: v-vector, m-map, s-mystruct,o-optional, p-pair,
+    //  with exceptions:     s2 - mystruct2,    st - set
+
+    vector<uint16_t> v;
+    map<string,string> m;
+    mystruct s;
+    mystruct2 s2;
+    set<uint16_t> st;
+    optional<string> o;
+    pair<uint16_t, uint16_t> p;
+    vector<mystruct> vs;
+
+    //The following are 2-layer nested containers involving vector/optional/map
+    vector<vec_uint16> vv;
+    optional<op_uint16> oo;
+    map<uint16_t, mp_uint16> mm;
+    set<set_uint16> stst;
+
+    vector<set_uint16> vst;
+    set<vec_uint16> stv;
+
+    vector<op_uint16> vo;
+    optional<vec_uint16> ov;
+    set<op_uint16> sto;
+    optional<set_uint16> ost;
+
+    vector<mp_uint16> vm;
+    map<uint16_t, vec_uint16> mv;
+
+    set<mp_uint16> stm;
+    map<uint16_t, set_uint16> mst;
+
+    optional<mp_uint16> om;
+    map<uint16_t, op_uint16> mo;
+
+    //The following are composite types involving pair and containers
+    vector<pair<uint32_t, uint32_t> > vp;
+    pair<uint32_t, vec_uint16> pv;
+
+    set<pair<uint32_t, uint32_t> > stp;
+    pair<uint32_t, set_uint16> pst;
+
+    optional<pr_unit16> op;
+    pair<uint32_t, op_uint16> po;
+
+    map<uint16_t, pr_unit16> mp;
+    pair<uint16_t, mp_uint16> pm;
+
+    pair<uint16_t, pr_unit16>  pp;
+
+    //The following is a 3-layer nested containers for motivation
+    optional<vecvec_uint32> ovv;
+};
+
+
+class [[eosio::contract("nestcontn2kv")]] nestcontn2kv : public eosio::contract {
+    using my_map_t = eosio::kv::map<"people2kv"_n, int, person2kv>;
+
+    //The following kv::map have different key types: std::string, eosio::name, mystructrefl
+    using my_map_t2 = eosio::kv::map<"people2kv2"_n, string, person2kv>;
+    using my_map_t3 = eosio::kv::map<"people2kv3"_n, name, person2kv>;
+    using my_map_t4 = eosio::kv::map<"people2kv4"_n, mystructrefl, person2kv>;
+
+    private:
+        my_map_t mymap{};
+        my_map_t2 mymap2{};
+        my_map_t3 mymap3{};
+        my_map_t4 mymap4{};
+
+    public:
+        using contract::contract;
+
+        nestcontn2kv(name receiver, name code,  datastream<const char*> ds): contract(receiver, code, ds) {}
+
+        //[[eosio::action]] void settuple(name user, const tuple<uint16_t>& tp) {}
+        //[[eosio::action]] void settuple(name user, const tuple<uint16_t, uint32_t, int16_t>& tp) {}
+        //  eosio-cpp compile error for std::tuple: Tried to get a nested template type of a template not containing one
+
+        //[[eosio::action]] void setdumkv(name user, const dummy_kvmap& tp) {}
+        // eosio-cpp compile error for above dummy_kvmap: Tried to get a non-existent template argument
+
+        //Example: cleos --verbose push action nestcontn2kv get '[1]' -p alice@active
+        [[eosio::action]]
+        person2kv get(int id)
+        {
+            //This action will be used by all prntx actions to retrieve item_found for given id
+            auto iter = mymap.find(id);
+            check(iter != mymap.end(), "Record does not exist");
+            const auto& item_found = iter->second();
+            return item_found;
+        }
+
+         /*Examples:
+          * cleos --verbose push action nestcontn2kv setv '[1,[100,200,300,600]]' -p alice@active
+          * cleos --verbose push action nestcontn2kv setv '[2, []]' -p bob@active
+          */
+        [[eosio::action]]
+        void setv(int id, const vector<uint16_t>& v)
+        {
+            SETCONTAINERVAL(v);
+            eosio::print("vector<uint16_t> stored successfully");
+        }
+
+         /*Examples:
+         *  cleos --verbose push action nestcontn2kv prntv '[1]' -p alice@active
+         *      output: >> size of stored v:4 vals:100,200,300,600,
+         *
+         *  cleos --verbose push action nestcontn2kv prntv '[2]' -p bob@active
+         *      output: >> size of stored v:0 vals:
+         */
+        [[eosio::action]]
+        void prntv(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("size of stored v:", psn.v.size()," vals:");
+            for (const auto & ele : psn.v)
+                eosio::print(ele, ",");
+        }
+
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv setst '[1, [101,201,301]]' -p alice@active
+         *  cleos --verbose push action nestcontn2kv setst '[2, []]' -p bob@active
+         */
+        [[eosio::action]]
+        void setst(int id, const set<uint16_t> & st)
+        {
+            SETCONTAINERVAL(st);
+            eosio::print("set<uint16_t> stored successfully");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv prntst '[1]' -p alice@active
+         *      output: >> size of stored st:3 vals:101,201,301,
+         *
+         *  cleos --verbose push action nestcontn2kv prntst '[2]' -p bob@active
+         *      output: >> size of stored st:0 vals:
+         */
+        [[eosio::action]]
+        void prntst(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("size of stored st:", psn.st.size()," vals:");
+            for (const auto & ele : psn.st)
+                eosio::print(ele, ",");
+
+        }
+
+        /*Examples:
+         * To use shortcut notation:
+         *   cleos --verbose push action nestcontn2kv setm '[1, [{"key":"str1","value":"str1val"}, {"key":"str3","value":"str3val"}]]' -p alice@active
+         *
+         * To use full JSON notation:
+         *   cleos --verbose push action nestcontn2kv setm '{"id":2, "m":[{"key":"str4", "value":"str4val"}, {"key":"str6", "value":"str6val"}]}' -p jane@active
+         *
+         * To pass an empty map:
+         *   cleos --verbose push action nestcontn2kv setm '[3, []]' -p bob@active
+         */
+        [[eosio::action]]
+        void setm(int id, const map<string,string>  & m)
+        {
+            SETCONTAINERVAL(m);
+            eosio::print("map<string,string> stored successfully");
+        }
+
+        /* Examples:
+         *  cleos --verbose push action nestcontn2kv prntm '[1]' -p alice@active
+         *      output: >> size of stored m:2 vals of m:str1:str1val  str3:str3val
+         *
+         *  cleos --verbose push action nestcontn2kv prntm '[2]' -p jane@active
+         *      output: >> size of stored m:2 vals of m:str4:str4val  str6:str6val
+         *
+         *  cleos --verbose push action nestcontn2kv prntm '[3]' -p bob@active
+         *      output: >> size of stored m:0 vals of m:
+        */
+        [[eosio::action]]
+        void prntm(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("size of stored m:", psn.m.size()," vals of m:");
+            for (auto it2 = psn.m.begin(); it2 != psn.m.end(); ++it2)
+                eosio::print(it2->first, ":", it2->second, "  ");
+
+        }
+
+        //Example: cleos --verbose push action nestcontn2kv sets '[1, {"_count":18, "_strID":"dumstr"}]' -p alice@active
+        [[eosio::action]]
+        void sets(int id, const mystruct& s)
+        {
+            SETCONTAINERVAL(s);
+            eosio::print("mystruct stored successfully");
+        }
+
+        /*Example:
+         * cleos --verbose push action nestcontn2kv  prnts '[1]' -p alice@active
+         *      output: >> stored mystruct val:18,dumstr
+         */
+        [[eosio::action]]
+        void prnts(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored mystruct val:", psn.s._count,",", psn.s._strID);
+        }
+
+        //Example: cleos --verbose push action nestcontn2kv sets2 '[1, {"_structfld":{"_count":18, "_strID":"dumstr"}, "_strID2":"dumstr2"}]' -p alice@active
+        [[eosio::action]]
+        void sets2(int id, const mystruct2& s2)
+        {
+            SETCONTAINERVAL(s2);
+            eosio::print("complex mystruct2 stored successfully");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prnts2 '[1]' -p alice@active
+         *      output: >> stored mystruct2 val:18,dumstr,dumstr2
+         */
+        [[eosio::action]]
+        void prnts2(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored mystruct2 val:", psn.s2._structfld._count,",", psn.s2._structfld._strID, ",", psn.s2._strID2);
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setvs '[1, [{"_count":18, "_strID":"dumstr"},{"_count":19, "_strID":"dumstr2"}]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setvs(int id, const vector<mystruct>& vs)
+        {
+            SETCONTAINERVAL(vs);
+            eosio::print("vector<mystruct> stored successfully");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntvs '[1]' -p alice@active
+         *      output: >> stored vector<mystruct>  size=2:
+         *              >> 18,dumstr
+         *              >> 19,dumstr2
+         */
+        [[eosio::action]]
+        void prntvs(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored vector<mystruct>  size=",psn.vs.size(), ":\n");
+            for (const auto& ele: psn.vs)
+            {
+                eosio::print(ele._count,",", ele._strID,"\n");
+            }
+        }
+
+        /*Examples
+         *  To pass a null value:
+         *      cleos --verbose push action nestcontn2kv seto '[1, null]' -p bob@active
+         *
+         *  To pass a non-null value:
+         *      cleos --verbose push action nestcontn2kv seto '[2,"hello strval22"]' -p alice@active
+         *
+         */
+        [[eosio::action]]
+        void seto(int id, const optional<string>& o)
+        {
+            SETCONTAINERVAL(o);
+            eosio::print("optional<string> stored successfully");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv  prnto '[1]' -p bob@active
+         *      output: >> stored optional<string>  has null value!
+         *
+         *  cleos --verbose push action nestcontn2kv  prnto '[2]' -p alice@active
+         *      output: >> stored optional<string> =hello strval22
+         */
+        [[eosio::action]]
+        void prnto(int id)
+        {
+            const auto& psn = get(id);
+            if (psn.o)
+                eosio::print("stored optional<string> =", psn.o.value());
+            else
+                eosio::print("stored optional<string>  has null value!");
+        }
+
+        //Example: cleos --verbose push action nestcontn2kv setp '[1, {"first":183, "second":269}]' -p alice@active
+        [[eosio::action]]
+        void setp(int id, const pair<uint16_t, uint16_t>& p)
+        {
+            SETCONTAINERVAL(p);
+            eosio::print("pair<uint16_t, uint16_t> stored successfully");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntp '[1]' -p alice@active
+         *      output: tored pair<uint16_t,uint16_t> val:183,269
+         */
+        [[eosio::action]]
+        void prntp(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored pair<uint16_t,uint16_t> val:", psn.p.first,",", psn.p.second);
+        }
+
+        //============Two-layer nest containers start here===========
+         //=== 1. Try set - set,vector,optional,map,pair
+
+        //Example: cleos --verbose push action nestcontn2kv setstst '[1, [[10,20],[3], [400,500,600]]]' -p alice@active
+        [[eosio::action]]
+        void setstst(int id, const set<set_uint16>& stst)
+        {
+            SETCONTAINERVAL(stst);
+            eosio::print("type defined set<set_uint16> stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntstst '[1]' -p alice@active
+         *      output: >> stored set<set<T>>:size=3 vals:
+         *              >> 3
+         *              >> 10 20
+         *              >> 400 500 600
+         */
+        [[eosio::action]]
+        void prntstst(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored set<set<T>>:size=", psn.stst.size(), " vals:\n");
+            for (auto it1=psn.stst.begin(); it1!= psn.stst.end(); it1++)
+            {
+                for (auto it2=it1->begin(); it2!= it1->end(); it2++)
+                    eosio::print(*it2, " ");
+                eosio::print("\n");
+            }
+        }
+
+         //Example: cleos --verbose push action nestcontn2kv setstv '[1, [[16,26],[36], [46,506,606]]]' -p alice@active
+        [[eosio::action]]
+        void setstv(int id, const set<vec_uint16>& stv)
+        {
+            SETCONTAINERVAL(stv);
+            eosio::print("type defined set<vec_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntstv '[1]' -p alice@active
+         *      output: >> stored set<vector<T>>:size=3 vals:
+         *              >> 16 26
+         *              >> 36
+         *              >> 46 506 606
+         */
+        [[eosio::action]]
+        void prntstv(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored set<vector<T>>:size=", psn.stv.size(), " vals:\n");
+            for (auto it1=psn.stv.begin(); it1!= psn.stv.end(); it1++)
+            {
+                for (auto it2=it1->begin(); it2!= it1->end(); it2++)
+                    eosio::print(*it2, " ");
+                eosio::print("\n");
+            }
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setsto '[1, [101, null, 201, 301]]' -p alice@active
+         *      *****user data can NOT be pushed into the chain, cleos get kv_table will not work if using setsto
+         *  set<optional<T> > is  NOT supported currently!
+         */
+        [[eosio::action]]
+        void setsto(int id, const set<op_uint16>& sto)
+        {
+            SETCONTAINERVAL(sto);
+            eosio::print("type defined set<optional<T> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntsto '[1]' -p alice@active
+         *      NOT supported
+         */
+        [[eosio::action]]
+        void prntsto(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored vector<op_uint16> vals:\n");
+            for (const auto& ele : psn.sto)
+            {
+                if (ele)
+                    eosio::print(ele.value(), " ");
+                else
+                    eosio::print("NULL", " ");
+            }
+        }
+
+        /*Example:
+         * cleos --verbose push action nestcontn2kv setstm '[1, [ [{"first":30,"second":300},{"first":31,"second":301}], [{"first":60,"second":600},{"first":61,"second":601}] ]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setstm(int id, const set<mp_uint16>& stm)
+        {
+            SETCONTAINERVAL(stm);
+            eosio::print("type defined set<map<K, V> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntstm '[1]' -p alice@active
+         *      output: >> stored set<mp_uint16>: size=2 content:
+         *              >>
+         *              >> Element 0--->
+         *              >> 	30:300  31:301
+         *              >> Element 1--->
+         *              >> 	60:600  61:601
+         */
+        [[eosio::action]]
+        void prntstm(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored set<mp_uint16>: size=", psn.stm.size()," content:\n");
+            int count=0;
+            for (const auto& mpval : psn.stm)
+            {
+                eosio::print("\nElement ", count++, "--->\n\t");
+                for (auto it2 = mpval.begin(); it2 != mpval.end(); ++it2)
+                    eosio::print(it2->first, ":", it2->second, "  ");
+            }
+        }
+
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setstp '[1, [{"first":68, "second":128}, {"first":69, "second":129}]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setstp(int id, const set<pair<uint32_t, uint32_t> >& stp)
+        {
+            SETCONTAINERVAL(stp);
+            eosio::print("set<pair<T1,T2 >> stored successfully");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntstp '[1]' -p alice@active
+         *      output: >> stored set<pair<uint32_t, uint32_t> >  size=2:
+         *              >> 68,128
+         *              >> 69,129
+         */
+        [[eosio::action]]
+        void prntstp(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored set<pair<uint32_t, uint32_t> >  size=", psn.stp.size(), ":\n");
+            for (const auto& ele: psn.stp)
+            {
+                eosio::print(ele.first,",", ele.second,"\n");
+            }
+        }
+
+        //=== 2. Try vector - set,vector,optional,map,pair
+
+        //Example: cleos --verbose push action nestcontn2kv setvst '[1, [[10,20],[3], [400,500,600]]]' -p alice@active
+        [[eosio::action]]
+        void setvst(int id, const vector<set_uint16>& vst)
+        {
+            SETCONTAINERVAL(vst);
+            eosio::print("type defined vector<set_uint16> stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntvst '[1]' -p alice@active
+         *      output: >> stored vector<set<T>>:size=3 vals:
+         *              >> 10 20
+         *              >> 3
+         *              >> 400 500 600
+         */
+        [[eosio::action]]
+        void prntvst(int id)
+        {
+
+            const auto& psn = get(id);
+            eosio::print("stored vector<set<T>>:size=", psn.vst.size(), " vals:\n");
+            for (auto it1=psn.vst.begin(); it1!= psn.vst.end(); it1++)
+            {
+                for (auto it2=it1->begin(); it2!= it1->end(); it2++)
+                    eosio::print(*it2, " ");
+                eosio::print("\n");
+            }
+        }
+
+
+        //Example: cleos --verbose push action nestcontn2kv setvv '[1, [[1,2],[30], [40,50,60]]]' -p alice@active
+        [[eosio::action]]
+        void setvv(int id, const vector<vec_uint16>& vv)
+        {
+            SETCONTAINERVAL(vv);
+            eosio::print("type defined vector<vec_uint16> stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntvv '[1]' -p alice@active
+         *      output: >> stored vector<vector<T>> vals:
+         *              >> 1 2
+         *              >> 30
+         *              >> 40 50 60
+         */
+        [[eosio::action]]
+        void prntvv(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored vector<vector<T>> vals:\n");
+            for (int i=0 ; i < psn.vv.size(); i++)
+            {
+                for (int j=0; j < psn.vv[i].size(); j++)
+                    eosio::print(psn.vv[i][j], " ");
+                eosio::print("\n"); //--- use cleos --verbose to show new lines !!!
+            }
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setvo '[1, [100, null, 200, null, 300]]' -p alice@active
+         *      *****user data can NOT be pushed into the chain, cleos get kv_table will not work if using setvo
+         *  vector<optional<T> > is  NOT supported currently!
+         */
+        [[eosio::action]]
+        void setvo(int id, const vector<op_uint16>& vo)
+        {
+            SETCONTAINERVAL(vo);
+            eosio::print("type defined vector<optional<T> > stored successfully!");
+        }
+
+        //Example: cleos --verbose push action nestcontn2kv  prntvo '[1]' -p alice@active
+        //          NOT supported
+        [[eosio::action]]
+        void prntvo(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored vector<op_uint16> vals:\n");
+            for (const auto& ele : psn.vo)
+            {
+                if (ele)
+                    eosio::print(ele.value(), " ");
+                else
+                    eosio::print("NULL", " ");
+            }
+        }
+
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setvm '[1, [ [{"first":10,"second":100},{"first":11,"second":101}], [{"first":80,"second":800},{"first":81,"second":9009}] ]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setvm(int id, const vector<mp_uint16>& vm)
+        {
+            SETCONTAINERVAL(vm);
+            eosio::print("type defined vector<map<K, V> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntvm '[1]' -p alice@active
+         *      output: >> stored vector<mp_uint16>: size=2 content:
+         *              >>
+         *              >> Element 0--->
+         *              >> 	10:100  11:101
+         *              >> Element 1--->
+         *              >> 	80:800  81:9009
+         */
+        [[eosio::action]]
+        void prntvm(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored vector<mp_uint16>: size=", psn.vm.size()," content:\n");
+            int count=0;
+            for (const auto& mpval : psn.vm)
+            {
+                eosio::print("\nElement ", count++, "--->\n\t");
+                for (auto it2 = mpval.begin(); it2 != mpval.end(); ++it2)
+                    eosio::print(it2->first, ":", it2->second, "  ");
+            }
+
+        }
+
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setvp '[1, [{"first":18, "second":28}, {"first":19, "second":29}]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setvp(int id, const vector<pair<uint32_t, uint32_t> >& vp)
+        {
+            SETCONTAINERVAL(vp);
+            eosio::print("vector<pair<uint32_t, uint32_t> > stored successfully");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntvp '[1]' -p alice@active
+         *      output: >> stored vector<pair<uint32_t, uint32_t> >  size=2:
+         *              >> 18,28
+         *              >> 19,29
+         */
+        [[eosio::action]]
+        void prntvp(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored vector<pair<uint32_t, uint32_t> >  size=", psn.vp.size(), ":\n");
+            for (const auto& ele: psn.vp)
+            {
+                eosio::print(ele.first,",", ele.second,"\n");
+            }
+        }
+
+        //=== 3. Try optional - set,vector,optional,map,pair
+
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv setost '[1, null]' -p bob@active
+         *  cleos --verbose push action nestcontn2kv setost '[2, [1006,2006, 3006]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setost(int id, const optional<set_uint16>& ost)
+        {
+            SETCONTAINERVAL(ost);
+            eosio::print("type defined optional<set<T> > stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv  prntost '[1]' -p bob@active
+         *      output: >> stored optional<set_uint16>  vals:
+         *              >> NULL or no value
+         *
+         *  cleos --verbose push action nestcontn2kv  prntost '[2]' -p alice@active
+         *      output: >> stored optional<set_uint16>  vals:
+         *              >> 1006 2006 3006
+         */
+        [[eosio::action]]
+        void prntost(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored optional<set_uint16>  vals:\n");
+            if (psn.ost)
+            {
+                for (const auto& ele : psn.ost.value())
+                    eosio::print(ele, " ");
+            }
+            else
+                eosio::print("NULL or no value");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv setov '[1, null]' -p bob@active
+         *
+         *  cleos --verbose push action nestcontn2kv setov '[2, [1001,2001, 3001]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setov(int id, const optional<vec_uint16>& ov)
+        {
+            SETCONTAINERVAL(ov);
+            eosio::print("type defined optional<vector<T> > stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv  prntov '[1]' -p bob@active
+         *      output: >> stored optional<vec_uint16>  vals:
+         *              >> NULL or no value
+         *
+         *  cleos --verbose push action nestcontn2kv  prntov '[2]' -p alice@active
+         *      output: >> stored optional<vec_uint16>  vals:
+         *              >> 1001 2001 3001
+         */
+        [[eosio::action]]
+        void prntov(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored optional<vec_uint16>  vals:\n");
+            if (psn.ov)
+            {
+                for (const auto& ele : psn.ov.value())
+                    eosio::print(ele, " ");
+            }
+            else
+                eosio::print("NULL or no value");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv setoo '[1, null]' -p bob@active
+         *
+         *  cleos --verbose push action nestcontn2kv setoo '[2,123]' -p alice@active
+         */
+        [[eosio::action]]
+        void setoo(int id, const optional<op_uint16>& oo)
+        {
+            SETCONTAINERVAL(oo);
+            eosio::print("type defined optional<op_uint16> stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv  prntoo '[1]' -p bob@active
+         *      ouput: >> stored optional<optional<T>> val:null or no real value stored
+         *
+         *  cleos --verbose push action nestcontn2a  prntoo '[2]' -p alice@active
+         *      output: >> stored optional<optional<T>> val:123
+         */
+        [[eosio::action]]
+        void prntoo(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored optional<optional<T>> val:");
+            if (psn.oo && psn.oo.value())
+                eosio::print(psn.oo.value().value(),"\n");
+            else
+                eosio::print("null or no real value stored");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv  setom '[1,[{"first":10,"second":1000},{"first":11,"second":1001}] ]' -p alice@active
+         *
+         *  cleos --verbose push action nestcontn2kv  setom '[2, null ]' -p bob@active
+         */
+        [[eosio::action]]
+        void setom(int id, const optional<mp_uint16>& om)
+        {
+            SETCONTAINERVAL(om);
+            eosio::print("type defined optional<map<K, V> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntom '[1]' -p alice@active
+         *      output: >> size of stored om:2 vals:10:1000  11:1001
+         *
+         *  cleos --verbose push action nestcontn2kv  prntom '[2]' -p bob@active
+         *      output: >> optional<mp_uint16> has NULL value
+         */
+        [[eosio::action]]
+        void prntom(int id)
+        {
+            const auto& psn = get(id);
+            if (psn.om)
+            {
+                auto mpval = psn.om.value();
+                eosio::print("size of stored om:", mpval.size()," vals:");
+                for (auto it2 = mpval.begin(); it2 != mpval.end(); ++it2)
+                    eosio::print(it2->first, ":", it2->second, "  ");
+
+            }
+            else
+                eosio::print("optional<mp_uint16> has NULL value\n");
+        }
+
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv setop '[1, {"first":60, "second":61}]' -p alice@active
+         *
+         *  cleos --verbose push action nestcontn2kv setop '[2, null]' -p bob@active
+         */
+        [[eosio::action]]
+        void setop(int id, const optional<pr_unit16> & op)
+        {
+            SETCONTAINERVAL(op);
+            eosio::print("type-defined optional-pair optional<pr_unit16> stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv  prntop '[1]' -p alice@active
+         *      output: >> stored optional<pr_unit16> data:60 61
+         *
+         *  cleos --verbose push action nestcontn2kv  prntop '[2]' -p bob@active
+         *      output: >> optional<pr_unit16> has NULL value
+         */
+        [[eosio::action]]
+        void prntop(int id)
+        {
+            const auto& psn = get(id);
+            if (psn.op)
+                eosio::print("stored optional<pr_unit16> data:", psn.op.value().first, " ", psn.op.value().second);
+            else
+                eosio::print("optional<pr_unit16> has NULL value\n");
+        }
+
+        //=== 4. Try map - set,vector,optional,map,pair
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setmst '[1, [{"key":1,"value":[10,11,12,16]},  {"key":2,"value":[200,300]} ]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setmst(int id, const map<uint16_t, set_uint16> & mst)
+        {
+            SETCONTAINERVAL(mst);
+            eosio::print("type-defined map<K, set<T> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntmst '[1]' -p alice@active
+         *      output: >> stored map<uint16_t, set_uint16>: size=2 content:
+         *              >> 1:vals 10 11 12 16
+         *              >> 2:vals 200 300
+         */
+        [[eosio::action]]
+        void prntmst(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored map<uint16_t, set_uint16>: size=", psn.mst.size()," content:\n");
+            for (auto it2 = psn.mst.begin(); it2 != psn.mst.end(); ++it2)
+            {
+                    eosio::print(it2->first, ":", "vals ");
+                    for (const auto& ele: it2->second)
+                    {
+                        eosio::print(ele," ");
+                    }
+                    eosio::print("\n");
+            }
+        }
+
+
+
+        /*Example:
+         * cleos --verbose push action nestcontn2kv setmv '[1, [{"key":1,"value":[10,11,12,16]},  {"key":2,"value":[200,300]} ]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setmv(int id, const map<uint16_t, vec_uint16>& mv)
+        {
+            SETCONTAINERVAL(mv);
+            eosio::print("type defined map<K, vector<T> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntmv '[1]' -p alice@active
+         *      output: >> stored map<uint16_t, vec_uint16>: size=2 content:
+         *              >> 1:vals 10 11 12 16
+         *              >> 2:vals 200 300
+         */
+        [[eosio::action]]
+        void prntmv(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored map<uint16_t, vec_uint16>: size=", psn.mv.size()," content:\n");
+            for (auto it2 = psn.mv.begin(); it2 != psn.mv.end(); ++it2)
+            {
+                    eosio::print(it2->first, ":", "vals ");
+                    for (const auto& ele: it2->second)
+                    {
+                        eosio::print(ele," ");
+                    }
+                    eosio::print("\n");
+            }
+        }
+
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setmo '[1, [{"key":10,"value":1000},{"key":11,"value":null}]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setmo(int id, const map<uint16_t, op_uint16>& mo)
+        {
+            SETCONTAINERVAL(mo);
+            eosio::print("type defined map<K, optional<T> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntmo '[1]' -p alice@active
+         *      output: >> size of stored mo:2 vals
+         *              >> 10:1000 11:NULL
+         */
+        [[eosio::action]]
+        void prntmo(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("size of stored mo:", psn.mo.size()," vals\n");
+            for (auto it2 = psn.mo.begin(); it2 != psn.mo.end(); ++it2)
+            {
+                eosio::print(it2->first, ":");
+                if (it2->second)
+                    eosio::print(it2->second.value()," ");
+                else
+                    eosio::print("NULL ");
+            }
+        }
+
+        /*Example:
+         *  cleos push action nestcontn2kv setmm '[1, [{"key":10,"value":[{"first":200,"second":2000}, {"first":201,"second":2001}] }, {"key":11,"value":[{"first":300,"second":3000}, {"first":301,"second":3001}] } ]]' -p alice@active
+         *       Attention: please note the cleos input of mm or map<K1, map<K2, V> > is a combination of strings key/value and first/second !
+         *       i.e the "value" part of mm is an array of <first,second> pairs!
+         */
+        [[eosio::action]]
+        void setmm(int id, const map<uint16_t, mp_uint16>& mm)
+        {
+            SETCONTAINERVAL(mm);
+            eosio::print("type defined map<K1,map<K2, V> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntmm '[1]' -p alice@active
+         *      output: >> stored map<uint16_t, mp_uint16> val:size=2 vals are the following:
+         *              >> 10--->
+         *              >> 	200:2000
+         *              >> 	201:2001
+         *              >> 11--->
+         *              >> 	300:3000
+         *              >> 	301:3001
+         */
+        [[eosio::action]]
+        void prntmm(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored map<uint16_t, mp_uint16> val:");
+            eosio::print("size=", psn.mm.size()," vals are the following:\n");
+            for (auto it2 = psn.mm.begin(); it2 != psn.mm.end(); ++it2)
+            {
+                eosio::print(it2->first,"--->\n");
+                const auto& temp = it2->second;
+                for (auto it3 = temp.begin(); it3 != temp.end(); ++it3)
+                    eosio::print("\t",it3->first, ":", it3->second, "\n");
+            }
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setmp '[1, [{"key":36,"value":{"first":300, "second":301}}, {"key":37,"value":{"first":600, "second":601}} ]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setmp(int id, const map<uint16_t, pr_unit16> & mp)
+        {
+            SETCONTAINERVAL(mp);
+            eosio::print("type-defined map-pair map<uint16_t, pr_unit16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntmp '[1]' -p alice@active
+         *      output: >> size of stored mp:2 vals:
+         *              >> 36:300 301
+         *              >> 37:600 601
+         */
+        [[eosio::action]]
+        void prntmp(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("size of stored mp:", psn.mp.size()," vals:\n");
+            for (auto it2 = psn.mp.begin(); it2 != psn.mp.end(); ++it2)
+                eosio::print(it2->first, ":", it2->second.first, " ", it2->second.second, "\n");
+        }
+
+
+        //=== 5. Try pair - set,vector,optional,map,pair
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setpst '[1, {"first":20, "second":[200,201,202]}]' -p alice@active
+         */
+        [[eosio::action]]
+        void setpst(int id, const pair<uint32_t, set_uint16>& pst)
+        {
+            SETCONTAINERVAL(pst);
+            eosio::print("type-defined pair-set pair<uint32_t, set_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntpst '[1]' -p alice@active
+         *      output: >> content of stored pair<uint32_t, set_uint16>: first=20
+         *              >> second=200 201 202
+         */
+        [[eosio::action]]
+        void prntpst(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("content of stored pair<uint32_t, set_uint16>: first=", psn.pst.first, "\nsecond=");
+            for (const auto& ele: psn.pst.second)
+                eosio::print(ele, " ");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setpv '[1, {"first":10, "second":[100,101,102]}]' -p alice@active
+         */
+        [[eosio::action]]
+        void setpv(int id, const pair<uint32_t, vec_uint16>& pv)
+        {
+            SETCONTAINERVAL(pv);
+            eosio::print("type-defined pair-vector pair<uint32_t, vec_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntpv '[1]' -p alice@active
+         *      output: >> content of stored pair<uint32_t, vec_uint16>: first=10
+         *              >> second=100 101 102
+         */
+        [[eosio::action]]
+        void prntpv(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("content of stored pair<uint32_t, vec_uint16>: first=", psn.pv.first, "\nsecond=");
+            for (const auto& ele: psn.pv.second)
+                eosio::print(ele, " ");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv setpo '[1, {"first":70, "second":71}]' -p alice@active
+         *
+         *  cleos --verbose push action nestcontn2kv setpo '[2, {"first":70, "second":null}]' -p bob@active
+         */
+        [[eosio::action]]
+        void setpo(int id, const pair<uint32_t, op_uint16> & po)
+        {
+            SETCONTAINERVAL(po);
+            eosio::print("type-defined pair-optional pair<uint32_t, op_uint16> stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv  prntpo '[1]' -p alice@active
+         *      output: >> content of stored pair<uint16_t, op_unit16>: first=70
+         *              >> second=71
+         *
+         *  cleos --verbose push action nestcontn2a  prntpo '[2]' -p bob@active
+         *      output: >> content of stored pair<uint16_t, op_unit16>: first=70
+         *              >> second=NULL
+         */
+        [[eosio::action]]
+        void prntpo(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("content of stored pair<uint16_t, op_unit16>: first=", psn.po.first, "\nsecond=");
+            if (psn.po.second)
+                eosio::print(psn.po.second.value(), " ");
+            else
+                eosio::print("NULL ");
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setpm '[1, {"key":6, "value":[{"first":20,"second":300}, {"first":21,"second":301}] }]' -p alice@active
+         *      Remark: the data input for pm uses a combination of key/vale and first/second
+         */
+        [[eosio::action]]
+        void setpm(int id, const pair<uint16_t, mp_uint16> & pm)
+        {
+            SETCONTAINERVAL(pm);
+            eosio::print("type-defined pair-map pair<uint16_t, mp_uint16> stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action nestcontn2kv  prntpm '[1]' -p alice@active
+         *      output: >> content of stored pair<uint16_t, mp_uint16>: first=6
+         *              >> second=20:300  21:301
+         */
+        [[eosio::action]]
+        void prntpm(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("content of stored pair<uint16_t, mp_uint16>: first=", psn.pm.first, "\nsecond=");
+            for (auto it2 = psn.pm.second.begin(); it2 != psn.pm.second.end(); ++it2)
+                eosio::print(it2->first, ":", it2->second, "  ");
+        }
+
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setpp '[1, {"key":30, "value":{"first":301, "second":302} }]' -p alice@active
+         *      Remark: input data for pp or pair-pair is a combination of key/value and first/second
+         */
+        [[eosio::action]]
+        void setpp(int id, const pair<uint16_t, pr_unit16> & pp)
+        {
+            SETCONTAINERVAL(pp);
+            eosio::print("type-defined pair-pair pair<uint16_t, pr_unit16> stored successfully!");
+        }
+
+        /*Example:
+         * cleos --verbose push action nestcontn2kv  prntpp '[1]' -p alice@active
+         *      output: >> content of stored pair<uint16_t, pr_unit16>: first=30
+         *              >> second=301 302
+         */
+        [[eosio::action]]
+        void prntpp(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("content of stored pair<uint16_t, pr_unit16>: first=", psn.pp.first, "\nsecond=");
+            eosio::print(psn.pp.second.first, " ", psn.pp.second.second);
+        }
+
+
+        //Try an example of 3-layer nested container
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv setovv '[1, [[21,22],[230], [240,250,260,280]]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setovv(int id, const optional<vecvec_uint32>& ovv)
+        {
+            // try type-defined 3-layer nested container optional<vector<vector<T> > > here
+            SETCONTAINERVAL(ovv);
+            eosio::print("type-defined optional<vecvec_uint32> stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action nestcontn2kv  prntovv '[1]' -p alice@active
+         *      output: >> stored optional<vector<vector<T> > > vals:
+         *              >> 21 22
+         *              >> 230
+         *              >> 240 250 260 280
+         */
+        [[eosio::action]]
+        void prntovv(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored optional<vector<vector<T> > > vals:\n");
+            if (psn.ovv)
+            {
+              auto v2 = psn.ovv.value();
+              for (int i=0 ; i < v2.size(); i++)
+              {
+                for (int j=0; j < v2[i].size(); j++)
+                    eosio::print(v2[i][j], " ");
+                eosio::print("\n");
+              }
+            }
+            else
+                eosio::print("stored optional<vector<vector<T> > >  has null value!");
+        }
+
+        //Example: cleos --verbose push action nestcontn2kv erase '["bob", 2]' -p bob@active
+        [[eosio::action]]
+        void erase(name user, int id)
+        {
+            require_auth(user);
+            eosio::print (user, " is requesting to erase the record with key=", id, "\n");
+            auto iter = mymap.find(id);
+            check(iter != mymap.end(), "cannot erase: Record with given id does not exist");
+            mymap.erase(id);
+            eosio::print("record with id=", id, " is successfully erased!");
+        }
+
+        //Example: cleos --verbose push action nestcontn2kv prntallkeys '["bob"]' -p bob@active
+        [[eosio::action]]
+        void prntallkeys(name user)
+        {
+            //print all keys stored in this block chain for this contract
+            require_auth(user);
+            eosio::print (user, " is requesting prntallkeys\n");
+            if (mymap.empty())
+                eosio::print ("mymap is empty, no key in mymap!");
+
+            eosio::print("mymap keys include:\n");
+            for ( const auto& item : mymap )
+            {
+                eosio::print(item.first(), "\n");
+            }
+        }
+
+        //Example: cleos --verbose push action nestcontn2kv get2 '["str1"]' -p alice@active
+        [[eosio::action]]
+        person2kv get2(string id)
+        {
+            auto iter = mymap2.find(id);
+            check(iter != mymap2.end(), "Record does not exist");
+            const auto& item_found = iter->second();
+            return item_found;
+        }
+
+        /*Examples:
+        * cleos --verbose push action nestcontn2kv setv2 '["str1",[102,202,302,602]]' -p alice@active
+        * cleos --verbose push action nestcontn2kv setv2 '["str2", []]' -p bob@active
+        */
+        [[eosio::action]]
+        void setv2(string id, const vector<uint16_t>& v)
+        {
+            SETCONTAINERVALN(2, v);
+            eosio::print("vector<uint16_t> stored successfully");
+        }
+
+        /*Examples:
+        *  cleos --verbose push action nestcontn2kv prntv2 '["str1"]' -p alice@active
+        *      output: >> size of stored v:4 vals:102,202,302,602,
+        *
+        *  cleos --verbose push action nestcontn2kv prntv2 '["str2"]' -p bob@active
+        *      output: >> size of stored v:0 vals:
+        */
+        [[eosio::action]]
+        void prntv2(string id)
+        {
+            const auto& psn = get2(id);
+            eosio::print("size of stored v:", psn.v.size()," vals:");
+            for (const auto & ele : psn.v)
+                eosio::print(ele, ",");
+        }
+
+
+        //Example: cleos --verbose push action nestcontn2kv get3 '["name1"]' -p alice@active
+        [[eosio::action]]
+        person2kv get3(name id)
+        {
+            auto iter = mymap3.find(id);
+            check(iter != mymap3.end(), "Record does not exist");
+            const auto& item_found = iter->second();
+            return item_found;
+        }
+
+        /*Examples:
+        * cleos --verbose push action nestcontn2kv setv3 '["name1",[103,203,303,603]]' -p alice@active
+        * cleos --verbose push action nestcontn2kv setv3 '["name2", []]' -p bob@active
+        */
+        [[eosio::action]]
+        void setv3(name id, const vector<uint16_t>& v)
+        {
+            SETCONTAINERVALN(3, v);
+            eosio::print("vector<uint16_t> stored successfully");
+        }
+
+        /*Examples:
+        *  cleos --verbose push action nestcontn2kv prntv3 '["name1"]' -p alice@active
+        *      output: >> size of stored v:4 vals:103,203,303,603,
+        *
+        *  cleos --verbose push action nestcontn2kv prntv3 '["name2"]' -p bob@active
+        *      output: >> size of stored v:0 vals:
+        */
+        [[eosio::action]]
+        void prntv3(name id)
+        {
+            const auto& psn = get3(id);
+            eosio::print("size of stored v:", psn.v.size()," vals:");
+            for (const auto & ele : psn.v)
+                eosio::print(ele, ",");
+        }
+
+
+        //Example: cleos --verbose push action nestcontn2kv get4 '[{"_count":18, "_strID":"dumstr"}]' -p alice@active
+        [[eosio::action]]
+        person2kv get4(mystructrefl id)
+        {
+            auto iter = mymap4.find(id);
+            check(iter != mymap4.end(), "Record does not exist");
+            const auto& item_found = iter->second();
+            return item_found;
+        }
+
+        /*Examples:
+        * cleos --verbose push action nestcontn2kv setv4 '[{"_count":18, "_strID":"dumstr"},[104,204,304,604]]' -p alice@active
+        * cleos --verbose push action nestcontn2kv setv4 '[{"_count":11, "_strID":"dumstr1"}, []]' -p bob@active
+        */
+        [[eosio::action]]
+        void setv4(mystructrefl id, const vector<uint16_t>& v)
+        {
+            SETCONTAINERVALN(4, v);
+            eosio::print("vector<uint16_t> stored successfully");
+        }
+
+        /*Examples:
+        *  cleos --verbose push action nestcontn2kv prntv4 '[{"_count":18, "_strID":"dumstr"}]' -p alice@active
+        *      output: >> size of stored v:4 vals:104,204,304,604,
+        *
+        *  cleos --verbose push action nestcontn2kv prntv4 '[{"_count":11, "_strID":"dumstr1"}]' -p bob@active
+        *      output: >> size of stored v:0 vals:
+        */
+        [[eosio::action]]
+        void prntv4(mystructrefl id)
+        {
+            const auto& psn = get4(id);
+            eosio::print("size of stored v:", psn.v.size()," vals:");
+            for (const auto & ele : psn.v)
+                eosio::print(ele, ",");
+        }
+
+        //The following are needed for eosio-cpp compiler to identify the actions in genearted .abi
+        using get_action = eosio::action_wrapper<"get"_n, &nestcontn2kv::get>;
+        using erase_action = eosio::action_wrapper<"erase"_n, &nestcontn2kv::erase>;
+        using prntallkeys_action = eosio::action_wrapper<"prntallkeys"_n, &nestcontn2kv::prntallkeys>;
+
+        using setv_action = eosio::action_wrapper<"setv"_n, &nestcontn2kv::setv>;
+        using prntv_action = eosio::action_wrapper<"prntv"_n, &nestcontn2kv::prntv>;
+        using setst_action = eosio::action_wrapper<"setst"_n, &nestcontn2kv::setst>;
+        using prntst_action = eosio::action_wrapper<"prntst"_n, &nestcontn2kv::prntst>;
+        using setm_action = eosio::action_wrapper<"setm"_n, &nestcontn2kv::setm>;
+        using prntm_action = eosio::action_wrapper<"prntm"_n, &nestcontn2kv::prntm>;
+        using sets_action = eosio::action_wrapper<"sets"_n, &nestcontn2kv::sets>;
+        using prnts_action = eosio::action_wrapper<"prnts"_n, &nestcontn2kv::prnts>;
+        using sets2_action = eosio::action_wrapper<"sets2"_n, &nestcontn2kv::sets2>;
+        using prnts2_action = eosio::action_wrapper<"prnts2"_n, &nestcontn2kv::prnts2>;
+        using setvs_action = eosio::action_wrapper<"setvs"_n, &nestcontn2kv::setvs>;
+        using prntvs_action = eosio::action_wrapper<"prntvs"_n, &nestcontn2kv::prntvs>;
+        using seto_action = eosio::action_wrapper<"seto"_n, &nestcontn2kv::seto>;
+        using prnto_action = eosio::action_wrapper<"prnto"_n, &nestcontn2kv::prnto>;
+        using setp_action = eosio::action_wrapper<"setp"_n, &nestcontn2kv::setp>;
+        using prntp_action = eosio::action_wrapper<"prntp"_n, &nestcontn2kv::prntp>;
+
+        using setstst_action = eosio::action_wrapper<"setstst"_n, &nestcontn2kv::setstst>;
+        using prntstst_action = eosio::action_wrapper<"prntstst"_n, &nestcontn2kv::prntstst>;
+        using setstv_action = eosio::action_wrapper<"setstv"_n, &nestcontn2kv::setstv>;
+        using prntstv_action = eosio::action_wrapper<"prntstv"_n, &nestcontn2kv::prntstv>;
+        using setsto_action = eosio::action_wrapper<"setsto"_n, &nestcontn2kv::setsto>;
+        using prntsto_action = eosio::action_wrapper<"prntsto"_n, &nestcontn2kv::prntsto>;
+        using setstm_action = eosio::action_wrapper<"setstm"_n, &nestcontn2kv::setstm>;
+        using prntstm_action = eosio::action_wrapper<"prntstm"_n, &nestcontn2kv::prntstm>;
+        using setstp_action = eosio::action_wrapper<"setstp"_n, &nestcontn2kv::setstp>;
+        using prntstp_action = eosio::action_wrapper<"prntstp"_n, &nestcontn2kv::prntstp>;
+
+        using setvst_action = eosio::action_wrapper<"setvst"_n, &nestcontn2kv::setvst>;
+        using prntvst_action = eosio::action_wrapper<"prntvst"_n, &nestcontn2kv::prntvst>;
+        using setvv_action = eosio::action_wrapper<"setvv"_n, &nestcontn2kv::setvv>;
+        using prntvv_action = eosio::action_wrapper<"prntvv"_n, &nestcontn2kv::prntvv>;
+        using setvo_action = eosio::action_wrapper<"setvo"_n, &nestcontn2kv::setvo>;
+        using prntvo_action = eosio::action_wrapper<"prntvo"_n, &nestcontn2kv::prntvo>;
+        using setvm_action = eosio::action_wrapper<"setvm"_n, &nestcontn2kv::setvm>;
+        using prntvm_action = eosio::action_wrapper<"prntvm"_n, &nestcontn2kv::prntvm>;
+        using setvp_action = eosio::action_wrapper<"setvp"_n, &nestcontn2kv::setvp>;
+        using prntvp_action = eosio::action_wrapper<"prntvp"_n, &nestcontn2kv::prntvp>;
+
+        using setost_action = eosio::action_wrapper<"setost"_n, &nestcontn2kv::setost>;
+        using prntost_action = eosio::action_wrapper<"prntost"_n, &nestcontn2kv::prntost>;
+        using setov_action = eosio::action_wrapper<"setov"_n, &nestcontn2kv::setov>;
+        using prntov_action = eosio::action_wrapper<"prntov"_n, &nestcontn2kv::prntov>;
+        using setoo_action = eosio::action_wrapper<"setoo"_n, &nestcontn2kv::setoo>;
+        using prntoo_action = eosio::action_wrapper<"prntoo"_n, &nestcontn2kv::prntoo>;
+        using setom_action = eosio::action_wrapper<"setom"_n, &nestcontn2kv::setom>;
+        using prntom_action = eosio::action_wrapper<"prntom"_n, &nestcontn2kv::prntom>;
+        using setop_action = eosio::action_wrapper<"setop"_n, &nestcontn2kv::setop>;
+        using prntop_action = eosio::action_wrapper<"prntop"_n, &nestcontn2kv::prntop>;
+
+        using setmst_action = eosio::action_wrapper<"setmst"_n, &nestcontn2kv::setmst>;
+        using prntmst_action = eosio::action_wrapper<"prntmst"_n, &nestcontn2kv::prntmst>;
+        using setmv_action = eosio::action_wrapper<"setmv"_n, &nestcontn2kv::setmv>;
+        using prntmv_action = eosio::action_wrapper<"prntmv"_n, &nestcontn2kv::prntmv>;
+        using setmo_action = eosio::action_wrapper<"setmo"_n, &nestcontn2kv::setmo>;
+        using prntmo_action = eosio::action_wrapper<"prntmo"_n, &nestcontn2kv::prntmo>;
+        using setmm_action = eosio::action_wrapper<"setmm"_n, &nestcontn2kv::setmm>;
+        using prntmm_action = eosio::action_wrapper<"prntmm"_n, &nestcontn2kv::prntmm>;
+        using setmp_action = eosio::action_wrapper<"setmp"_n, &nestcontn2kv::setmp>;
+        using prntmp_action = eosio::action_wrapper<"prntmp"_n, &nestcontn2kv::prntmp>;
+
+        using setpst_action = eosio::action_wrapper<"setpst"_n, &nestcontn2kv::setpst>;
+        using prntpst_action = eosio::action_wrapper<"prntpst"_n, &nestcontn2kv::prntpst>;
+        using setpv_action = eosio::action_wrapper<"setpv"_n, &nestcontn2kv::setpv>;
+        using prntpv_action = eosio::action_wrapper<"prntpv"_n, &nestcontn2kv::prntpv>;
+        using setpo_action = eosio::action_wrapper<"setpo"_n, &nestcontn2kv::setpo>;
+        using prntpo_action = eosio::action_wrapper<"prntpo"_n, &nestcontn2kv::prntpo>;
+        using setpm_action = eosio::action_wrapper<"setpm"_n, &nestcontn2kv::setpm>;
+        using prntpm_action = eosio::action_wrapper<"prntpm"_n, &nestcontn2kv::prntpm>;
+        using setpp_action = eosio::action_wrapper<"setpp"_n, &nestcontn2kv::setpp>;
+        using prntpp_action = eosio::action_wrapper<"prntpp"_n, &nestcontn2kv::prntpp>;
+
+        using setovv_action = eosio::action_wrapper<"setovv"_n, &nestcontn2kv::setovv>;
+        using prntovv_action = eosio::action_wrapper<"prntovv"_n, &nestcontn2kv::prntovv>;
+
+        using get2_action = eosio::action_wrapper<"get2"_n, &nestcontn2kv::get2>;
+        using setv2_action = eosio::action_wrapper<"setv2"_n, &nestcontn2kv::setv2>;
+        using prntv2_action = eosio::action_wrapper<"prntv2"_n, &nestcontn2kv::prntv2>;
+
+        using get3_action = eosio::action_wrapper<"get3"_n, &nestcontn2kv::get3>;
+        using setv3_action = eosio::action_wrapper<"setv3"_n, &nestcontn2kv::setv3>;
+        using prntv3_action = eosio::action_wrapper<"prntv3"_n, &nestcontn2kv::prntv3>;
+
+        using get4_action = eosio::action_wrapper<"get4"_n, &nestcontn2kv::get4>;
+        using setv4_action = eosio::action_wrapper<"setv4"_n, &nestcontn2kv::setv4>;
+        using prntv4_action = eosio::action_wrapper<"prntv4"_n, &nestcontn2kv::prntv4>;
+};
+

--- a/tests/toolchain/build-pass/nestcontn2kv.json
+++ b/tests/toolchain/build-pass/nestcontn2kv.json
@@ -1,0 +1,10 @@
+{
+    "tests": [
+        {
+            "expected": {
+                "exit-code": 0
+            }
+        }
+    ]
+}
+

--- a/tests/toolchain/build-pass/tupletest.cpp
+++ b/tests/toolchain/build-pass/tupletest.cpp
@@ -1,0 +1,518 @@
+/* Verify the support of nested containers involving std::tuple<Ts...> in eosio multi-index table
+ * This tupletest.cpp can be  regarded as a continuation of ../nestcontn2a.cpp
+ * For each action, an example regarding how to use the action with the cleos command line is given.
+ *
+ * Important Remarks:
+ *      1) The input of a std::tuple<T0,T1,T2> via cleos uses [ele0, ele1, ele2], it is the same as the input of a vector/set
+ *      2) However the input formats of settm,settp are different from those of corresponding setvm, setvp in nestcontn2a.cpp
+ *      3) More importantly, vector<optional<T> > and set<optional<T> >  are NOT yet supported as shown in nestcontn2a.cpp,
+ *         BUT tuple of optional<T> is supported as shown here in this tupletest.cpp
+ *
+ * Expected printout:
+ *      For each setx action, the printed result on the cleos console is given in its corresponding prntx action.
+ */
+
+#include <eosio/eosio.hpp>
+
+#include <vector>
+#include <set>
+#include <optional>
+#include <map>
+#include <tuple>
+
+using namespace eosio;
+using namespace std;
+
+#define  SETCONTAINERVAL(x) do { \
+        require_auth(user); \
+        psninfoindex2 tblIndex(get_self(), get_first_receiver().value); \
+        auto iter = tblIndex.find(user.value); \
+        if (iter == tblIndex.end()) \
+        { \
+            tblIndex.emplace(user, [&](auto &row) { \
+                        row.key = user; \
+                        row.x = x; \
+                    }); \
+        } \
+        else \
+        { \
+            tblIndex.modify(iter, user, [&]( auto& row ) { \
+                        row.x = x; \
+                    }); \
+        } \
+    }while(0)
+
+#define PRNTCHECK() require_auth(user); \
+        psninfoindex2 tblIndex(get_self(), get_first_receiver().value); \
+        auto iter = tblIndex.find(user.value); \
+        check(iter != tblIndex.end(), "Record does not exist");
+
+
+// use typedefs to make multi-layer nested containers work!
+typedef vector<uint16_t> vec_uint16;
+typedef set<uint16_t> set_uint16;
+typedef optional<uint16_t> op_uint16;
+typedef map<uint16_t, uint16_t> mp_uint16;
+typedef pair<uint16_t, uint16_t> pr_uint16;
+
+typedef tuple<uint16_t, uint16_t> tup_uint16;
+
+class [[eosio::contract("tupletest")]] tupletest : public eosio::contract {
+    private:
+        struct [[eosio::table]] person2 {
+            name key;
+
+            //  Each container/object is represented by one letter: v-vector, m-map, s-mystruct,o-optional, p-pair, t - tuple
+            //  with exceptions:     s2 - mystruct2,    st - set
+
+            tuple<uint16_t, string> t;
+
+            //Two-layer nested-container involving tuple
+            vector<tup_uint16> vt;
+            set<tup_uint16> stt;
+            optional<tup_uint16> ot;
+            map<uint16_t, tup_uint16> mt;
+            pair<uint32_t, tup_uint16> pt;
+            tuple<tup_uint16, tup_uint16,  tup_uint16> tt;
+
+            tuple<uint16_t, vec_uint16, vec_uint16> tv;     //tuple of vectors
+            tuple<uint16_t, set_uint16, set_uint16> tst;
+            tuple<op_uint16, op_uint16, op_uint16,op_uint16,op_uint16> to;
+            tuple<uint16_t, mp_uint16, mp_uint16> tm;
+            tuple<uint16_t, pr_uint16, pr_uint16> tp;       //tuple of pairs
+
+            tuple<string, vec_uint16, pr_uint16> tmisc;     //tuple of misc. types
+
+
+
+            uint64_t primary_key() const { return key.value; }
+        };
+        using psninfoindex2 = eosio::multi_index<"people2"_n, person2>;
+
+
+    public:
+        using contract::contract;
+
+        tupletest(name receiver, name code,  datastream<const char*> ds): contract(receiver, code, ds) {}
+
+        /*Examples:
+         * cleos --verbose push action tupletest sett '["alice", [100,"strA"]]' -p alice@active
+         * cleos --verbose push action tupletest sett '["bob", [200, "strB"]]' -p bob@active
+          */
+        [[eosio::action]]
+        void sett(name user, const tuple<uint16_t, string>& t)
+        {
+            SETCONTAINERVAL(t);
+            eosio::print("tuple<uint16_t, string> stored successfully");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action tupletest prntt '["alice"]' -p alice@active
+         *      output: >> elements of stored tuple t:100, strA
+         *
+         *  cleos --verbose push action tupletest prntt '["bob"]' -p bob@active
+         *      output: >> elements of stored tuple t:200, strB
+         */
+        [[eosio::action]]
+        void prntt(name user)
+        {
+            PRNTCHECK();
+            eosio::print("elements of stored tuple t:", std::get<0>(iter->t), ", ", std::get<1>(iter->t));
+        }
+
+        //=== 1. Try other containers (vector,set,optional,map,pair,tuple)  of tuples
+
+        //Example: cleos --verbose push action tupletest setvt '["alice", [[10,20],[30,60], [80,90]]]' -p alice@active
+        [[eosio::action]]
+        void setvt(name user, const vector<tup_uint16>& vt)
+        {
+            SETCONTAINERVAL(vt);
+            eosio::print("type defined vector<tup_uint16>  or vector<tuple<Ts...> stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletest  prntvt '["alice"]' -p alice@active
+         *      output: >> stored vector<tuple<Ts...> vals:
+         *              >> 10 20
+         *              >> 30 60
+         *              >> 80 90
+         */
+        [[eosio::action]]
+        void prntvt(name user)
+        {
+
+            PRNTCHECK();
+            eosio::print("stored vector<tuple<Ts...> vals:\n");
+            for (int i=0 ; i < iter->vt.size(); i++)
+            {
+                eosio::print(std::get<0>(iter->vt[i]), " ", std::get<1>(iter->vt[i]));
+                eosio::print("\n");
+            }
+        }
+
+        //Example: cleos --verbose push action tupletest  setstt '["alice", [[1,2],[3,6], [8,9]]]' -p alice@active
+        [[eosio::action]]
+        void setstt(name user, const set<tup_uint16> & stt)
+        {
+            SETCONTAINERVAL(stt);
+            eosio::print("type defined set<tup_uint16> or set<tuple<Ts...> stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletest   prntstt '["alice"]' -p alice@active
+         *      output: >> stored set<tuple<Ts...> vals:
+         *              >> 1 2
+         *              >> 3 6
+         *              >> 8 9
+         */
+        [[eosio::action]]
+        void prntstt(name user)
+        {
+
+            PRNTCHECK();
+            eosio::print("stored set<tuple<Ts...> vals:\n");
+            for (auto it1=iter->stt.begin(); it1!= iter->stt.end(); it1++)
+            {
+                eosio::print(std::get<0>(*it1), " ", std::get<1>(*it1));
+                eosio::print("\n");
+            }
+        }
+
+
+        /*Examples:
+         *  cleos --verbose push action tupletest setot '["bob", null]' -p bob@active
+         *
+         *  cleos --verbose push action tupletest setot '["alice", [1001,2001]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setot(name user, const optional<tup_uint16> & ot)
+        {
+            SETCONTAINERVAL(ot);
+            eosio::print("type defined optional<tuple<Ts...> > stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action tupletest  prntot '["bob"]' -p bob@active
+         *      output: >> stored optional<tup_uint16>  vals:
+         *              >> NULL or no value
+         *
+         *  cleos --verbose push action tupletest  prntot '["alice"]' -p alice@active
+         *      output: >> stored optional<tup_uint16>  vals:
+         *              >> 1001 2001
+         */
+        [[eosio::action]]
+        void prntot(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored optional<tup_uint16>  vals:\n");
+            if (iter->ot)
+            {
+                eosio::print(std::get<0>(iter->ot.value()), " ", std::get<1>(iter->ot.value()));
+            }
+            else
+                eosio::print("NULL or no value");
+        }
+
+
+
+        /*Example:
+         * cleos --verbose push action tupletest setmt '["alice", [{"key":1,"value":[10,11]},  {"key":2,"value":[200,300]} ]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setmt(name user, const map<uint16_t, tup_uint16> & mt)
+        {
+            SETCONTAINERVAL(mt);
+            eosio::print("type defined map<K, tuple<Ts...> > stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletest  prntmt '["alice"]' -p alice@active
+         *      output: >> stored map<uint16_t, vec_uint16>: size=2 content:
+         *              >> 1:vals 10 11
+         *              >> 2:vals 200 300
+         */
+        [[eosio::action]]
+        void prntmt(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored map<uint16_t, tup_uint16>: size=", iter->mt.size()," content:\n");
+            for (auto it2 = iter->mt.begin(); it2 != iter->mt.end(); ++it2)
+            {
+                    eosio::print(it2->first, ":", "vals ");
+                    eosio::print(std::get<0>(it2->second), " ", std::get<1>(it2->second));
+                    eosio::print("\n");
+            }
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletest setpt '["alice", {"first":10, "second":[100,101]}]' -p alice@active
+         */
+        [[eosio::action]]
+        void setpt(name user, const pair<uint32_t, tup_uint16>& pt)
+        {
+            SETCONTAINERVAL(pt);
+            eosio::print("type-defined pair-tuple pair<uint32_t, tup_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletest  prntpt '["alice"]' -p alice@active
+         *      output: >> content of stored pair<uint32_t, tup_uint16>: first=10
+         *              >> second=100 101
+         */
+        [[eosio::action]]
+        void prntpt(name user)
+        {
+            PRNTCHECK();
+            eosio::print("content of stored pair<uint32_t, tup_uint16>: first=", iter->pt.first, "\nsecond=");
+            eosio::print(std::get<0>(iter->pt.second), " ", std::get<1>(iter->pt.second));
+        }
+
+        //Example: cleos --verbose push action tupletest settt '["alice", [[1,2],[30,40], [50,60]]]' -p alice@active
+        [[eosio::action]]
+        void settt(name user, const tuple<tup_uint16, tup_uint16,  tup_uint16>& tt)
+        {
+            SETCONTAINERVAL(tt);
+            eosio::print("type defined tuple<tuple<Ts...> > stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletest  prnttt '["alice"]' -p alice@active
+         *      output: >> stored tuple<tup_uint16, tup_uint16,  tup_uint16> vals:
+         *              >> 1 2
+         *              >> 30 40
+         *              >> 50 60
+         */
+        [[eosio::action]]
+        void prnttt(name user)
+        {
+
+            PRNTCHECK();
+            eosio::print("stored tuple<tup_uint16, tup_uint16,  tup_uint16> vals:\n");
+            const auto& ele0 = std::get<0>(iter->tt);
+            const auto& ele1 = std::get<1>(iter->tt);
+            const auto& ele2 = std::get<2>(iter->tt);
+
+            eosio::print(std::get<0>(ele0), " ", std::get<1>(ele0), "\n");
+            eosio::print(std::get<0>(ele1), " ", std::get<1>(ele1), "\n");
+            eosio::print(std::get<0>(ele2), " ", std::get<1>(ele2), "\n");
+        }
+
+        //=== 2. Try tuple of other containers (vector,set,optional,map,pair)
+
+         //Example: cleos --verbose push action tupletest settv '["alice", [16,[26,36], [46,506,606]]]' -p alice@active
+        [[eosio::action]]
+        void settv(name user, const tuple<uint16_t, vec_uint16, vec_uint16>& tv)
+        {
+            SETCONTAINERVAL(tv);
+            eosio::print("type defined tuple<uint16_t, vec_uint16, vec_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletest  prnttv '["alice"]' -p alice@active
+         *      output: >> stored tuple<uint16_t, vec_uint16, vec_uint16>  vals:
+         *              >> ele0: 16
+         *              >> ele1: 26 36
+         *              >> ele2: 46 506 606
+         */
+        [[eosio::action]]
+        void prnttv(name user)
+        {
+
+            PRNTCHECK();
+
+            eosio::print("stored tuple<uint16_t, vec_uint16, vec_uint16>  vals:\n");
+
+            auto printVec = [](vec_uint16 v) {//eosio-cpp compiler allows c++11 usage such as lambda
+                for (int i=0; i < v.size();i++)
+                    eosio::print(v[i]," ");
+                eosio::print("\n");
+            };
+            eosio::print("ele0: ", std::get<0>(iter->tv),"\n");
+            eosio::print("ele1: "); printVec(std::get<1>(iter->tv));
+            eosio::print("ele2: "); printVec(std::get<2>(iter->tv));
+        }
+
+         //Example: cleos --verbose push action tupletest settst '["alice", [10,[21,31], [41,51,61]]]' -p alice@active
+        [[eosio::action]]
+        void settst(name user, const tuple<uint16_t, set_uint16, set_uint16>& tst)
+        {
+            SETCONTAINERVAL(tst);
+            eosio::print("type defined tuple<uint16_t, set_uint16, set_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletest  prnttst '["alice"]' -p alice@active
+         *      output: >> stored tuple<uint16_t, set_uint16, set_uint16>  vals:
+         *              >> ele0: 10
+         *              >> ele1: 21 31
+         *              >> ele2: 41 51 61
+         */
+        [[eosio::action]]
+        void prnttst(name user)
+        {
+
+            PRNTCHECK();
+
+            eosio::print("stored tuple<uint16_t, set_uint16, set_uint16> vals:\n");
+
+            auto printSet = [](set_uint16 s) {
+                for (auto it = s.begin(); it !=s.end(); it++ )
+                    eosio::print(*it, " ");
+                eosio::print("\n");
+            };
+            eosio::print("ele0: ", std::get<0>(iter->tst),"\n");
+            eosio::print("ele1: "); printSet(std::get<1>(iter->tst));
+            eosio::print("ele2: "); printSet(std::get<2>(iter->tst));
+        }
+
+        /*Examples:
+         *  cleos --verbose push action tupletest  setto '["alice", [100, null, 200, null, 300]]' -p alice@active
+         *
+         *  cleos --verbose push action tupletest  setto '["bob", [null, null, 10, null, 20]]' -p bob@active
+         *      Remark: Yes, tuple of optionals is supported here !
+         */
+        [[eosio::action]]
+        void setto(name user, const tuple<op_uint16, op_uint16, op_uint16,op_uint16,op_uint16> & to)
+        {
+            SETCONTAINERVAL(to);
+            eosio::print("type defined tuple<op_uint16, op_uint16, op_uint16,op_uint16,op_uint16> stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action tupletest  prntto '["alice"]' -p alice@active
+         *      output: >> stored tuple<op_uint16, op_uint16, op_uint16,op_uint16,op_uint16> vals:
+         *              >> 100 NULL 200 NULL 300
+         *
+         *  cleos --verbose push action tupletest  prntto '["bob"]' -p bob@active
+         *      output: >> stored tuple<op_uint16, op_uint16, op_uint16,op_uint16,op_uint16> vals:
+         *              >> NULL NULL 10 NULL 20
+         */
+        [[eosio::action]]
+        void prntto(name user)
+        {
+            PRNTCHECK();
+            eosio::print("stored tuple<op_uint16, op_uint16, op_uint16,op_uint16,op_uint16> vals:\n");
+            auto printOptional = [](op_uint16 op) {
+                if (op)
+                    eosio::print(op.value(),  " ");
+                else
+                    eosio::print("NULL", " ");
+            };
+
+            printOptional(std::get<0>(iter->to));
+            printOptional(std::get<1>(iter->to));
+            printOptional(std::get<2>(iter->to));
+            printOptional(std::get<3>(iter->to));
+            printOptional(std::get<4>(iter->to));
+            eosio::print("\n");
+        }
+
+
+        //Example: cleos --verbose push action tupletest settm '["alice", [126, [{"key":10,"value":100},{"key":11,"value":101}], [{"key":80,"value":800},{"key":81,"value":9009}] ]]' -p alice@active
+        //         ******Note: The input format of settm is different from that of setvm in nestcontn2a.cpp!
+        [[eosio::action]]
+        void settm(name user, const tuple<uint16_t, mp_uint16, mp_uint16>& tm)
+        {
+            SETCONTAINERVAL(tm);
+            eosio::print("type defined tuple<uint16_t, mp_uint16, mp_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletest  prnttm '["alice"]' -p alice@active
+         *      output: >> stored tuple<uint16_t, mp_uint16, mp_uint16> vals:
+         *              >> ele0: 126
+         *              >> ele1: 10:100 11:101
+         *              >> ele2: 80:800 81:9009
+         */
+        [[eosio::action]]
+        void prnttm(name user)
+        {
+
+            PRNTCHECK();
+
+            eosio::print("stored tuple<uint16_t, mp_uint16, mp_uint16> vals:\n");
+
+            auto printMap = [](mp_uint16 m) {
+                for (auto it = m.begin(); it !=m.end(); it++ )
+                    eosio::print(it->first, ":", it->second, " ");
+                eosio::print("\n");
+            };
+            eosio::print("ele0: ", std::get<0>(iter->tm),"\n");
+            eosio::print("ele1: "); printMap(std::get<1>(iter->tm));
+            eosio::print("ele2: "); printMap(std::get<2>(iter->tm));
+        }
+
+        //Example:  cleos --verbose push action tupletest settp '["alice", [127, {"key":18, "value":28}, {"key":19, "value":29}]]' -p alice@active
+        //         ******Note: The input format of settp is different from that of setvp in nestcontn2a.cpp!
+        [[eosio::action]]
+        void settp(name user, const tuple<uint16_t, pr_uint16, pr_uint16>& tp)
+        {
+            SETCONTAINERVAL(tp);
+            eosio::print("type defined tuple<uint16_t, pr_uint16, pr_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletest  prnttp '["alice"]' -p alice@active
+         *      output: >> stored tuple<uint16_t, pr_unit16, pr_unit16> vals:
+         *              >> ele0: 127
+         *              >> ele1: 18:28
+         *              >> ele2: 19:29
+         */
+        [[eosio::action]]
+        void prnttp(name user)
+        {
+
+            PRNTCHECK();
+
+            eosio::print("stored tuple<uint16_t, pr_unit16, pr_unit16> vals:\n");
+
+            auto printPair = [](pr_uint16 p) {
+                eosio::print(p.first, ":", p.second);
+                eosio::print("\n");
+            };
+            eosio::print("ele0: ", std::get<0>(iter->tp),"\n");
+            eosio::print("ele1: "); printPair(std::get<1>(iter->tp));
+            eosio::print("ele2: "); printPair(std::get<2>(iter->tp));
+        }
+
+        //Example: cleos --verbose push action tupletest settmisc '["alice", ["strHere", [10,11,12,16], {"key":86,"value":96}] ]' -p alice@active
+        [[eosio::action]]
+        void settmisc(name user, const tuple<string, vec_uint16, pr_uint16>  & tmisc)
+        {
+            SETCONTAINERVAL(tmisc);
+            eosio::print("type defined tuple<string, vec_uint16, pr_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletest  prnttmisc '["alice"]' -p alice@active
+         *      output: >> stored tuple<string, vec_uint16, pr_uint16> vals:
+         *              >> ele0: strHere
+         *              >> ele1: 10 11 12 16
+         *              >> ele2: 86:96
+         */
+        [[eosio::action]]
+        void prnttmisc(name user)
+        {
+
+            PRNTCHECK();
+
+            eosio::print("stored tuple<string, vec_uint16, pr_uint16> vals:\n");
+
+            auto printVec = [](vec_uint16 v) {
+                for (int i=0; i < v.size();i++)
+                    eosio::print(v[i]," ");
+                eosio::print("\n");
+            };
+
+            auto printPair = [](pr_uint16 p) {
+                eosio::print(p.first, ":", p.second);
+                eosio::print("\n");
+            };
+            eosio::print("ele0: ", std::get<0>(iter->tmisc),"\n");
+            eosio::print("ele1: "); printVec(std::get<1>(iter->tmisc));
+            eosio::print("ele2: "); printPair(std::get<2>(iter->tmisc));
+        }
+};

--- a/tests/toolchain/build-pass/tupletest.json
+++ b/tests/toolchain/build-pass/tupletest.json
@@ -1,0 +1,10 @@
+{
+    "tests": [
+        {
+            "expected": {
+                "exit-code": 0
+            }
+        }
+    ]
+}
+

--- a/tests/toolchain/build-pass/tupletestkv.cpp
+++ b/tests/toolchain/build-pass/tupletestkv.cpp
@@ -1,0 +1,530 @@
+/* Verify the support of nested containers involving std::tuple<Ts...> for the new Key-value table eosio::kv::map
+ * This tupletestkv.cpp can be  regarded as a continuation of ../nestcontn2kv.cpp
+ * For each action, an example regarding how to use the action with the cleos command line is given.
+ *
+ * Important Remarks:
+ *      1) The input of a std::tuple<T0,T1,T2> via cleos uses [ele0, ele1, ele2], it is the same as the input of a vector/set
+ *      2) However the input formats of settm,settp are different from those of corresponding setvm, setvp in nestcontn2a.cpp
+ *      3) More importantly, vector<optional<T> > and set<optional<T> >  are NOT yet supported as shown in nestcontn2a.cpp,
+ *         BUT tuple of optional<T> is supported as shown here in this tupletest.cpp
+ *
+ * Expected printout:
+ *      For each setx action, the printed result on the cleos console is given in its corresponding prntx action.
+ */
+
+
+//--- You might need to verify some eosio-defined types such as eosio::asset can be the values of kv::map
+
+#include <eosio/eosio.hpp>
+#include <eosio/map.hpp>
+
+#include <vector>
+#include <set>
+#include <optional>
+#include <map>
+#include <tuple>
+
+using namespace eosio;
+using namespace std;
+
+
+#define SETCONTAINERVAL(x) do { \
+        person2kv obj = mymap[id]; \
+        obj.x = x; \
+        mymap[id] =  obj; \
+    }while(0)
+
+// use typedefs to make multi-layer nested containers work!
+typedef vector<uint16_t> vec_uint16;
+typedef set<uint16_t> set_uint16;
+typedef optional<uint16_t> op_uint16;
+typedef map<uint16_t, uint16_t> mp_uint16;
+typedef pair<uint16_t, uint16_t> pr_uint16;
+
+typedef tuple<uint16_t, uint16_t> tup_uint16;
+
+
+struct person2kv {
+    //  Each container/object is represented by one letter: v-vector, m-map, s-mystruct,o-optional, p-pair, t-tuple
+    //  with exceptions:     s2 - mystruct2,    st - set
+
+    tuple<uint16_t, string> t; //---new code on verifying std::tuple<Ts...>
+
+    //Two-layer nested-container involving tuple
+    vector<tup_uint16> vt;
+    set<tup_uint16> stt;
+    optional<tup_uint16> ot;
+    map<uint16_t, tup_uint16> mt;
+    pair<uint32_t, tup_uint16> pt;
+    tuple<tup_uint16, tup_uint16,  tup_uint16> tt;
+
+    tuple<uint16_t, vec_uint16, vec_uint16> tv;     //tuple of vectors
+    tuple<uint16_t, set_uint16, set_uint16> tst;
+    tuple<op_uint16, op_uint16, op_uint16,op_uint16,op_uint16> to;
+    tuple<uint16_t, mp_uint16, mp_uint16> tm;
+    tuple<uint16_t, pr_uint16, pr_uint16> tp;       //tuple of pairs
+
+    tuple<string, vec_uint16, pr_uint16> tmisc;     //tuple of misc. types
+};
+
+
+class [[eosio::contract("tupletestkv")]] tupletestkv : public eosio::contract {
+    using my_map_t = eosio::kv::map<"people2kv"_n, int, person2kv>;
+    private:
+        my_map_t mymap{};
+
+    public:
+        using contract::contract;
+
+        tupletestkv(name receiver, name code,  datastream<const char*> ds): contract(receiver, code, ds) {}
+
+
+        //Example: cleos --verbose push action nestcontn2kv get '[1]' -p alice@active
+        [[eosio::action]]
+        person2kv get(int id)
+        {
+            //This action will be used by all prntx actions to retrieve item_found for given id
+            auto iter = mymap.find(id);
+            check(iter != mymap.end(), "Record does not exist");
+            const auto& item_found = iter->second();
+            return item_found;
+        }
+
+        /*Examples:
+          * cleos --verbose push action tupletestkv sett '[1,[100,"str1"]]' -p alice@active
+          */
+        [[eosio::action]]
+        void sett(int id, const tuple<uint16_t, string>& t)
+        {
+            SETCONTAINERVAL(t);
+            eosio::print("tuple<uint16_t, string> stored successfully");
+        }
+
+
+         /*Examples:
+         *  cleos --verbose push action tupletestkv prntt '[1]' -p alice@active
+         *      output: >> elements of stored tuple t:100, str1
+         */
+        [[eosio::action]]
+        void prntt(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("elements of stored tuple t:", std::get<0>(psn.t), ", ", std::get<1>(psn.t));
+        }
+
+        //=== 1. Try other containers (vector,set,optional,map,pair,tuple)  of tuples
+
+        //Example: cleos --verbose push action tupletestkv setvt '[1, [[10,20],[30,40], [50,60]]]' -p alice@active
+        [[eosio::action]]
+        void setvt(int id, const vector<tup_uint16>& vt)
+        {
+            SETCONTAINERVAL(vt);
+            eosio::print("type defined vector<tup_uint16> stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletestkv  prntvt '[1]' -p alice@active
+         *      output: >> stored vector<tuple<Ts...>> vals:
+         *              >> 10 20
+         *              >> 30 40
+         *              >> 50 60
+         */
+        [[eosio::action]]
+        void prntvt(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored vector<tuple<Ts...>> vals:\n");
+            for (int i=0 ; i < psn.vt.size(); i++)
+            {
+                eosio::print(std::get<0>(psn.vt[i]), " ", std::get<1>(psn.vt[i]));
+                eosio::print("\n");
+            }
+        }
+
+        //Example: cleos --verbose push action tupletestkv setstt '[1, [[1,2],[36,46], [56,66]]]' -p alice@active
+        [[eosio::action]]
+        void setstt(int id, const set<tup_uint16>& stt)
+        {
+            SETCONTAINERVAL(stt);
+            eosio::print("type defined set<tup_uint16> stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletestkv  prntstt '[1]' -p alice@active
+         *      output: >> stored set<tuple<Ts...>> vals:
+         *              >> 1 2
+         *              >> 36 46
+         *              >> 56 66
+         */
+        [[eosio::action]]
+        void prntstt(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored set<tuple<Ts...>> vals:\n");
+            for (auto it1=psn.stt.begin(); it1!= psn.stt.end(); it1++)
+            {
+                eosio::print(std::get<0>(*it1), " ", std::get<1>(*it1));
+                eosio::print("\n");
+            }
+        }
+
+         /*Examples:
+         *  cleos --verbose push action tupletestkv setot '[1, null]' -p bob@active
+         *
+         *  cleos --verbose push action tupletestkv setot '[2, [1001,2001]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setot(int id, const optional<tup_uint16>& ot)
+        {
+            SETCONTAINERVAL(ot);
+            eosio::print("type defined optional<tup_uint16> stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action tupletestkv  prntot '[1]' -p bob@active
+         *      output: >> stored optional<tup_uint16>  vals:
+         *              >> NULL or no value
+         *
+         *  cleos --verbose push action tupletestkv  prntot '[2]' -p alice@active
+         *      output: >> stored optional<tup_uint16>  vals:
+         *              >> 1001 2001
+         */
+        [[eosio::action]]
+        void prntot(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored optional<tup_uint16>  vals:\n");
+            if (psn.ot)
+            {
+                eosio::print(std::get<0>(psn.ot.value()), " ", std::get<1>(psn.ot.value()));
+            }
+            else
+                eosio::print("NULL or no value");
+        }
+
+        /*Example:
+         * cleos --verbose push action tupletestkv setmt '[1, [{"key":1,"value":[10,11]},  {"key":2,"value":[200,300]} ]]' -p alice@active
+         */
+        [[eosio::action]]
+        void setmt(int id, const map<uint16_t, tup_uint16>& mt)
+        {
+            SETCONTAINERVAL(mt);
+            eosio::print("type defined map<uint16_t, tup_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletestkv  prntmt '[1]' -p alice@active
+         *      output: >> stored map<uint16_t, vec_uint16>: size=2 content:
+         *              >> 1:vals 10 11
+         *              >> 2:vals 200 300
+         */
+        [[eosio::action]]
+        void prntmt(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored map<uint16_t, tup_uint16>: size=", psn.mt.size()," content:\n");
+            for (auto it2 = psn.mt.begin(); it2 != psn.mt.end(); ++it2)
+            {
+                    eosio::print(it2->first, ":", "vals ");
+                    eosio::print(std::get<0>(it2->second), " ", std::get<1>(it2->second));
+                    eosio::print("\n");
+            }
+        }
+
+
+
+        /*Example:
+         * cleos --verbose push action tupletestkv setpt '[1, {"first":10, "second":[100,101]}]' -p alice@active
+         */
+        [[eosio::action]]
+        void setpt(int id, const pair<uint32_t, tup_uint16>& pt)
+        {
+            SETCONTAINERVAL(pt);
+            eosio::print("type defined pair<uint32_t, tup_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletestkv  prntpt '[1]' -p alice@active
+         *      output: >> content of stored pair<uint32_t, tup_uint16>: first=10
+         *              >> second=100 101
+         */
+        [[eosio::action]]
+        void prntpt(int id)
+        {
+            const auto& psn = get(id);
+
+            eosio::print("content of stored pair<uint32_t, tup_uint16>: first=", psn.pt.first, "\nsecond=");
+            eosio::print(std::get<0>(psn.pt.second), " ", std::get<1>(psn.pt.second));
+        }
+
+        //Example: cleos --verbose push action tupletestkv settt '[1, [[1,2],[30,40], [50,60]]]' -p alice@active
+        [[eosio::action]]
+        void settt(int id, const tuple<tup_uint16, tup_uint16,  tup_uint16>& tt)
+        {
+            SETCONTAINERVAL(tt);
+            eosio::print("type defined tuple<tuple<Ts...> > stored successfully!");
+
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletestkv  prnttt '[1]' -p alice@active
+         *      output: >> stored tuple<tup_uint16, tup_uint16,  tup_uint16> vals:
+         *              >> 1 2
+         *              >> 30 40
+         *              >> 50 60
+         */
+        [[eosio::action]]
+        void prnttt(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored tuple<tup_uint16, tup_uint16,  tup_uint16> vals:\n");
+            const auto& ele0 = std::get<0>(psn.tt);
+            const auto& ele1 = std::get<1>(psn.tt);
+            const auto& ele2 = std::get<2>(psn.tt);
+
+            eosio::print(std::get<0>(ele0), " ", std::get<1>(ele0), "\n");
+            eosio::print(std::get<0>(ele1), " ", std::get<1>(ele1), "\n");
+            eosio::print(std::get<0>(ele2), " ", std::get<1>(ele2), "\n");
+        }
+
+         //=== 2. Try tuple of other containers (vector,set,optional,map,pair)
+
+         //Example: cleos --verbose push action tupletestkv settv '[1, [16,[26,36], [46,506,606]]]' -p alice@active
+        [[eosio::action]]
+        void settv(int id, const tuple<uint16_t, vec_uint16, vec_uint16>& tv)
+        {
+            SETCONTAINERVAL(tv);
+            eosio::print("type defined tuple<uint16_t, vec_uint16, vec_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletestkv  prnttv '[1]' -p alice@active
+         *      output: >> stored tuple<uint16_t, vec_uint16, vec_uint16>  vals:
+         *              >> ele0: 16
+         *              >> ele1: 26 36
+         *              >> ele2: 46 506 606
+         */
+        [[eosio::action]]
+        void prnttv(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored tuple<uint16_t, vec_uint16, vec_uint16>  vals:\n");
+
+            auto printVec = [](vec_uint16 v) {//eosio-cpp compiler allows c++11 usage such as lambda
+                for (int i=0; i < v.size();i++)
+                    eosio::print(v[i]," ");
+                eosio::print("\n");
+            };
+            eosio::print("ele0: ", std::get<0>(psn.tv),"\n");
+            eosio::print("ele1: "); printVec(std::get<1>(psn.tv));
+            eosio::print("ele2: "); printVec(std::get<2>(psn.tv));
+        }
+
+         //Example: cleos --verbose push action tupletestkv settst '[1, [10,[21,31], [41,51,61]]]' -p alice@active
+        [[eosio::action]]
+        void settst(int id, const tuple<uint16_t, set_uint16, set_uint16>& tst)
+        {
+            SETCONTAINERVAL(tst);
+            eosio::print("type defined tuple<uint16_t, set_uint16, set_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletestkv  prnttst '[1]' -p alice@active
+         *      output: >> stored tuple<uint16_t, set_uint16, set_uint16>  vals:
+         *              >> ele0: 10
+         *              >> ele1: 21 31
+         *              >> ele2: 41 51 61
+         */
+        [[eosio::action]]
+        void prnttst(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored tuple<uint16_t, set_uint16, set_uint16> vals:\n");
+
+            auto printSet = [](set_uint16 s) {
+                for (auto it = s.begin(); it !=s.end(); it++ )
+                    eosio::print(*it, " ");
+                eosio::print("\n");
+            };
+            eosio::print("ele0: ", std::get<0>(psn.tst),"\n");
+            eosio::print("ele1: "); printSet(std::get<1>(psn.tst));
+            eosio::print("ele2: "); printSet(std::get<2>(psn.tst));
+        }
+
+         /*Examples:
+         *  cleos --verbose push action tupletestkv  setto '[1, [100, null, 200, null, 300]]' -p alice@active
+         *
+         *  cleos --verbose push action tupletestkv  setto '[2, [null, null, 10, null, 20]]' -p bob@active
+         *      Remark: Yes, tuple of optionals is supported here !
+         */
+        [[eosio::action]]
+        void setto(int id, const tuple<op_uint16, op_uint16, op_uint16,op_uint16,op_uint16> & to)
+        {
+            SETCONTAINERVAL(to);
+            eosio::print("type defined tuple<op_uint16, op_uint16, op_uint16,op_uint16,op_uint16> stored successfully!");
+        }
+
+        /*Examples:
+         *  cleos --verbose push action tupletest  prntto '[1]' -p alice@active
+         *      output: >> stored tuple<op_uint16, op_uint16, op_uint16,op_uint16,op_uint16> vals:
+         *              >> 100 NULL 200 NULL 300
+         *
+         *  cleos --verbose push action tupletest  prntto '[2]' -p bob@active
+         *      output: >> stored tuple<op_uint16, op_uint16, op_uint16,op_uint16,op_uint16> vals:
+         *              >> NULL NULL 10 NULL 20
+         */
+        [[eosio::action]]
+        void prntto(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored tuple<op_uint16, op_uint16, op_uint16,op_uint16,op_uint16> vals:\n");
+            auto printOptional = [](op_uint16 op) {
+                if (op)
+                    eosio::print(op.value(),  " ");
+                else
+                    eosio::print("NULL", " ");
+            };
+
+            printOptional(std::get<0>(psn.to));
+            printOptional(std::get<1>(psn.to));
+            printOptional(std::get<2>(psn.to));
+            printOptional(std::get<3>(psn.to));
+            printOptional(std::get<4>(psn.to));
+            eosio::print("\n");
+        }
+
+
+        //Example: cleos --verbose push action tupletestkv settm '[1, [126, [{"key":10,"value":100},{"key":11,"value":101}], [{"key":80,"value":800},{"key":81,"value":9009}] ]]' -p alice@active
+        //         ******Note: The input format of settm is different from that of setvm in nestcontn2a.cpp!
+        [[eosio::action]]
+        void settm(int id, const tuple<uint16_t, mp_uint16, mp_uint16>& tm)
+        {
+            SETCONTAINERVAL(tm);
+            eosio::print("type defined tuple<uint16_t, mp_uint16, mp_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletestkv  prnttm '[1]' -p alice@active
+         *      output: >> stored tuple<uint16_t, mp_uint16, mp_uint16> vals:
+         *              >> ele0: 126
+         *              >> ele1: 10:100 11:101
+         *              >> ele2: 80:800 81:9009
+         */
+        [[eosio::action]]
+        void prnttm(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored tuple<uint16_t, mp_uint16, mp_uint16> vals:\n");
+
+            auto printMap = [](mp_uint16 m) {
+                for (auto it = m.begin(); it !=m.end(); it++ )
+                    eosio::print(it->first, ":", it->second, " ");
+                eosio::print("\n");
+            };
+            eosio::print("ele0: ", std::get<0>(psn.tm),"\n");
+            eosio::print("ele1: "); printMap(std::get<1>(psn.tm));
+            eosio::print("ele2: "); printMap(std::get<2>(psn.tm));
+        }
+
+        //Example:  cleos --verbose push action tupletestkv settp '[1, [127, {"key":18, "value":28}, {"key":19, "value":29}]]' -p alice@active
+        //         ******Note: The input format of settp is different from that of setvp in nestcontn2a.cpp!
+        [[eosio::action]]
+        void settp(int id, const tuple<uint16_t, pr_uint16, pr_uint16>& tp)
+        {
+            SETCONTAINERVAL(tp);
+            eosio::print("type defined tuple<uint16_t, pr_uint16, pr_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletestkv  prnttp '[1]' -p alice@active
+         *      output: >> stored tuple<uint16_t, pr_unit16, pr_unit16> vals:
+         *              >> ele0: 127
+         *              >> ele1: 18:28
+         *              >> ele2: 19:29
+         */
+        [[eosio::action]]
+        void prnttp(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored tuple<uint16_t, pr_unit16, pr_unit16> vals:\n");
+
+            auto printPair = [](pr_uint16 p) {
+                eosio::print(p.first, ":", p.second);
+                eosio::print("\n");
+            };
+            eosio::print("ele0: ", std::get<0>(psn.tp),"\n");
+            eosio::print("ele1: "); printPair(std::get<1>(psn.tp));
+            eosio::print("ele2: "); printPair(std::get<2>(psn.tp));
+        }
+
+        //Example: cleos --verbose push action tupletestkv settmisc '[1, ["strHere", [10,11,12,16], {"key":86,"value":96}] ]' -p alice@active
+        [[eosio::action]]
+        void settmisc(int id, const tuple<string, vec_uint16, pr_uint16>  & tmisc)
+        {
+            SETCONTAINERVAL(tmisc);
+            eosio::print("type defined tuple<string, vec_uint16, pr_uint16> stored successfully!");
+        }
+
+        /*Example:
+         *  cleos --verbose push action tupletestkv  prnttmisc '[1]' -p alice@active
+         *      output: >> stored tuple<string, vec_uint16, pr_uint16> vals:
+         *              >> ele0: strHere
+         *              >> ele1: 10 11 12 16
+         *              >> ele2: 86:96
+         */
+        [[eosio::action]]
+        void prnttmisc(int id)
+        {
+            const auto& psn = get(id);
+            eosio::print("stored tuple<string, vec_uint16, pr_uint16> vals:\n");
+
+            auto printVec = [](vec_uint16 v) {
+                for (int i=0; i < v.size();i++)
+                    eosio::print(v[i]," ");
+                eosio::print("\n");
+            };
+
+            auto printPair = [](pr_uint16 p) {
+                eosio::print(p.first, ":", p.second);
+                eosio::print("\n");
+            };
+            eosio::print("ele0: ", std::get<0>(psn.tmisc),"\n");
+            eosio::print("ele1: "); printVec(std::get<1>(psn.tmisc));
+            eosio::print("ele2: "); printPair(std::get<2>(psn.tmisc));
+        }
+
+        //The following are needed for eosio-cpp compiler to identify the actions in genearted .abi
+        using get_action = eosio::action_wrapper<"get"_n, &tupletestkv::get>;
+
+        using sett_action = eosio::action_wrapper<"sett"_n, &tupletestkv::sett>;
+        using prntt_action = eosio::action_wrapper<"prntt"_n, &tupletestkv::prntt>;
+        using setvt_action = eosio::action_wrapper<"setvt"_n, &tupletestkv::setvt>;
+        using prntvt_action = eosio::action_wrapper<"prntvt"_n, &tupletestkv::prntvt>;
+        using setstt_action = eosio::action_wrapper<"setstt"_n, &tupletestkv::setstt>;
+        using prntstt_action = eosio::action_wrapper<"prntstt"_n, &tupletestkv::prntstt>;
+        using setot_action = eosio::action_wrapper<"setot"_n, &tupletestkv::setot>;
+        using prntot_action = eosio::action_wrapper<"prntot"_n, &tupletestkv::prntot>;
+        using setmt_action = eosio::action_wrapper<"setmt"_n, &tupletestkv::setmt>;
+        using prntmt_action = eosio::action_wrapper<"prntmt"_n, &tupletestkv::prntmt>;
+        using setpt_action = eosio::action_wrapper<"setpt"_n, &tupletestkv::setpt>;
+        using prntpt_action = eosio::action_wrapper<"prntpt"_n, &tupletestkv::prntpt>;
+        using settt_action = eosio::action_wrapper<"settt"_n, &tupletestkv::settt>;
+        using prnttt_action = eosio::action_wrapper<"prnttt"_n, &tupletestkv::prnttt>;
+
+        using settv_action = eosio::action_wrapper<"settv"_n, &tupletestkv::settv>;
+        using prnttv_action = eosio::action_wrapper<"prnttv"_n, &tupletestkv::prnttv>;
+        using settst_action = eosio::action_wrapper<"settst"_n, &tupletestkv::settst>;
+        using prnttst_action = eosio::action_wrapper<"prnttst"_n, &tupletestkv::prnttst>;
+        using setto_action = eosio::action_wrapper<"setto"_n, &tupletestkv::setto>;
+        using prntto_action = eosio::action_wrapper<"prntto"_n, &tupletestkv::prntto>;
+        using settm_action = eosio::action_wrapper<"settm"_n, &tupletestkv::settm>;
+        using prnttm_action = eosio::action_wrapper<"prnttm"_n, &tupletestkv::prnttm>;
+        using settp_action = eosio::action_wrapper<"settp"_n, &tupletestkv::settp>;
+        using prnttp_action = eosio::action_wrapper<"prnttp"_n, &tupletestkv::prnttp>;
+        using settmisc_action = eosio::action_wrapper<"settmisc"_n, &tupletestkv::settmisc>;
+        using prnttmisc_action = eosio::action_wrapper<"prnttmisc"_n, &tupletestkv::prnttmisc>;
+};
+
+

--- a/tests/toolchain/build-pass/tupletestkv.json
+++ b/tests/toolchain/build-pass/tupletestkv.json
@@ -1,0 +1,10 @@
+{
+    "tests": [
+        {
+            "expected": {
+                "exit-code": 0
+            }
+        }
+    ]
+}
+

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -169,7 +169,14 @@ namespace eosio { namespace cdt {
          }
          abi_struct kv;
          std::string name = get_type(type);
-         kv.name = name.substr(0, name.length() - 2);
+         auto remove_ending_brackets = [&]( std::string name ) {
+            int i = name.length()-1;
+            for (; i >= 0; i--)
+               if ( name[i] != '[' && name[i] != ']' )
+                  break;
+            return name.substr(0,i+1);
+         };
+         kv.name = remove_ending_brackets(name);
          kv.fields.push_back( {"key", get_template_argument_as_string(type)} );
          kv.fields.push_back( {"value", get_template_argument_as_string(type, 1)} );
          add_type(std::get<clang::QualType>(get_template_argument(type)));

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -515,9 +515,13 @@ struct generation_utils {
             return t+"[]";
          }
       }
-      else if (is_tuple(type)) {
-         return translate_type(get_nested_type(type));
-      }
+      //The following else if (is_tuple(type)) block is removed, because it causes eosio-cpp compilation
+      //failure on any action that has std::tuple<Ts...> parameter, also the type eosio::non_unique this block
+      //was supposed to handle is obsolete now.
+      //
+      //else if (is_tuple(type)) {
+      //   return translate_type(get_nested_type(type));
+      //}
       else if ( is_template_specialization( type, {"optional"} ) )
          return get_template_argument_as_string( type )+"?";
       else if ( is_template_specialization( type, {"map"} )) {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Merge into CDT release/1.8.x to solve an issue to compile contract in eos/unittests/test-contracts/kv_addr_book/ correctly 
Here to make toolchain test successful,  two commits are cherry picked, one is from my [PR1193](https://github.com/EOSIO/eosio.cdt/pull/1193/) , the other is from Qing's [early change on map of map in abigen.hpp](https://github.com/EOSIO/eosio.cdt/commit/9333e1099ba3ee44a50fb0764b199412aaef1910)


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
