### PR TITLE
Add user function get/set_parameters to support host function get/set_parameters_packed

### DIFF
--- a/libraries/eosiolib/capi/eosio/privileged.h
+++ b/libraries/eosiolib/capi/eosio/privileged.h
@@ -105,6 +105,12 @@ void set_blockchain_parameters_packed( char* data, uint32_t datalen );
 __attribute__((eosio_wasm_import))
 uint32_t get_blockchain_parameters_packed( char* data, uint32_t datalen );
 
+ __attribute__((eosio_wasm_import))
+ void set_parameters_packed( char* data, uint32_t datalen );
+
+ __attribute__((eosio_wasm_import))
+ uint32_t get_parameters_packed( char* id, uint32_t idlen , char* data, uint32_t datalen  );
+
 /**
  * Set the KV parameters
  *

--- a/libraries/eosiolib/contracts/eosio/privileged.hpp
+++ b/libraries/eosiolib/contracts/eosio/privileged.hpp
@@ -28,6 +28,12 @@ namespace eosio {
          uint32_t get_blockchain_parameters_packed( char* data, uint32_t datalen );
 
          __attribute__((eosio_wasm_import))
+         void set_parameters_packed( char* data, uint32_t datalen );
+
+         __attribute__((eosio_wasm_import))
+         uint32_t get_parameters_packed( char* id, uint32_t idlen , char* data, uint32_t datalen  );
+
+         __attribute__((eosio_wasm_import))
          void set_kv_parameters_packed( const char* data, uint32_t datalen );
 
          __attribute((eosio_wasm_import))
@@ -169,6 +175,27 @@ namespace eosio {
       )
    };
 
+   enum {
+      max_block_net_usage_id,
+      target_block_net_usage_pct_id,
+      max_transaction_net_usage_id,
+      base_per_transaction_net_usage_id,
+      net_usage_leeway_id,
+      context_free_discount_net_usage_num_id,
+      context_free_discount_net_usage_den_id,
+      max_block_cpu_usage_id,
+      target_block_cpu_usage_pct_id,
+      max_transaction_cpu_usage_id,
+      min_transaction_cpu_usage_id,
+      max_transaction_lifetime_id,
+      deferred_trx_expiration_window_id,
+      max_transaction_delay_id,
+      max_inline_action_size_id,
+      max_inline_action_depth_id,
+      max_authority_depth_id,
+      max_action_return_value_size_id
+   };
+
    /**
     *  Set the blockchain parameters
     *
@@ -184,6 +211,23 @@ namespace eosio {
     *  @param params - It will be replaced with the retrieved blockchain params
     */
    void get_blockchain_parameters(eosio::blockchain_parameters& params);
+
+   /**
+    *  Set the blockchain parameters flexibly by id data pair vector
+    *
+    *  @ingroup privileged
+    *  @param params - New blockchain parameters to set, only id and data in the params will be set.
+    */
+   void set_parameters(const std::vector<std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>>>& params);
+
+   /**
+    *  Retrieve the blolckchain parameters flexibly by ids
+    *
+    *  @ingroup privileged
+    *  @param param_ids - The id vecter in which ids are being queried from chain, see upper enum
+    *  @param params - It is output data with the retrieved blockchain params, before call it should be empty
+    */
+   void get_parameters(const std::vector<uint32_t> & param_ids,  std::vector<std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>>>& params);
 
    /**
     *  Tunable KV configuration that can be changed via consensus

--- a/libraries/eosiolib/contracts/eosio/privileged.hpp
+++ b/libraries/eosiolib/contracts/eosio/privileged.hpp
@@ -196,6 +196,8 @@ namespace eosio {
       max_action_return_value_size_id
    };
 
+   using id_param_pairs_type = std::vector<std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>>>;
+
    /**
     *  Set the blockchain parameters
     *
@@ -218,7 +220,7 @@ namespace eosio {
     *  @ingroup privileged
     *  @param params - New blockchain parameters to set, only id and data in the params will be set.
     */
-   void set_parameters(const std::vector<std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>>>& params);
+   void set_parameters(const id_param_pairs_type & params);
 
    /**
     *  Retrieve the blolckchain parameters flexibly by ids
@@ -227,7 +229,7 @@ namespace eosio {
     *  @param param_ids - The id vecter in which ids are being queried from chain, see upper enum
     *  @param params - It is output data with the retrieved blockchain params, before call it should be empty
     */
