### PR TITLE
Fix libc build on MacOS

### DIFF
--- a/libraries/libc/CMakeLists.txt
+++ b/libraries/libc/CMakeLists.txt
@@ -20,10 +20,6 @@ set(INTERNAL_SOURCES musl/src/internal/floatscan.c musl/src/internal/intscan.c m
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-everything -allow-sse")
 set(CMAKE_BUILD_TYPE "Release")
 
-if(__APPLE)
-  add_definitions(-D__APPLE__)
-endif()
-
 file(GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/musl/include/*.h"
                   "${CMAKE_CURRENT_SOURCE_DIR}/musl/src/internal/*.h"
                   "${CMAKE_CURRENT_SOURCE_DIR}/musl/arch/eos/*.h")
@@ -90,6 +86,9 @@ target_include_directories(native_c
 
 target_compile_options(c PUBLIC "-fno-default-paths")
 target_compile_options(native_c PUBLIC "-fno-default-paths")
+if(__APPLE)
+  target_compile_options(native_c PRIVATE -D__APPLE__)
+endif()
 
 add_custom_command( TARGET c POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:c> ${BASE_BINARY_DIR}/lib )
 add_custom_command( TARGET native_c POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:native_c> ${BASE_BINARY_DIR}/lib )


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
This PR fixes `libc.a` difference between Linux and MacOS builds. Previously, when macro `__APPLE__` is defined for native builds of `libnative_c.a` (https://github.com/EOSIO/eosio.cdt/pull/738/commits/2e0e344b65c9e6f4afc4e7e846be93ff3d267a0b), it is still defined when building non-native `libc.a` (containing WASM object files). And due to https://github.com/EOSIO/musl/commit/208f308e1cd7816f61fc83b3f1cd2e5da3f4a5a7, e.g. in `fflush.c`
```
#ifdef __APPLE__
   static FILE *volatile __stdout_used = 0;
#else
   weak_alias(dummy, __stdout_used);
#endif

int fflush(FILE *f)
{
```
macro ` __APPLE__` causes the WASM code of some functions (e.g. above `fflush`) in `libc.a` (and finally contracts that use these functions) to be different between Linux and MacOS. This PR limits ` __APPLE__` to native_c builds.

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
