### PR TITLE
Unify format of get/set_parameters_packed

### DIFF
--- a/libraries/eosiolib/capi/eosio/privileged.h
+++ b/libraries/eosiolib/capi/eosio/privileged.h
@@ -106,10 +106,10 @@ __attribute__((eosio_wasm_import))
 uint32_t get_blockchain_parameters_packed( char* data, uint32_t datalen );
 
  __attribute__((eosio_wasm_import))
- void set_parameters_packed( char* data, uint32_t datalen );
+ void set_parameters_packed(const char* data, uint32_t datalen );
 
  __attribute__((eosio_wasm_import))
- uint32_t get_parameters_packed( char* id, uint32_t idlen , char* data, uint32_t datalen  );
+ uint32_t get_parameters_packed(const char* id, uint32_t idlen , char* data, uint32_t datalen  );
 
 /**
  * Set the KV parameters

--- a/libraries/eosiolib/contracts/eosio/privileged.hpp
+++ b/libraries/eosiolib/contracts/eosio/privileged.hpp
@@ -28,10 +28,10 @@ namespace eosio {
          uint32_t get_blockchain_parameters_packed( char* data, uint32_t datalen );
 
          __attribute__((eosio_wasm_import))
-         void set_parameters_packed( char* data, uint32_t datalen );
+         void set_parameters_packed(const char* data, uint32_t datalen );
 
          __attribute__((eosio_wasm_import))
-         uint32_t get_parameters_packed( char* id, uint32_t idlen , char* data, uint32_t datalen  );
+         uint32_t get_parameters_packed(const char* id, uint32_t idlen , char* data, uint32_t datalen  );
 
          __attribute__((eosio_wasm_import))
          void set_kv_parameters_packed( const char* data, uint32_t datalen );

--- a/libraries/eosiolib/eosiolib.cpp
+++ b/libraries/eosiolib/eosiolib.cpp
@@ -17,9 +17,9 @@ namespace eosio {
      __attribute__((eosio_wasm_import))
      uint32_t get_blockchain_parameters_packed(char*, uint32_t);
      __attribute__((eosio_wasm_import))
-     void set_parameters_packed(char*, uint32_t);
+     void set_parameters_packed(const char*, uint32_t);
      __attribute__((eosio_wasm_import))
-     uint32_t get_parameters_packed(char*, uint32_t, char*, uint32_t);
+     uint32_t get_parameters_packed(const char*, uint32_t, char*, uint32_t);
      __attribute__((eosio_wasm_import))
      int64_t set_proposed_producers( char *producer_data, uint32_t producer_data_size );
      __attribute__((eosio_wasm_import))

--- a/libraries/native/intrinsics.cpp
+++ b/libraries/native/intrinsics.cpp
@@ -34,10 +34,10 @@ extern "C" {
    void set_blockchain_parameters_packed( char* data, uint32_t datalen ) {
       return intrinsics::get().call<intrinsics::set_blockchain_parameters_packed>(data, datalen);
    }
-   uint32_t get_parameters_packed( char* id, uint32_t idlen, char* data, uint32_t datalen) {
+   uint32_t get_parameters_packed(const char* id, uint32_t idlen, char* data, uint32_t datalen) {
       return intrinsics::get().call<intrinsics::get_parameters_packed>(id, idlen, data, datalen);
    }
-   void set_parameters_packed( char* data, uint32_t datalen ) {
+   void set_parameters_packed(const char* data, uint32_t datalen ) {
       return intrinsics::get().call<intrinsics::set_parameters_packed>(data, datalen);
    }
    void set_kv_parameters_packed( const char* data, uint32_t datalen ) {

--- a/tests/toolchain/compile-fail/host_functions_tests.cpp
+++ b/tests/toolchain/compile-fail/host_functions_tests.cpp
@@ -61,7 +61,7 @@ extern "C" __attribute__((eosio_wasm_import)) void send_deferred(const uint128_t
 extern "C" __attribute__((eosio_wasm_import)) int64_t set_proposed_producers( char*, uint32_t );
 extern "C" __attribute__((eosio_wasm_import)) int64_t set_proposed_producers_ex( uint64_t producer_data_format, char *producer_data, uint32_t producer_data_size );
 extern "C" __attribute__((eosio_wasm_import)) void set_wasm_parameters_packed(const void*, std::size_t);
-extern "C" __attribute__((eosio_wasm_import)) void set_parameters_packed( char* params, uint32_t params_size );
+extern "C" __attribute__((eosio_wasm_import)) void set_parameters_packed(const char* params, uint32_t params_size );
 
 extern "C" __attribute__((eosio_wasm_import)) void send_inline(char *serialized_action, size_t size);
 extern "C" __attribute__((eosio_wasm_import)) void send_context_free_inline(char *serialized_action, size_t size);

--- a/tests/unit/test_contracts/parameter_tests.cpp
+++ b/tests/unit/test_contracts/parameter_tests.cpp
@@ -12,9 +12,9 @@ namespace eosio {
      __attribute__((eosio_wasm_import))
      uint32_t get_blockchain_parameters_packed(char*, uint32_t);
      __attribute__((eosio_wasm_import))
-     void set_parameters_packed(char*, uint32_t);
+     void set_parameters_packed(const char*, uint32_t);
      __attribute__((eosio_wasm_import))
-     uint32_t get_parameters_packed(char*, uint32_t, char*, uint32_t);
+     uint32_t get_parameters_packed(const char*, uint32_t, char*, uint32_t);
    }
 }
 // test set_parameters and get_parameters which flexibly set or get chain parameters by ids

--- a/tests/unit/test_contracts/parameter_tests.cpp
+++ b/tests/unit/test_contracts/parameter_tests.cpp
@@ -5,18 +5,6 @@
 
 using namespace eosio;
 
-namespace eosio {
-   extern "C" {
-     __attribute__((eosio_wasm_import))
-     void set_blockchain_parameters_packed(char*, uint32_t);
-     __attribute__((eosio_wasm_import))
-     uint32_t get_blockchain_parameters_packed(char*, uint32_t);
-     __attribute__((eosio_wasm_import))
-     void set_parameters_packed(const char*, uint32_t);
-     __attribute__((eosio_wasm_import))
-     uint32_t get_parameters_packed(const char*, uint32_t, char*, uint32_t);
-   }
-}
 // test set_parameters and get_parameters which flexibly set or get chain parameters by ids
 class [[eosio::contract]] parameter_tests : eosio::contract {
  public:


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

See EPE 2001 also.

Currently there are 3 format of get/set_parameters_packed formats.
void set_parameters_packed( char* data, uint32_t datalen ) , 
void set_parameters_packed( const char* params, uint32_t params_size );
void set_parameters_packed(const char*, std::size_t);

unified to void set_parameters_packed( const char* , uint32_t );

For get_parameters_packed, unified to get_parameters_packed( const char* , uint32_t,  char* , uint32_t );

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
