### PR TITLE
Remove macOS 10.14 from buildkite pipeline

### DIFF
--- a/.cicd/README.md
+++ b/.cicd/README.md
@@ -31,7 +31,6 @@ RUN_ALL_TESTS='true'                 # run all tests in the current build (inclu
 SKIP_AMAZON_LINUX_2='true|false'     # skip all steps for Amazon Linux 2
 SKIP_CENTOS_7='true|false'           # skip all steps for Centos 7
 SKIP_CENTOS_8='true|false'           # skip all steps for Centos 8
-SKIP_MACOS_10_14='true|false'        # skip all steps for MacOS 10.14
 SKIP_MACOS_10_15='true|false'        # skip all steps for MacOS 10.15
 SKIP_UBUNTU_16_04='true|false'       # skip all steps for Ubuntu 16.04
 SKIP_UBUNTU_18_04='true|false'       # skip all steps for Ubuntu 18.04

--- a/.cicd/pipeline-upload.sh
+++ b/.cicd/pipeline-upload.sh
@@ -12,7 +12,6 @@ if [[ "$BUILDKITE" == 'true' && "$RETRY" == '0' ]]; then
 elif [[ "$BUILDKITE" == 'true' ]]; then
     printf "Skipping \033]1339;url=$DOCS_URL;content=documentation\a upload for job retry number $RETRY.\n"
 fi
-export MACOS_10_14_TAG="eosio-cdt-macos-10.14-$(sha1sum .cicd/platforms/macos-10.14.sh | awk '{print $1}')"
 export MACOS_10_15_TAG="eosio-cdt-macos-10.15-$(sha1sum .cicd/platforms/macos-10.15.sh | awk '{print $1}')"
 # pipeline upload
 echo '+++ :pipeline_upload: Deploying Pipeline Steps'

--- a/.cicd/pipeline.yml
+++ b/.cicd/pipeline.yml
@@ -45,45 +45,6 @@ steps:
     timeout: ${TIMEOUT:-60}
     skip: ${SKIP_UBUNTU_18}${SKIP_LINUX}
 
-  - label: ":darwin: macOS 10.14 - Build"
-    command:
-      - "git clone $BUILDKITE_REPO eosio.cdt"
-      - "cd eosio.cdt && if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then git fetch -v --prune origin refs/pull/$(echo $BUILDKITE_BRANCH | cut -d/ -f2)/head; fi"
-      - "cd eosio.cdt && git checkout -f $BUILDKITE_COMMIT && git submodule update --init --recursive"
-      - "cd eosio.cdt && ./.cicd/build.sh"
-      - "cd eosio.cdt && tar -pczf build.tar.gz build && buildkite-agent artifact upload build.tar.gz"
-    plugins:
-      - EOSIO/anka#v0.6.0:
-          no-volume: true
-          inherit-environment-vars: true
-          vm-name: 10.14.6_6C_14G_80G
-          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent::${MACOS_10_14_TAG}"
-          modify-cpu: 12
-          modify-ram: 24
-          always-pull: true
-          debug: true
-          wait-network: true
-          pre-execute-sleep: 5
-          pre-execute-ping-sleep: github.com
-          failover-registries:
-            - 'registry-1'
-            - 'registry-2'
-          pre-commands:
-            - "rm -rf mac-anka-fleet; git clone git@github.com:EOSIO/mac-anka-fleet.git && cd mac-anka-fleet && . ./ensure-tag.bash -u 12 -r 25G -a '-n'"
-      - EOSIO/skip-checkout#v0.1.1:
-          cd: ~
-    env:
-      PROJECT_TAG: ${MACOS_10_14_TAG}
-      REPO: ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO}
-      REPO_COMMIT: $BUILDKITE_COMMIT
-      TAG_COMMANDS: "git clone ${BUILDKITE_PULL_REQUEST_REPO:-$BUILDKITE_REPO} eosio.cdt && cd eosio.cdt && git checkout -f $BUILDKITE_COMMIT && git submodule update --init --recursive && . ./.cicd/platforms/macos-10.14.sh && cd ~/eosio.cdt && cd .. && rm -rf eosio.cdt"
-      TEMPLATE: 10.14.6_6C_14G_80G
-      TEMPLATE_TAG: clean::cicd::git-ssh::nas::brew::buildkite-agent
-    timeout: ${TIMEOUT:-120}
-    agents:
-      - "queue=mac-anka-large-node-fleet"
-    skip: ${SKIP_MACOS_10_14}${SKIP_MAC}
-
   - label: ":darwin: macOS 10.15 - Build"
     command:
       - "git clone $BUILDKITE_REPO eosio.cdt"
