### PR TITLE
Fix linking eosio-ld linking errors on Big Sur

### DIFF
--- a/tools/include/compiler_options.hpp.in
+++ b/tools/include/compiler_options.hpp.in
@@ -544,6 +544,10 @@ static void GetLdDefaults(std::vector<std::string>& ldopts) {
       }
    } else {
 #ifdef __APPLE__
+      // Adding the -F option fixes an issue in Big Sur where it's unable to
+      // link the Foundation framework. Adding this doesn't seem to cause
+      // problems for the older version of OSX.
+      ldopts.insert(ldopts.end(), {"-F/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks/"});
       ldopts.insert(ldopts.end(), {"-arch", "x86_64", "-macosx_version_min", "10.13", "-framework", "Foundation", "-framework", "System"});
 #endif
       ldopts.emplace_back("-static");


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

Building the wasm tests on Big Sur fails when linking at least the Foundation framework. Adds a flag to eosio-ld with a different possible location for the framework, fixing the issue. Addressed as part of: https://blockone.atlassian.net/browse/EPE-941


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