-   void get_parameters(const std::vector<uint32_t> & param_ids,  std::vector<std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>>>& params);
+   void get_parameters(const std::vector<uint32_t> & param_ids,  id_param_pairs_type & params);
 
    /**
     *  Tunable KV configuration that can be changed via consensus

--- a/libraries/eosiolib/eosiolib.cpp
+++ b/libraries/eosiolib/eosiolib.cpp
@@ -82,6 +82,7 @@ namespace eosio {
          ds << p.first;
          ds << p.second;
       }
+      eosio::check( ds.tellp() <= sizeof(buff), "buffer is too small" );
       set_parameters_packed( buff, ds.tellp() );
    }
 
@@ -96,8 +97,9 @@ namespace eosio {
       for(const auto & id : param_ids){
          id_ds << id;
       }
+      eosio::check( id_ds.tellp() <= sizeof(buff_ids), "ids buffer is too small" );
       uint32_t size = get_parameters_packed( buff_ids,  id_ds.tellp(), buff_params, sizeof(buff_params));
-      eosio::check( size <= sizeof(buff_params), "buffer is too small" );
+      eosio::check( size <= sizeof(buff_params), "params buffer is too small" );
       eosio::datastream<const char*> para_ds( buff_params, size );
       uint32_t para_size;
       para_ds >> para_size;

--- a/libraries/eosiolib/eosiolib.cpp
+++ b/libraries/eosiolib/eosiolib.cpp
@@ -69,11 +69,10 @@ namespace eosio {
       ds >> params;
    }
 
-   using params_type = std::vector<std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>>>;
    //  considering of runtime efficiency, using a estimated size to save the exact size calculating time
    const int estimate_param_ids_buff_size = 128;
    const int estimate_params_buff_size = 256;
-   void set_parameters(const params_type & params) {
+   void set_parameters(const id_param_pairs_type & params) {
       char buff[estimate_params_buff_size];
       unsigned_int size = params.size();
       if(params.size() == 0) return;
@@ -98,7 +97,7 @@ namespace eosio {
       set_parameters_packed( buff, ds.tellp() );
    }
 
-   void get_parameters(const std::vector<uint32_t> & param_ids,  params_type & params) {
+   void get_parameters(const std::vector<uint32_t> & param_ids,  id_param_pairs_type & params) {
       char buff_ids[estimate_param_ids_buff_size];
       char buff_params[estimate_params_buff_size];
       unsigned_int id_size = param_ids.size();

--- a/libraries/eosiolib/eosiolib.cpp
+++ b/libraries/eosiolib/eosiolib.cpp
@@ -69,16 +69,17 @@ namespace eosio {
       ds >> params;
    }
 
+   using params_type = std::vector<std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>>>;
    //  considering of runtime efficiency, using a estimated size to save the exact size calculating time
    const int estimate_param_ids_buff_size = 128;
    const int estimate_params_buff_size = 256;
-   void set_parameters(const std::vector<std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>>>& params) {
+   void set_parameters(const params_type & params) {
       char buff[estimate_params_buff_size];
       unsigned_int size = params.size();
       if(params.size() == 0) return;
       eosio::datastream<char *> ds( buff, sizeof(buff) );
       ds << size;
-      for(const std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>> & p : params ){
+      for(const auto & p : params ){
          unsigned_int id = p.first;
          ds << id;
          std::variant<uint16_t, uint32_t, uint64_t> var = p.second;
@@ -97,7 +98,7 @@ namespace eosio {
       set_parameters_packed( buff, ds.tellp() );
    }
 
-   void get_parameters(const std::vector<uint32_t> & param_ids,  std::vector<std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>>>& params) {
+   void get_parameters(const std::vector<uint32_t> & param_ids,  params_type & params) {
       char buff_ids[estimate_param_ids_buff_size];
       char buff_params[estimate_params_buff_size];
       unsigned_int id_size = param_ids.size();

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -34,6 +34,12 @@ extern "C" {
    void set_blockchain_parameters_packed( char* data, uint32_t datalen ) {
       return intrinsics::get().call<intrinsics::set_blockchain_parameters_packed>(data, datalen);
    }
+   uint32_t get_parameters_packed( char* id, uint32_t idlen, char* data, uint32_t datalen) {
+      return intrinsics::get().call<intrinsics::get_parameters_packed>(id, idlen, data, datalen);
+   }
+   void set_parameters_packed( char* data, uint32_t datalen ) {
+      return intrinsics::get().call<intrinsics::set_parameters_packed>(data, datalen);
+   }
    void set_kv_parameters_packed( const char* data, uint32_t datalen ) {
       return intrinsics::get().call<intrinsics::set_kv_parameters_packed>(data, datalen);
    }

--- a/libraries/native/native/eosio/intrinsics_def.hpp
+++ b/libraries/native/native/eosio/intrinsics_def.hpp
@@ -47,6 +47,8 @@ intrinsic_macro(set_proposed_producers) \
 intrinsic_macro(set_proposed_producers_ex) \
 intrinsic_macro(get_blockchain_parameters_packed) \
 intrinsic_macro(set_blockchain_parameters_packed) \
+intrinsic_macro(get_parameters_packed) \
+intrinsic_macro(set_parameters_packed) \
 intrinsic_macro(set_kv_parameters_packed) \
 intrinsic_macro(is_privileged) \
 intrinsic_macro(set_privileged) \

--- a/tests/toolchain/compile-fail/host_functions_tests.cpp
+++ b/tests/toolchain/compile-fail/host_functions_tests.cpp
@@ -61,7 +61,7 @@ extern "C" __attribute__((eosio_wasm_import)) void send_deferred(const uint128_t
 extern "C" __attribute__((eosio_wasm_import)) int64_t set_proposed_producers( char*, uint32_t );
 extern "C" __attribute__((eosio_wasm_import)) int64_t set_proposed_producers_ex( uint64_t producer_data_format, char *producer_data, uint32_t producer_data_size );
 extern "C" __attribute__((eosio_wasm_import)) void set_wasm_parameters_packed(const void*, std::size_t);
-extern "C" __attribute__((eosio_wasm_import)) void set_parameters_packed( const char* params, uint32_t params_size );
+extern "C" __attribute__((eosio_wasm_import)) void set_parameters_packed( char* params, uint32_t params_size );
 
 extern "C" __attribute__((eosio_wasm_import)) void send_inline(char *serialized_action, size_t size);
 extern "C" __attribute__((eosio_wasm_import)) void send_context_free_inline(char *serialized_action, size_t size);

--- a/tests/unit/test_contracts/CMakeLists.txt
+++ b/tests/unit/test_contracts/CMakeLists.txt
@@ -14,6 +14,7 @@ add_contract(kv_map_tests kv_map_tests kv_map_tests.cpp)
 add_contract(capi_tests capi_tests capi/capi.c capi/action.c capi/chain.c capi/crypto.c capi/db.c capi/permission.c
                                    capi/print.c capi/privileged.c capi/system.c capi/transaction.c)
 add_contract(kv_bios kv_bios kv_bios/kv_bios.cpp)
+add_contract(parameter_tests parameter_tests parameter_tests.cpp )
 
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/simple_wrong.abi ${CMAKE_CURRENT_BINARY_DIR}/simple_wrong.abi COPYONLY )
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/capi/capi_tests.abi ${CMAKE_CURRENT_BINARY_DIR}/capi_tests.abi COPYONLY )

--- a/tests/unit/test_contracts/capi/privileged.c
+++ b/tests/unit/test_contracts/capi/privileged.c
@@ -10,5 +10,7 @@ void test_privileged( void ) {
    set_privileged(0, 0);
    set_blockchain_parameters_packed(NULL, 0);
    get_blockchain_parameters_packed(NULL, 0);
+   set_parameters_packed(NULL, 0);
+   get_parameters_packed(NULL, 0, NULL, 0);
    preactivate_feature(NULL);
 }

--- a/tests/unit/test_contracts/parameter_tests.cpp
+++ b/tests/unit/test_contracts/parameter_tests.cpp
@@ -1,0 +1,87 @@
+#include <eosio/contract.hpp>
+#include <eosio/name.hpp>
+#include <eosio/privileged.hpp>
+
+
+using namespace eosio;
+
+namespace eosio {
+   extern "C" {
+     __attribute__((eosio_wasm_import))
+     void set_blockchain_parameters_packed(char*, uint32_t);
+     __attribute__((eosio_wasm_import))
+     uint32_t get_blockchain_parameters_packed(char*, uint32_t);
+     __attribute__((eosio_wasm_import))
+     void set_parameters_packed(char*, uint32_t);
+     __attribute__((eosio_wasm_import))
+     uint32_t get_parameters_packed(char*, uint32_t, char*, uint32_t);
+   }
+}
+// test set_parameters and get_parameters which flexibly set or get chain parameters by ids
+class [[eosio::contract]] parameter_tests : eosio::contract {
+ public:
+   using contract::contract;
+
+   // usage: cleos -v push action eosio getall '[]' -p eosio@active
+   [[eosio::action]] eosio::blockchain_parameters getall(){
+      eosio::blockchain_parameters params;
+      get_blockchain_parameters(params);
+      int id = 0;
+      eosio::cout << "id =" << id++ << ", max_block_net_usage=" << params.max_block_net_usage << "\n";
+      eosio::cout << "id =" << id++ << ", target_block_net_usage_pct=" << params.target_block_net_usage_pct << "\n";
+      eosio::cout << "id =" << id++ << ", max_transaction_net_usage=" << params.max_transaction_net_usage << "\n";
+      eosio::cout << "id =" << id++ << ", base_per_transaction_net_usage=" << params.base_per_transaction_net_usage << "\n";
+      eosio::cout << "id =" << id++ << ", net_usage_leeway=" << params.net_usage_leeway << "\n";
+      eosio::cout << "id =" << id++ << ", context_free_discount_net_usage_num=" << params.context_free_discount_net_usage_num << "\n";
+      eosio::cout << "id =" << id++ << ", context_free_discount_net_usage_den=" << params.context_free_discount_net_usage_den << "\n";
+      eosio::cout << "id =" << id++ << ", max_block_cpu_usage=" << params.max_block_cpu_usage << "\n";
+      eosio::cout << "id =" << id++ << ", target_block_cpu_usage_pct=" << params.target_block_cpu_usage_pct << "\n";
+      eosio::cout << "id =" << id++ << ", max_transaction_cpu_usage=" << params.max_transaction_cpu_usage << "\n";
+      eosio::cout << "id =" << id++ << ", min_transaction_cpu_usage=" << params.min_transaction_cpu_usage << "\n";
+      eosio::cout << "id =" << id++ << ", max_transaction_lifetime=" << params.max_transaction_lifetime << "\n";
+      eosio::cout << "id =" << id++ << ", deferred_trx_expiration_window=" << params.deferred_trx_expiration_window << "\n";
+      eosio::cout << "id =" << id++ << ", max_transaction_delay=" << params.max_transaction_delay << "\n";
+      eosio::cout << "id =" << id++ << ", max_inline_action_size=" << params.max_inline_action_size << "\n";
+      eosio::cout << "id =" << id++ << ", max_inline_action_depth=" << params.max_inline_action_depth << "\n";
+      eosio::cout << "id =" << id++ << ", max_authority_depth=" << params.max_authority_depth << "\n";
+      return params;
+   }
+   /*
+   enum {
+      max_block_net_usage_id,
+      target_block_net_usage_pct_id,
+      max_transaction_net_usage_id,
+      base_per_transaction_net_usage_id,
+      net_usage_leeway_id,
+      context_free_discount_net_usage_num_id,
+      context_free_discount_net_usage_den_id,
+      max_block_cpu_usage_id,
+      target_block_cpu_usage_pct_id,
+      max_transaction_cpu_usage_id,
+      min_transaction_cpu_usage_id,
+      max_transaction_lifetime_id,
+      deferred_trx_expiration_window_id,
+      max_transaction_delay_id,
+      max_inline_action_size_id,
+      max_inline_action_depth_id,
+      max_authority_depth_id,
+      max_action_return_value_size_id
+   };
+*/
+   //usage:  cleos -v push action eosio get '[[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17]]' -p eosio@active
+   [[eosio::action]] std::vector<std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>>> get(  std::vector<uint32_t>  param_ids){
+      std::vector<std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>>>  params;
+      get_parameters(param_ids, params);
+      for(const auto & p : params){
+         std::variant<uint16_t, uint32_t, uint64_t> var = p.second;
+         eosio::cout << "id = " << p.first << ", value= " <<  (std::holds_alternative<uint16_t>(var) ? std::get<uint16_t>(var) :
+                                             std::holds_alternative<uint32_t>(var) ? std::get<uint32_t>(var) : std::get<uint64_t>(var) ) << "\n";
+      }
+      return params;
+   }
+   //usage: cleos -v push action eosio set '[[{"first":0,"second":["uint64",1048800]},{"first":1,"second":["uint32",1008]}, {"first":2,"second":["uint32",524290]},{"first":15,"second":["uint16",5]}, {"first":16,"second":["uint16",7]}]]' -p eosio@active
+   [[eosio::action]] void set( std::vector<std::pair<uint32_t, std::variant<uint16_t, uint32_t, uint64_t>>>  params  ){
+      set_parameters(params);
+      return;
+   }
+};