@@ -169,34 +130,6 @@ steps:
     timeout: ${TIMEOUT:-10}
     skip: ${SKIP_UBUNTU_18}${SKIP_LINUX}${SKIP_UNIT_TESTS}
 
-  - label: ":darwin: macOS 10.14 - Unit Tests"
-    command:
-      - "git clone $BUILDKITE_REPO eosio.cdt"
-      - "cd eosio.cdt && if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then git fetch -v --prune origin refs/pull/$(echo $BUILDKITE_BRANCH | cut -d/ -f2)/head; fi"
-      - "cd eosio.cdt && git checkout -f $BUILDKITE_COMMIT && git submodule update --init --recursive"
-      - "cd eosio.cdt && buildkite-agent artifact download build.tar.gz . --step ':darwin: macOS 10.14 - Build' && tar -xzf build.tar.gz"
-      - "cd eosio.cdt && ./.cicd/tests.sh"
-    plugins:
-      - EOSIO/anka#v0.6.0:
-          no-volume: true
-          inherit-environment-vars: true
-          vm-name: 10.14.6_6C_14G_80G
-          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent::${MACOS_10_14_TAG}"
-          always-pull: true
-          debug: true
-          wait-network: true
-          pre-execute-sleep: 5
-          pre-execute-ping-sleep: github.com
-          failover-registries:
-            - 'registry-1'
-            - 'registry-2'
-      - EOSIO/skip-checkout#v0.1.1:
-          cd: ~
-    agents:
-      - "queue=mac-anka-node-fleet"
-    timeout: ${TIMEOUT:-20}
-    skip: ${SKIP_MACOS_10_14}${SKIP_MAC}${SKIP_UNIT_TESTS}
-
   - label: ":darwin: macOS 10.15 - Unit Tests"
     command:
       - "git clone $BUILDKITE_REPO eosio.cdt"
@@ -268,34 +201,6 @@ steps:
       queue: "automation-eks-eos-tester-fleet"
     timeout: ${TIMEOUT:-10}
     skip: ${SKIP_UBUNTU_18}${SKIP_LINUX}${SKIP_TOOLCHAIN_TESTS}
-
-  - label: ":darwin: macOS 10.14 - Toolchain Tests"
-    command:
-      - "git clone $BUILDKITE_REPO eosio.cdt"
-      - "cd eosio.cdt && if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then git fetch -v --prune origin refs/pull/$(echo $BUILDKITE_BRANCH | cut -d/ -f2)/head; fi"
-      - "cd eosio.cdt && git checkout -f $BUILDKITE_COMMIT && git submodule update --init --recursive"
-      - "cd eosio.cdt && buildkite-agent artifact download build.tar.gz . --step ':darwin: macOS 10.14 - Build' && tar -xzf build.tar.gz"
-      - "cd eosio.cdt && ./.cicd/toolchain-tests.sh"
-    plugins:
-      - EOSIO/anka#v0.6.0:
-          no-volume: true
-          inherit-environment-vars: true
-          vm-name: 10.14.6_6C_14G_80G
-          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent::${MACOS_10_14_TAG}"
-          always-pull: true
-          debug: true
-          wait-network: true
-          pre-execute-sleep: 5
-          pre-execute-ping-sleep: github.com
-          failover-registries:
-            - 'registry-1'
-            - 'registry-2'
-      - EOSIO/skip-checkout#v0.1.1:
-          cd: ~
-    agents:
-      - "queue=mac-anka-node-fleet"
-    timeout: ${TIMEOUT:-20}
-    skip: ${SKIP_MACOS_10_14}${SKIP_MAC}${SKIP_TOOLCHAIN_TESTS}
 
   - label: ":darwin: macOS 10.15 - Toolchain Tests"
     command:
@@ -411,35 +316,6 @@ steps:
     timeout: ${TIMEOUT:-10}
     skip: ${SKIP_UBUNTU_18}${SKIP_LINUX}${SKIP_PACKAGE_BUILDER}
 
