### PR TITLE
Remove macOS 10.14 cdt package download - 1.8.x

### DIFF
--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -521,16 +521,13 @@ steps:
 
   - label: ":beer: Brew Updater"
     command: |
-      buildkite-agent artifact download eosio.cdt.rb . --step ':darwin: macOS 10.14 - Package Builder'
-      mv eosio.cdt.rb eosio_cdt_mojave.rb
-      buildkite-agent artifact upload eosio_cdt_mojave.rb
       buildkite-agent artifact download eosio.cdt.rb . --step ':darwin: macOS 10.15 - Package Builder'
       mv eosio.cdt.rb eosio_cdt_catalina.rb
       buildkite-agent artifact upload eosio_cdt_catalina.rb
     agents:
       queue: "automation-basic-builder-fleet"
     timeout: "${TIMEOUT:-5}"
-    skip: ${SKIP_MACOS_10_14}${SKIP_MACOS_10_15}${SKIP_MAC}${SKIP_PACKAGE_BUILDER}
+    skip: ${SKIP_MACOS_10_15}${SKIP_MAC}${SKIP_PACKAGE_BUILDER}
 
   - label: ":git: Git Submodule Regression Check"
     command:


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

It still merge back PR for CDT  PR 1243. See also EPE 1766. 

Just miss a cherry-pick commit in last merge back PR . 

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
