### PR TITLE
Replace int8[] in vector/set/deque/list<char/int8/uint8>  with bytes - 1.8.x

### DIFF
--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -382,10 +382,11 @@ namespace eosio { namespace cdt {
       inline void adding_explicit_nested_dispatcher(const clang::QualType& inside_type, int depth, std::string & inside_type_name){
          if(is_explicit_nested(inside_type)){  // inside type is still explict nested  <<>>
             inside_type_name = add_explicit_nested_type(inside_type, depth + 1);
-         } else if(is_explicit_container(inside_type)) {  // inside type is single container,  only one <>
-            inside_type_name = add_explicit_nested_type(inside_type, depth + 1);
          }else if (is_builtin_type(translate_type(inside_type))){   // inside type is builtin
             inside_type_name = translate_type(inside_type);
+         } else if(is_explicit_container(inside_type)) {  // inside type is single container,  only one <>
+            std::string inside_type_string = inside_type.getAsString();
+            inside_type_name = add_explicit_nested_type(inside_type, depth + 1);
          } else if (is_aliasing(inside_type)) { // inside type is an alias
             add_typedef(inside_type);
             inside_type_name = get_base_type_name( inside_type );

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -503,10 +503,10 @@ struct generation_utils {
    inline void translating_explicit_nested_dispatcher(const clang::QualType& inside_type, int depth, std::string & inside_type_name){
       if(is_explicit_nested(inside_type)){  // inside type is still explict nested  <<>>
          inside_type_name = translate_explicit_nested_type(inside_type, depth + 1);
-      } else if(is_explicit_container(inside_type)) {  // inside type is single container,  only one <>
-         inside_type_name = translate_explicit_nested_type(inside_type, depth + 1);
       }else if (is_builtin_type(translate_type(inside_type))){   // inside type is builtin
          inside_type_name = translate_type(inside_type);
+      } else if(is_explicit_container(inside_type)) {  // inside type is single container,  only one <>
+         inside_type_name = translate_explicit_nested_type(inside_type, depth + 1);
       } else if (is_aliasing(inside_type)) { // inside type is a alias
          inside_type_name = get_base_type_name( inside_type );
       } else if (is_template_specialization(inside_type, {})) {


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
Merge back cdt PR 1227 to 1.8.x.
vector/set/deque/list<char/int8/uint8> should be "bytes" not int8[].

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
