### PR TITLE
Filter eosio::kv::non_unique out of is_explicit_nested(), fix build problem

### DIFF
--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -642,7 +642,7 @@ struct generation_utils {
          }
       }
       if(!gottype) {
-         std::string errstring = "add_explicit_nested_type failed to fetch type from ";
+         std::string errstring = "translate_explicit_nested_type failed to fetch type from ";
          errstring += type.getAsString();
          CDT_INTERNAL_ERROR(errstring);
          return "";
@@ -809,8 +809,12 @@ struct generation_utils {
 
    inline bool is_explicit_nested(const clang::QualType& t ){
       std::string tstr = t.getAsString();
-      if(tstr.find("decay_t") != std::string::npos || tstr.find("decltype") != std::string::npos || tstr.find("ignore") != std::string::npos ||
-         tstr.find("invoke") != std::string::npos || tstr.find("index") != std::string::npos || tstr.find("declval") != std::string::npos ) return false;
+      // won't deal with these kinds of nested container so far
+      std::vector<std::string> filters = {"decay_t", "decltype", "ignore", "invoke",
+                           "index", "declval", "non_unique", "_BaseT", "typename"};
+      for(auto & word : filters){
+         if(tstr.find(word) != std::string::npos) return false;
+      }
       return std::count (tstr.begin(), tstr.end(), '<') >= 2;
    }
 


### PR DESCRIPTION
For fix build problem, filter eosio::kv::non_unique out of is_explicit_nested(). 

As add_explicit_nested_type doesn't support eosio::kv::non_unique so far, let add_type deal with it is OK.

See https://blockone.atlassian.net/browse/EPE-1589

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