### PR DESCRIPTION
See EPE665 also.
Add user function get/set_parameters to support host function get/set_parameters_packed, and also test contract for it, test actions passed.

For the eos part is hard to change as a released host function, so I changed cdt part format to adapt eos part now it works well without eos change.

note: before set contract, need active parameter feature firstly. just run "cleos system activate PREACTIVATE_FEATURE" , this feature is not activated by default.

cleos -v push action eosio get '[[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17]]' -p eosio@active
executed transaction: 714d42fb2c5cf023b4d9c5cfcb153e2df9c64f5b1ad7a90fb72eff882ab5e63b  168 bytes  786 us
#         eosio <= eosio::get                   {"param_ids":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17]}
=>                                return value: [{"first":0,"second":["uint64",1048800]},{"first":1,"second":["uint32",1008]},{"first":2,"second":["...
>> id = 0, value= 1048800
>> id = 1, value= 1008
>> id = 2, value= 524290
>> id = 3, value= 12
>> id = 4, value= 500
>> id = 5, value= 20
>> id = 6, value= 100
>> id = 7, value= 200000
>> id = 8, value= 1000
>> id = 9, value= 150000
>> id = 10, value= 100
>> id = 11, value= 3600
>> id = 12, value= 600
>> id = 13, value= 3888000
>> id = 14, value= 524288
>> id = 15, value= 5
>> id = 16, value= 7
>> id = 17, value= 256

cleos -v push action eosio set '[[{"first":0,"second":["uint64",4448800]},{"first":1,"second":["uint32",1228]}, {"first":2,"second":["uint32",528890]},{"first":15,"second":["uint16",15]}, {"first":16,"second":["uint16",17]}]]' -p eosio@active
executed transaction: 4515d16856411413ae5c1c8b935328607fa50f674f3b5e54c050b56ce706f14a  1168 bytes  1000 us
#         eosio <= eosio::set                   {"params":[{"first":0,"second":["uint64",4448800]},{"first":1,"second":["uint32",1228]},{"first":2,"...
warning: transaction executed locally, but may not be confirmed by the network yet


cleos -v push action eosio get '[[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17]]' -p eosio@active                                                                        executed transaction: a00680833af891a8155c45811a7e8038f6f1c83b72ff1a0ff3963ac0a799ff0d  1192 bytes  1000 us
#         eosio <= eosio::get                   {"param_ids":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17]}
=>                                return value: [{"first":0,"second":["uint64",4448800]},{"first":1,"second":["uint32",1228]},{"first":2,"second":["...
>> id = 0, value= 4448800
>> id = 1, value= 1228
>> id = 2, value= 528890
>> id = 3, value= 1024
>> id = 4, value= 700
>> id = 5, value= 50
>> id = 6, value= 120
>> id = 7, value= 250000
>> id = 8, value= 1500
>> id = 9, value= 230000
>> id = 10, value= 1000
>> id = 11, value= 1800
>> id = 12, value= 900
>> id = 13, value= 2592000
>> id = 14, value= 1048576
>> id = 15, value= 15
>> id = 16, value= 17
>> id = 17, value= 512
warning: transaction executed locally, but may not be confirmed by the network yet         ]

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->


## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->

The ids from 0 to 17 have this meaning :
   enum {
      max_block_net_usage_id,
      target_block_net_usage_pct_id,
      max_transaction_net_usage_id,
      base_per_transaction_net_usage_id,
      net_usage_leeway_id,
      context_free_discount_net_usage_num_id,
      context_free_discount_net_usage_den_id,
      max_block_cpu_usage_id,
      target_block_cpu_usage_pct_id,
      max_transaction_cpu_usage_id,
      min_transaction_cpu_usage_id,
      max_transaction_lifetime_id,
      deferred_trx_expiration_window_id,
      max_transaction_delay_id,
      max_inline_action_size_id,
      max_inline_action_depth_id,
      max_authority_depth_id,
      max_action_return_value_size_id
   };

For the value of these ids,  max_block_net_usage is unit64_t, max_inline_action_depth and max_authority_depth is uint16_t, and others are all uint32_t.
The the data transform before/after pack/unpack to/from datastream:
size  uint32<->unsinged_int 
id     uint32<->unsinged_int
data  keep as uint16/32/64 
note: unsigned_int is a struct, not unsigned int