### PR TITLE
Fix abigen with int expression template arguments

### DIFF
--- a/tools/include/eosio/gen.hpp
+++ b/tools/include/eosio/gen.hpp
@@ -370,7 +370,8 @@ struct generation_utils {
          if (auto ce = llvm::dyn_cast<clang::CastExpr>(std::get<clang::Expr*>(arg))) {
             auto il = llvm::dyn_cast<clang::IntegerLiteral>(ce->getSubExpr());
             return std::to_string(il->getValue().getLimitedValue());
-         }
+         } else if (auto ce = llvm::dyn_cast<clang::ConstantExpr>(std::get<clang::Expr*>(arg)))
+             return ce->getResultAsAPSInt().toString(10);
       } else {
          return std::get<llvm::APSInt>(arg).toString(10);
       }


### PR DESCRIPTION
## Change Description
In my contracts, I use several template arguments which are types
which resolve to integral values (such as an `eosio::name`) but are
not trivially integer values. This works great in my contracts, but
causes abigen to fail.

This PR fixes abigen in cases where a template argument is an expression
that resolves to an integer, but isn't an integer literal.

*Note:* This is targeted at the master branch instead of develop because develop fails to build my contract due to other reasons. I'm hoping that this is just instabilities in unreleased code. In the meantime, I'm staying on 1.8.1, and so I base my PR there.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
