### PR TITLE
Include crt0.o in Binary Package Install

### DIFF
--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -euo pipefail
 
 NAME=$1
 CDT_PREFIX=${PREFIX}/${SUBPREFIX}
@@ -14,35 +15,35 @@ mkdir -p ${CDT_PREFIX}/licenses
 #echo "${PREFIX} ** ${SUBPREFIX} ** ${CDT_PREFIX}"
 
 # install binaries
-cp -R ${BUILD_DIR}/bin/* ${CDT_PREFIX}/bin || exit 1
-cp -R ${BUILD_DIR}/licenses/* ${CDT_PREFIX}/licenses || exit 1
+cp -R ${BUILD_DIR}/bin/* ${CDT_PREFIX}/bin
+cp -R ${BUILD_DIR}/licenses/* ${CDT_PREFIX}/licenses
 
 # install cmake modules
-sed "s/_PREFIX_/\/${SPREFIX}/g" ${BUILD_DIR}/modules/EosioCDTMacrosPackage.cmake &> ${CDT_PREFIX}/lib/cmake/${PROJECT}/EosioCDTMacros.cmake || exit 1
-sed "s/_PREFIX_/\/${SPREFIX}/g" ${BUILD_DIR}/modules/EosioWasmToolchainPackage.cmake &> ${CDT_PREFIX}/lib/cmake/${PROJECT}/EosioWasmToolchain.cmake || exit 1
-sed "s/_PREFIX_/\/${SPREFIX}\/${SSUBPREFIX}/g" ${BUILD_DIR}/modules/${PROJECT}-config.cmake.package &> ${CDT_PREFIX}/lib/cmake/${PROJECT}/${PROJECT}-config.cmake || exit 1
+sed "s/_PREFIX_/\/${SPREFIX}/g" ${BUILD_DIR}/modules/EosioCDTMacrosPackage.cmake &> ${CDT_PREFIX}/lib/cmake/${PROJECT}/EosioCDTMacros.cmake
+sed "s/_PREFIX_/\/${SPREFIX}/g" ${BUILD_DIR}/modules/EosioWasmToolchainPackage.cmake &> ${CDT_PREFIX}/lib/cmake/${PROJECT}/EosioWasmToolchain.cmake
+sed "s/_PREFIX_/\/${SPREFIX}\/${SSUBPREFIX}/g" ${BUILD_DIR}/modules/${PROJECT}-config.cmake.package &> ${CDT_PREFIX}/lib/cmake/${PROJECT}/${PROJECT}-config.cmake
 
 # install scripts
-cp -R ${BUILD_DIR}/scripts/* ${CDT_PREFIX}/scripts  || exit 1
+cp -R ${BUILD_DIR}/scripts/* ${CDT_PREFIX}/scripts 
 
 # install misc.
-cp ${BUILD_DIR}/eosio.imports ${CDT_PREFIX} || exit 1
+cp ${BUILD_DIR}/eosio.imports ${CDT_PREFIX}
 
 # install wasm includes
-cp -R ${BUILD_DIR}/include/* ${CDT_PREFIX}/include || exit 1
+cp -R ${BUILD_DIR}/include/* ${CDT_PREFIX}/include
 
 # install wasm libs
-cp ${BUILD_DIR}/lib/*.a ${CDT_PREFIX}/lib || exit 1
+cp ${BUILD_DIR}/lib/*.a ${CDT_PREFIX}/lib
 
 # make symlinks
 pushd ${PREFIX}/lib/cmake/${PROJECT} &> /dev/null
-ln -sf ../../../${SUBPREFIX}/lib/cmake/${PROJECT}/${PROJECT}-config.cmake ${PROJECT}-config.cmake || exit 1
-ln -sf ../../../${SUBPREFIX}/lib/cmake/${PROJECT}/EosioWasmToolchain.cmake EosioWasmToolchain.cmake || exit 1
-ln -sf ../../../${SUBPREFIX}/lib/cmake/${PROJECT}/EosioCDTMacros.cmake EosioCDTMacros.cmake || exit 1
+ln -sf ../../../${SUBPREFIX}/lib/cmake/${PROJECT}/${PROJECT}-config.cmake ${PROJECT}-config.cmake
+ln -sf ../../../${SUBPREFIX}/lib/cmake/${PROJECT}/EosioWasmToolchain.cmake EosioWasmToolchain.cmake
+ln -sf ../../../${SUBPREFIX}/lib/cmake/${PROJECT}/EosioCDTMacros.cmake EosioCDTMacros.cmake
 popd &> /dev/null
 
 create_symlink() {
-   ln -sf ../${SUBPREFIX}/bin/$1 ${PREFIX}/bin/$2 || exit 1
+   ln -sf ../${SUBPREFIX}/bin/$1 ${PREFIX}/bin/$2
 }
 
 create_symlink eosio-cc eosio-cc
@@ -62,5 +63,5 @@ create_symlink eosio-readelf eosio-readelf
 create_symlink eosio-strip eosio-strip
 
 echo "Generating Tarball $NAME.tar.gz..."
-tar -cvzf $NAME.tar.gz ./${PREFIX}/* || exit 1
-rm -r ${PREFIX} || exit 1
+tar -cvzf $NAME.tar.gz ./${PREFIX}/*
+rm -r ${PREFIX}

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -32,6 +32,7 @@ cp -R ${BUILD_DIR}/include/* ${CDT_PREFIX}/include
 
 # install wasm libs
 cp ${BUILD_DIR}/lib/*.a ${CDT_PREFIX}/lib
+cp ${BUILD_DIR}/lib/crt0.o ${CDT_PREFIX}/lib
 
 # make symlinks
 pushd ${PREFIX}/lib/cmake/${PROJECT} &> /dev/null

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-set -euo pipefail
+set -eo pipefail
 echo 'Generating tarball.'
 NAME=$1
 CDT_PREFIX=${PREFIX}/${SUBPREFIX}

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 set -euo pipefail
-
+echo 'Generating tarball.'
 NAME=$1
 CDT_PREFIX=${PREFIX}/${SUBPREFIX}
 mkdir -p ${PREFIX}/bin/
@@ -60,6 +60,7 @@ create_symlink eosio-ranlib eosio-ranlib
 create_symlink eosio-readelf eosio-readelf
 create_symlink eosio-strip eosio-strip
 
-echo "Generating Tarball $NAME.tar.gz..."
+echo "Packing $NAME.tar.gz..."
 tar -cvzf $NAME.tar.gz ./${PREFIX}/*
 rm -r ${PREFIX}
+echo "Created \"$NAME.tar.gz\"."

--- a/scripts/generate_tarball.sh
+++ b/scripts/generate_tarball.sh
@@ -12,8 +12,6 @@ mkdir -p ${CDT_PREFIX}/cmake
 mkdir -p ${CDT_PREFIX}/scripts
 mkdir -p ${CDT_PREFIX}/licenses
 
-#echo "${PREFIX} ** ${SUBPREFIX} ** ${CDT_PREFIX}"
-
 # install binaries
 cp -R ${BUILD_DIR}/bin/* ${CDT_PREFIX}/bin
 cp -R ${BUILD_DIR}/licenses/* ${CDT_PREFIX}/licenses


### PR DESCRIPTION
## Change Description
From [BLU-31175](https://blockone.atlassian.net/browse/BLU-31175), we were unable to build exchange contract tests using a container that had EOSIO built and installed from source with CDT installed from a binary.
```
$ make -j 1
[  0%] Built target default_catch_entry
[  1%] Built target tester
[  1%] Linking CXX executable ../../../*******_tests.wasm
wasm-ld: error: cannot open /usr/opt/eosio.cdt/1.7.0-develop/bin/../lib/crt0.o: No such file or directory
```
This pull request packs the missing object file needed to build some WASM tests into the binary packages so CDT does not need to be built and installed from source to use it.

## API Changes
- [ ] API Changes

None.

## Documentation Additions
- [ ] Documentation Additions

None.