### PR TITLE
Fix #1277: Installed CDT uses toolchain from build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,13 +57,11 @@ include(modules/ToolsExternalProject.txt)
 set(WASM_SDK_BUILD true)
 
 ### Configure the EosioWasmToolchain.cmakes
-set(CDT_ROOT_DIR ${CMAKE_BINARY_DIR})
+set(CDT_ROOT_DIR ${CDT_INSTALL_PREFIX})
 
 configure_file(${CMAKE_SOURCE_DIR}/modules/eosio.cdt-config.cmake ${CMAKE_BINARY_DIR}/lib/cmake/eosio.cdt/eosio.cdt-config.cmake @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/modules/EosioCDTMacros.cmake.in ${CMAKE_BINARY_DIR}/lib/cmake/eosio.cdt/EosioCDTMacros.cmake @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/modules/EosioWasmToolchain.cmake.in ${CMAKE_BINARY_DIR}/lib/cmake/eosio.cdt/EosioWasmToolchain.cmake @ONLY)
-
-set(CDT_ROOT_DIR ${CDT_INSTALL_PREFIX})
 
 configure_file(${CMAKE_SOURCE_DIR}/modules/eosio.cdt-config.cmake ${CMAKE_BINARY_DIR}/modules/eosio.cdt-config.cmake @ONLY)
 configure_file(${CMAKE_SOURCE_DIR}/modules/EosioCDTMacros.cmake.in ${CMAKE_BINARY_DIR}/modules/EosioCDTMacros.cmake @ONLY)


### PR DESCRIPTION
See https://github.com/EOSIO/eosio.cdt/issues/1277 for details.

<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

CMake preparation of the installed CMake module configuration files interpolates the build directory into the configuration rather than the install directory. Fix this by properly setting the `CDT_ROOT_DIR` variable to the installed path before generating the configuration files.


## API Changes
None
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
None
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
