### PR TITLE
Filter "allocator" out of is_explicit_nested

### DIFF
--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -811,7 +811,7 @@ struct generation_utils {
       std::string tstr = t.getAsString();
       // won't deal with these kinds of nested container so far
       std::vector<std::string> filters = {"decay_t", "decltype", "ignore", "invoke",
-                           "index", "declval", "non_unique", "_BaseT", "typename"};
+                           "index", "declval", "non_unique", "_BaseT", "typename", "allocator"};
       for(auto & word : filters){
          if(tstr.find(word) != std::string::npos) return false;
       }


### PR DESCRIPTION
explicit_nested don't deal with this so far.
see EPE-1730 also, fix build problem cause by "class std::__1::vector<unsigned short, class std::__1::allocator<unsigned short> >" 

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