-  - label: ":darwin: Mojave - Package Builder"
-    command:
-      - "git clone $BUILDKITE_REPO eosio.cdt"
-      - "cd eosio.cdt && if [[ $BUILDKITE_BRANCH =~ ^pull/[0-9]+/head: ]]; then git fetch -v --prune origin refs/pull/$(echo $BUILDKITE_BRANCH | cut -d/ -f2)/head; fi"
-      - "cd eosio.cdt && git checkout -f $BUILDKITE_COMMIT && git submodule update --init --recursive"
-      - "cd eosio.cdt && buildkite-agent artifact download build.tar.gz . --step ':darwin: macOS 10.14 - Build' && tar -xzf build.tar.gz"
-      - "cd eosio.cdt && ./.cicd/package.sh"
-    plugins:
-      - EOSIO/anka#v0.5.7:
-          no-volume: true
-          pre-execute-ping-sleep: "8.8.8.8"
-          inherit-environment-vars: true
-          vm-name: 10.14.6_6C_14G_80G
-          vm-registry-tag: "clean::cicd::git-ssh::nas::brew::buildkite-agent"
-          always-pull: true
-          debug: true
-          wait-network: true
-          pre-execute-sleep: 5
-          pre-execute-ping-sleep: github.com
-          failover-registries:
-            - 'registry-1'
-            - 'registry-2'
-      - EOSIO/skip-checkout#v0.1.1:
-          cd: ~
-    agents:
-      - "queue=mac-anka-node-fleet"
-    timeout: ${TIMEOUT:-20}
-    skip: ${SKIP_MACOS_10_14}${SKIP_MAC}${SKIP_PACKAGE_BUILDER}
-
   - label: ":darwin: Catalina - Package Builder"
     command:
       - "git clone $BUILDKITE_REPO eosio.cdt"
@@ -478,16 +354,13 @@ steps:
 
   - label: ":beer: Brew Updater"
     command: |
-      buildkite-agent artifact download eosio.cdt.rb . --step ':darwin: Mojave - Package Builder'
-      mv eosio.cdt.rb eosio_cdt_mojave.rb
-      buildkite-agent artifact upload eosio_cdt_mojave.rb
       buildkite-agent artifact download eosio.cdt.rb . --step ':darwin: Catalina - Package Builder'
       mv eosio.cdt.rb eosio_cdt_catalina.rb
       buildkite-agent artifact upload eosio_cdt_catalina.rb
     agents:
       queue: "automation-basic-builder-fleet"
     timeout: "${TIMEOUT:-5}"
-    skip: ${SKIP_MACOS_10_14}${SKIP_MACOS_10_15}${SKIP_MAC}${SKIP_PACKAGE_BUILDER}
+    skip: ${SKIP_MACOS_10_15}${SKIP_MAC}${SKIP_PACKAGE_BUILDER}
 
   - label: ":git: Git Submodule Regression Check"
     command:

--- a/.cicd/platforms/macos-10.14.sh
+++ b/.cicd/platforms/macos-10.14.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -eou pipefail
-VERSION=1
-
-brew update && brew upgrade
-brew install automake cmake doxygen gettext git gmp graphviz lcov libtool python@3 wget

--- a/scripts/generate_bottle.sh
+++ b/scripts/generate_bottle.sh
@@ -1,15 +1,15 @@
 #! /bin/bash
 
-VERS=`sw_vers -productVersion | awk '/10\.14\..*/{print $0}'`
+VERS=`sw_vers -productVersion | awk '/10\.15\..*/{print $0}'`
 if [[ -z "$VERS" ]]; then
-   VERS=`sw_vers -productVersion | awk '/10\.15.*/{print $0}'`
+   VERS=`sw_vers -productVersion | awk '/11\.*.*/{print $0}'`
    if [[ -z $VERS ]]; then
       echo "Error, unsupported OS X version"
       exit -1
    fi
-   MAC_VERSION="catalina"
+   MAC_VERSION="big sur"
 else
-   MAC_VERSION="mojave"
+   MAC_VERSION="catalina"
 fi
 
 NAME="${PROJECT}-${VERSION}.${MAC_VERSION}.bottle"

--- a/scripts/generate_bottle.sh
+++ b/scripts/generate_bottle.sh
@@ -2,7 +2,7 @@
 
 VERS=`sw_vers -productVersion | awk '/10\.15\..*/{print $0}'`
 if [[ -z "$VERS" ]]; then
-   VERS=`sw_vers -productVersion | awk '/11\.*.*/{print $0}'`
+   VERS=`sw_vers -productVersion | awk '/11\..*/{print $0}'`
    if [[ -z $VERS ]]; then
       echo "Error, unsupported OS X version"
       exit -1


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
macOS 10.14 support is out of date and thus removed from CI pipeline for `develop-boxed` branch. (It has already been removed from `develop` and `release/1.8.x`, see https://github.com/EOSIO/eosio.cdt/pull/1243)

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
