### PR TITLE
Using mpair instead of pair for std::map element abi type

### DIFF
--- a/tests/toolchain/abigen-pass/nested_container.abi
+++ b/tests/toolchain/abigen-pass/nested_container.abi
@@ -4,7 +4,7 @@
     "types": [
         {
             "new_type_name": "B_map_string_string_E",
-            "type": "kvpair_string_string[]"
+            "type": "mpair_string_string[]"
         },
         {
             "new_type_name": "B_vector_int32_E",
@@ -13,7 +13,21 @@
     ],
     "structs": [
         {
-            "name": "kvpair_string_B_map_string_string_E",
+            "name": "map2map",
+            "base": "",
+            "fields": [
+                {
+                    "name": "m",
+                    "type": "mpair_string_string[]"
+                },
+                {
+                    "name": "m2m",
+                    "type": "mpair_string_B_map_string_string_E[]"
+                }
+            ]
+        },
+        {
+            "name": "mpair_string_B_map_string_string_E",
             "base": "",
             "fields": [
                 {
@@ -27,7 +41,7 @@
             ]
         },
         {
-            "name": "kvpair_string_string",
+            "name": "mpair_string_string",
             "base": "",
             "fields": [
                 {
@@ -37,20 +51,6 @@
                 {
                     "name": "value",
                     "type": "string"
-                }
-            ]
-        },
-        {
-            "name": "map2map",
-            "base": "",
-            "fields": [
-                {
-                    "name": "m",
-                    "type": "kvpair_string_string[]"
-                },
-                {
-                    "name": "m2m",
-                    "type": "kvpair_string_B_map_string_string_E[]"
                 }
             ]
         },

--- a/tests/toolchain/abigen-pass/nested_container.abi
+++ b/tests/toolchain/abigen-pass/nested_container.abi
@@ -4,7 +4,7 @@
     "types": [
         {
             "new_type_name": "B_map_string_string_E",
-            "type": "pair_string_string[]"
+            "type": "kvpair_string_string[]"
         },
         {
             "new_type_name": "B_vector_int32_E",
@@ -13,21 +13,7 @@
     ],
     "structs": [
         {
-            "name": "map2map",
-            "base": "",
-            "fields": [
-                {
-                    "name": "m",
-                    "type": "pair_string_string[]"
-                },
-                {
-                    "name": "m2m",
-                    "type": "pair_string_B_map_string_string_E[]"
-                }
-            ]
-        },
-        {
-            "name": "pair_string_B_map_string_string_E",
+            "name": "kvpair_string_B_map_string_string_E",
             "base": "",
             "fields": [
                 {
@@ -41,7 +27,7 @@
             ]
         },
         {
-            "name": "pair_string_string",
+            "name": "kvpair_string_string",
             "base": "",
             "fields": [
                 {
@@ -51,6 +37,20 @@
                 {
                     "name": "value",
                     "type": "string"
+                }
+            ]
+        },
+        {
+            "name": "map2map",
+            "base": "",
+            "fields": [
+                {
+                    "name": "m",
+                    "type": "kvpair_string_string[]"
+                },
+                {
+                    "name": "m2m",
+                    "type": "kvpair_string_B_map_string_string_E[]"
                 }
             ]
         },

--- a/tests/unit/test_contracts/explicit_nested_tests.cpp
+++ b/tests/unit/test_contracts/explicit_nested_tests.cpp
@@ -94,6 +94,20 @@ CONTRACT explicit_nested_tests : public contract {
    }
 
    [[eosio::action]]
+   // usage : cleos -v push action eosio vmistr '[[[{"key":12,"value":"map test"},{"key":34,"value":"passed"}]]]'  -p eosio@active
+   std::vector<std::map<int, std::string>>  vmistr(std::vector<std::map<int, std::string>> input){
+      std::vector<std::map<int, std::string>> output = input;
+      return output;
+   }
+
+   [[eosio::action]]
+   // usage : cleos -v push action eosio vpistr '[[{"first":12,"second":"pair test"},{"first":34,"second":"passed"}]]'  -p eosio@active
+   std::vector<std::pair<int, std::string>>  vpistr(std::vector<std::pair<int, std::string>> input){
+      std::vector<std::pair<int, std::string>> output = input;
+      return output;
+   }
+
+   [[eosio::action]]
    // usage : cleos -v push action eosio tup '[{"field_0":1,"field_1":2.0,"field_2":[4,5,6,7]}]'  -p eosio@active
    std::tuple<uint64_t, std::optional<float>, std::vector<int>>  tup(std::tuple<uint64_t, std::optional<float>, std::vector<int>>  input){
       std::tuple<uint64_t, std::optional<float>, std::vector<int>> output = input;

--- a/tests/unit/test_contracts/explicit_nested_tests.cpp
+++ b/tests/unit/test_contracts/explicit_nested_tests.cpp
@@ -108,6 +108,20 @@ CONTRACT explicit_nested_tests : public contract {
    }
 
    [[eosio::action]]
+   // usage : cleos -v push action eosio vmpiistr '[[{"key":12,"value":{"first":"map pair","second":"test passed"}}]]'  -p eosio@active
+   std::map<int, std::pair<std::string, std::string>>  vmpiistr(std::map<int, std::pair<std::string, std::string>> input){
+      std::map<int, std::pair<std::string, std::string>> output = input;
+      return output;
+   }
+
+   [[eosio::action]]
+   // usage : cleos -v push action eosio vpmiistr '[{"first":34, "second":[{"key":"pair","value":"map"}, {"key":"test","value":"passed"}] }]'  -p eosio@active
+   std::pair<int, std::map<std::string, std::string>>  vpmiistr(std::pair<int, std::map<std::string, std::string>> input){
+      std::pair<int, std::map<std::string, std::string>> output = input;
+      return output;
+   }
+
+   [[eosio::action]]
    // usage : cleos -v push action eosio tup '[{"field_0":1,"field_1":2.0,"field_2":[4,5,6,7]}]'  -p eosio@active
    std::tuple<uint64_t, std::optional<float>, std::vector<int>>  tup(std::tuple<uint64_t, std::optional<float>, std::vector<int>>  input){
       std::tuple<uint64_t, std::optional<float>, std::vector<int>> output = input;

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -434,10 +434,10 @@ namespace eosio { namespace cdt {
 
          if(inside_type_name[0] != "" && inside_type_name[1] != ""){
             ret += inside_type_name[0] + "_" + inside_type_name[1];
-            abidef.type = "kvpair_" + inside_type_name[0] + "_" + inside_type_name[1] + "[]";
+            abidef.type = "mpair_" + inside_type_name[0] + "_" + inside_type_name[1] + "[]";
 
             abi_struct kv;
-            kv.name = "kvpair_" + inside_type_name[0] + "_" + inside_type_name[1];
+            kv.name = "mpair_" + inside_type_name[0] + "_" + inside_type_name[1];
             kv.fields.push_back( {"key", inside_type_name[0]} );
             kv.fields.push_back( {"value", inside_type_name[1]} );
             _abi.structs.insert(kv);

--- a/tools/include/eosio/abigen.hpp
+++ b/tools/include/eosio/abigen.hpp
@@ -434,10 +434,10 @@ namespace eosio { namespace cdt {
 
          if(inside_type_name[0] != "" && inside_type_name[1] != ""){
             ret += inside_type_name[0] + "_" + inside_type_name[1];
-            abidef.type = "pair_" + inside_type_name[0] + "_" + inside_type_name[1] + "[]";
+            abidef.type = "kvpair_" + inside_type_name[0] + "_" + inside_type_name[1] + "[]";
 
             abi_struct kv;
-            kv.name = "pair_" + inside_type_name[0] + "_" + inside_type_name[1];
+            kv.name = "kvpair_" + inside_type_name[0] + "_" + inside_type_name[1];
             kv.fields.push_back( {"key", inside_type_name[0]} );
             kv.fields.push_back( {"value", inside_type_name[1]} );
             _abi.structs.insert(kv);

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -534,7 +534,7 @@ struct generation_utils {
    }
 
    void translate_explicit_nested_map_or_pair(const clang::QualType& type, int depth, std::string & ret, const std::string & tname, bool & gottype){
-      ret += depth > 0 ? tname + "_" : "pair_";
+      ret += depth > 0 ? tname + "_" : tname == "map" ? "kvpair_" : "pair_";
       clang::QualType inside_type[2];
       std::string inside_type_name[2];
       for(int i = 0; i < 2; ++i){
@@ -680,7 +680,7 @@ struct generation_utils {
       else if ( is_template_specialization( type, {"map"} )) {
          auto t0 = get_template_argument_as_string( type );
          auto t1 = get_template_argument_as_string( type, 1);
-         return replace_in_name("pair_" + t0 + "_" + t1 + "[]");
+         return replace_in_name("kvpair_" + t0 + "_" + t1 + "[]");
       }
       else if ( is_template_specialization( type, {"pair"} )) {
          auto t0 = get_template_argument_as_string( type );

--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -534,7 +534,7 @@ struct generation_utils {
    }
 
    void translate_explicit_nested_map_or_pair(const clang::QualType& type, int depth, std::string & ret, const std::string & tname, bool & gottype){
-      ret += depth > 0 ? tname + "_" : tname == "map" ? "kvpair_" : "pair_";
+      ret += depth > 0 ? tname + "_" : tname == "map" ? "mpair_" : "pair_";
       clang::QualType inside_type[2];
       std::string inside_type_name[2];
       for(int i = 0; i < 2; ++i){
@@ -680,7 +680,7 @@ struct generation_utils {
       else if ( is_template_specialization( type, {"map"} )) {
          auto t0 = get_template_argument_as_string( type );
          auto t1 = get_template_argument_as_string( type, 1);
-         return replace_in_name("kvpair_" + t0 + "_" + t1 + "[]");
+         return replace_in_name("mpair_" + t0 + "_" + t1 + "[]");
       }
       else if ( is_template_specialization( type, {"pair"} )) {
          auto t0 = get_template_argument_as_string( type );


### PR DESCRIPTION
Using mpair instead of pair for std::map element abi type, so as to avoid conflicting with pair.
See EPE 1469 also.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
After this PR,  the std::map  corresponding abi structure type is "mpair_A_B[]" instead of "pair_A_B[]".
The abi file made before this PR can still work with eos,  as this PR doesn't change eos. 